### PR TITLE
fix(flatten): attribute a merged operator_compose equation to its variable's system

### DIFF
--- a/esm-libraries-spec.md
+++ b/esm-libraries-spec.md
@@ -768,6 +768,40 @@ order; the application sequence and the reporting sequence are separate.
      already substituted, so in both cases this rewrite is the identity. Step 4 introduces no
      renaming of its own beyond it.
    - Variables from system B that appear in the combined RHS are added to the merged system's variable list.
+   - **The merged equation belongs to its dependent variable's system.** A composed tendency is
+     no longer either author's contribution, so for the purpose of every LATER `operator_compose`
+     entry the merged equation is attributed to the system that owns `x` — the component named by
+     `x`'s leading namespace segment — and not to whichever of A and B happened to carry the
+     surviving equation.
+
+     Where A already is that system, this is the identity and there is nothing to observe. It bites
+     where A is not: §4.7.1 places no restriction on which side is the operator, and an operator
+     component may author `D(Chemistry.O3, t) = …` directly — B's variable under A's authorship.
+     A document may then CHAIN entries over one state with the operator as `systems[0]`:
+
+     ```json
+     {"type": "operator_compose", "systems": ["DepositionSink",  "Chemistry"]},
+     {"type": "operator_compose", "systems": ["EmissionSource",  "Chemistry"]},
+     {"type": "operator_compose", "systems": ["Chemistry", "Transport"], "lifting": "pointwise"}
+     ```
+
+     Entry 1 consumes `Chemistry`'s own equation for `O3`. If the sum is left attributed to
+     `DepositionSink`, entry 2 looks at `EmissionSource` and `Chemistry`, finds no equation for
+     `O3` in either, and merges nothing — so the emission term is never added and the flattened
+     system carries TWO equations claiming `D(Chemistry.O3, t)`. That is an over-determination
+     raised (at best) stages later, for a document that is spec-valid and must flatten.
+
+     Attribution is not recoverable from the equation itself: after namespacing, an operator's
+     equation for a chemistry species is textually indistinguishable from the chemistry
+     component's own, and placeholder expansion produces the same shape. An implementation MUST
+     therefore carry it explicitly — as a per-equation owner beside the equation list, or as which
+     component's equation list the equation lives in — and MUST update it here.
+
+     Attribution is about VISIBILITY to later entries, not about ordering; ordering stays what
+     §4.7.5 step 4 says. Note that in an implementation whose attribution IS the equation list an
+     equation sits in, updating it necessarily moves the equation: append it to the owner's list,
+     so that in a chained composition each merged equation trails the merges that preceded it.
+
    - **The merged-away name does not survive.** When a match renames the dependent variable — a
      translation match, or the bare-name fallback, which is a name-based translation — B's
      declaration of that variable is left with nothing to constrain it: the equation that defined

--- a/pkg/EarthSciAST.jl/test/flatten_conformance_test.jl
+++ b/pkg/EarthSciAST.jl/test/flatten_conformance_test.jl
@@ -861,38 +861,15 @@ end
         # dependent variable, not left as A's authored contribution. Keeping
         # A's ownership made entries 2 and 3 match nothing, and the flattened
         # system carried THREE equations claiming `D(Chem.O3)`.
-        doc = """
-        {"esm": "1.0.0",
-         "metadata": {"name": "ChainedCompose",
-                      "description": "chained operator_compose with the operator as A",
-                      "authors": ["EarthSciAST test suite"],
-                      "created": "2026-08-25T00:00:00Z"},
-         "models": {
-           "Chem": {"variables": {"O3": {"type": "unknown", "units": "mol/mol", "default": 1.0},
-                                  "NO": {"type": "unknown", "units": "mol/mol", "default": 1.0},
-                                  "k1": {"type": "parameter", "units": "1/s", "default": 0.1},
-                                  "k2": {"type": "parameter", "units": "1/s", "default": 0.2}},
-                    "equations": [{"lhs": {"op": "D", "args": ["O3"], "wrt": "t"},
-                                   "rhs": {"op": "*", "args": [{"op": "-", "args": ["k1"]}, "O3"]}},
-                                  {"lhs": {"op": "D", "args": ["NO"], "wrt": "t"},
-                                   "rhs": {"op": "*", "args": [{"op": "-", "args": ["k2"]}, "NO"]}}]},
-           "Sink": {"variables": {"kd": {"type": "parameter", "units": "1/s", "default": 0.01}},
-                    "equations": [{"lhs": {"op": "D", "args": ["Chem.O3"], "wrt": "t"},
-                                   "rhs": {"op": "*", "args": [{"op": "-", "args": ["kd"]}, "Chem.O3"]}},
-                                  {"lhs": {"op": "D", "args": ["Chem.NO"], "wrt": "t"},
-                                   "rhs": {"op": "*", "args": [{"op": "-", "args": ["kd"]}, "Chem.NO"]}}]},
-           "Src":  {"variables": {"e": {"type": "parameter", "units": "mol/mol/s", "default": 2.0}},
-                    "equations": [{"lhs": {"op": "D", "args": ["Chem.O3"], "wrt": "t"},
-                                   "rhs": "e"}]},
-           "Adv":  {"variables": {"wind": {"type": "parameter", "units": "m/s", "default": 3.0}},
-                    "equations": [{"lhs": {"op": "D", "args": ["_var"], "wrt": "t"},
-                                   "rhs": {"op": "*", "args": [{"op": "-", "args": ["wind"]},
-                                                               {"op": "grad", "args": ["_var"]}]}}]}},
-         "coupling": [{"type": "operator_compose", "systems": ["Sink", "Chem"]},
-                      {"type": "operator_compose", "systems": ["Src", "Chem"]},
-                      {"type": "operator_compose", "systems": ["Chem", "Adv"], "lifting": "pointwise"}]}
-        """
-        flat = flatten(load_string(doc))
+        #
+        # The document moved into the shared tree with the issue #173 fix (the
+        # same gap in the Python oracle, TypeScript, Rust and Go), so the corpus
+        # now carries it as the `chained_compose` tier and this testset drives
+        # the SAME file. What stays here is the rendered answer: the corpus
+        # records it too, but reading it as prose is what makes a regression
+        # legible.
+        flat = flatten(load_path(joinpath(_FLATTEN_TESTS_DIR, "coupling",
+                                          "chained_operator_compose.esm")))
         # ONE equation per species, every chained contribution in its RHS. The
         # POSITIONS are the merge trail: each merge keeps the surviving A
         # equation's document slot, so NO's chain ends at the sink's slot and

--- a/pkg/earthsci-ast-go/pkg/esm/flatten.go
+++ b/pkg/earthsci-ast-go/pkg/esm/flatten.go
@@ -1436,6 +1436,12 @@ func applyOperatorCompose(components map[string]*componentSystem, entry Operator
 	// bDep -> targetDep for every match that RENAMED the dependent variable.
 	mergedAway := map[string]string{}
 	var mergedAwayOrder []string
+	// Positions in A's equation slice this entry merged INTO, for the
+	// reattribution below. Collected rather than acted on in place because
+	// aIndex indexes that slice POSITIONALLY and stays live until the last B
+	// equation has been matched -- relocating an equation mid-loop would
+	// invalidate it.
+	mergedPositions := map[int]bool{}
 	for _, bEq := range b.equations {
 		bDep := lhsDependentVar(bEq.LHS)
 		if bDep == "" {
@@ -1498,6 +1504,7 @@ func applyOperatorCompose(components map[string]*componentSystem, entry Operator
 			RHS:          addExprs(aEq.RHS, rhs),
 			SourceSystem: aEq.SourceSystem,
 		}
+		mergedPositions[i] = true
 		if targetDep != bDep {
 			if _, seen := mergedAway[bDep]; !seen {
 				mergedAwayOrder = append(mergedAwayOrder, bDep)
@@ -1506,6 +1513,15 @@ func applyOperatorCompose(components map[string]*componentSystem, entry Operator
 		}
 	}
 	b.equations = surviving
+
+	// `a == b` is a self-compose (`"systems": ["X", "X"]`), which nothing rejects
+	// and which has just rebound the one shared slice out from under
+	// mergedPositions. The reattribution would be the identity there anyway -- A
+	// and the variable owner are the same component -- so skip it rather than
+	// index a slice the positions no longer describe.
+	if a != b {
+		reattributeMergedEquations(components, entry.Systems[0], mergedPositions)
+	}
 
 	// §4.7.1 step 4, "the merged-away name does not survive": a RENAMING match
 	// (a translation match, or the bare-name fallback, which is a name-based
@@ -1525,6 +1541,86 @@ func applyOperatorCompose(components map[string]*componentSystem, entry Operator
 			b.stateVars.remove(gone)
 			b.observed.remove(gone)
 		}
+	}
+}
+
+// reattributeMergedEquations moves each freshly merged equation into its
+// dependent variable's component.
+//
+// A composed tendency is no longer any single author's contribution, so
+// esm-libraries-spec §4.7.1 step 4 attributes it to the system that OWNS its
+// dependent variable rather than to the `systems[0]` that happened to carry the
+// surviving equation. Where A already IS that system -- the ordinary
+// `["Chemistry", "Advection"]` spelling, and every fixture in the shared tree
+// before this one -- the move is the identity and nothing changes.
+//
+// Where it is NOT the identity is a document that CHAINS compose entries over
+// one state with the OPERATOR as A:
+//
+//	{"type": "operator_compose", "systems": ["Sink", "Chem"]}
+//	{"type": "operator_compose", "systems": ["Src",  "Chem"]}
+//	{"type": "operator_compose", "systems": ["Chem", "Adv"], "lifting": "pointwise"}
+//
+// with Sink and Src authoring `D(Chem.X, t) = ...` directly. §4.7.1 permits it
+// and reseact.esm is built on it (deposition, then emission, then the transport
+// lift). Entry 1 consumes Chem's own equation and leaves the sum in the Sink
+// component; entry 2 then walks Src and Chem and cannot see it. Both the
+// composed tendency and Src's un-merged contribution reach assembleSystem, which
+// reports two systems defining Chem.O3 -- loud rather than corrupt, but the
+// document is spec-valid and must flatten. Relocating the merge to Chem is what
+// puts it back where the next entry looks for it, in either role.
+//
+// The component bag is this binding's analogue of the reference
+// implementation's per-equation owner (Julia coupling_apply.jl, the
+// `new_owners[j] = _component_root(dep)` line): which component's equation slice
+// an equation sits in is the only record of who authored it, and after
+// namespacing an operator's equation for a chemistry species is textually
+// indistinguishable from the chemistry component's own.
+//
+// POSITION. §4.7.5 step 4 makes document order normative, and a relocated
+// equation is APPENDED to the owner's slice rather than inserted at the slot of
+// the B equation it consumed. Appending is what reproduces the reference order:
+// each merge trails the ones before it, so a species whose chain ends at a later
+// entry ends up after one whose chain ended earlier -- Chem.NO (last merged by
+// entry 1) ahead of Chem.O3 (last merged by entry 2) in the document above.
+// Inserting at the consumed equation's slot instead would freeze both at Chem's
+// original declaration order and disagree with every other binding.
+//
+// An equation whose dependent variable names no component of this document stays
+// where it is; there is no bag to move it to.
+func reattributeMergedEquations(components map[string]*componentSystem, aName string, mergedPositions map[int]bool) {
+	if len(mergedPositions) == 0 {
+		return
+	}
+	a := components[aName]
+	var kept []FlattenedEquation
+	type relocation struct {
+		owner string
+		eq    FlattenedEquation
+	}
+	var moved []relocation
+	for i, eq := range a.equations {
+		owner := ""
+		if mergedPositions[i] {
+			if dep := lhsDependentVar(eq.LHS); dep != "" {
+				owner = dep
+				if root, _, found := strings.Cut(dep, "."); found {
+					owner = root
+				}
+			}
+		}
+		if _, ok := components[owner]; owner == "" || owner == aName || !ok {
+			kept = append(kept, eq)
+			continue
+		}
+		moved = append(moved, relocation{owner: owner, eq: eq})
+	}
+	if len(moved) == 0 {
+		return
+	}
+	a.equations = kept
+	for _, m := range moved {
+		components[m.owner].equations = append(components[m.owner].equations, m.eq)
 	}
 }
 

--- a/pkg/earthsci-ast-py/src/earthsci_ast/flatten.py
+++ b/pkg/earthsci-ast-py/src/earthsci_ast/flatten.py
@@ -1261,6 +1261,11 @@ def _apply_operator_compose(
     surviving_b: list[FlattenedEquation] = []
     # b_dep -> target_dep for every match that RENAMED the dependent variable.
     merged_away: dict[str, str] = {}
+    # Positions in `a.equations` this entry merged INTO, for the reattribution
+    # below. Collected rather than acted on in place because `a_index` indexes
+    # `a.equations` positionally and stays live until the last B equation has
+    # been matched -- relocating an equation mid-loop would invalidate it.
+    merged_positions: set[int] = set()
 
     for b_eq in b.equations:
         b_dep = _lhs_dependent_var(b_eq.lhs)
@@ -1303,12 +1308,21 @@ def _apply_operator_compose(
                 rhs=new_rhs,
                 source_system=a_eq.source_system,
             )
+            merged_positions.add(i)
             if target_dep != b_dep:
                 merged_away[b_dep] = target_dep
         else:
             surviving_b.append(b_eq)
 
     b.equations = surviving_b
+
+    # `a is b` is a self-compose (`"systems": ["X", "X"]`), which nothing rejects
+    # and which has just rebound the one shared list out from under
+    # `merged_positions`. The reattribution would be the identity there anyway --
+    # A and the variable owner are the same component -- so skip it rather than
+    # index a list the positions no longer describe.
+    if a is not b:
+        _reattribute_merged_equations(components, a_name, merged_positions)
 
     # A renaming match CONSUMES B's defining equation, so B's declaration of that
     # name is left with nothing to constrain it -- an algebraic unknown with no
@@ -1325,6 +1339,80 @@ def _apply_operator_compose(
         for gone in merged_away:
             b.state_vars.pop(gone, None)
             b.observed.pop(gone, None)
+
+
+def _reattribute_merged_equations(
+    components: OrderedDict[str, _ComponentSystem],
+    a_name: str,
+    merged_positions: set[int],
+) -> None:
+    """Move each freshly merged equation into its dependent variable's component.
+
+    A composed tendency is no longer any single author's contribution, so
+    esm-libraries-spec §4.7.1 step 4 attributes it to the system that OWNS its
+    dependent variable rather than to the ``systems[0]`` that happened to carry
+    the surviving equation. Where A already is that system -- the ordinary
+    ``["Chemistry", "Advection"]`` spelling, and every fixture in the shared tree
+    before this one -- the move is the identity and nothing changes.
+
+    Where it is NOT the identity is a document that CHAINS compose entries over
+    one state with the OPERATOR as A::
+
+        {"type": "operator_compose", "systems": ["Sink", "Chem"]}
+        {"type": "operator_compose", "systems": ["Src",  "Chem"]}
+        {"type": "operator_compose", "systems": ["Chem", "Adv"], ...}
+
+    with ``Sink`` and ``Src`` authoring ``D(Chem.X, t) = ...`` directly. §4.7.1
+    permits it and ``reseact.esm`` is built on it (deposition, then emission,
+    then the transport lift). Entry 1 consumes Chem's own equation and leaves
+    the sum in ``components["Sink"].equations``; entry 2 then walks
+    ``components["Src"]`` and ``components["Chem"]`` and cannot see it. Both the
+    composed tendency and Src's un-merged contribution reach
+    :func:`_assemble_system`, which raises ``ConflictingDerivativeError`` for
+    ``Chem.O3`` -- loud rather than corrupt, but the document is spec-valid and
+    must flatten. Relocating the merge to ``components["Chem"]`` is what puts it
+    back where the next entry looks for it, in either role.
+
+    The component bag is the Python analogue of the reference implementation's
+    per-equation owner (Julia ``coupling_apply.jl``, the ``new_owners[j] =
+    _component_root(dep)`` line): membership in ``components[X].equations`` is
+    the only record of who authored an equation, and after namespacing an
+    operator's equation for a chemistry species is textually indistinguishable
+    from the chemistry component's own.
+
+    POSITION. §4.7.5 step 4 makes document order normative, and a relocated
+    equation is APPENDED to the owner's list rather than inserted at the slot of
+    the B equation it consumed. Appending is what reproduces the reference
+    order: each merge trails the ones before it, so a species whose chain ends at
+    a later entry ends up after one whose chain ended earlier -- ``Chem.NO``
+    (last merged by entry 1) ahead of ``Chem.O3`` (last merged by entry 2) in the
+    document above. Inserting at the consumed equation's slot instead would
+    freeze both at Chem's original declaration order and disagree with every
+    other binding.
+
+    An equation whose dependent variable names no component of this document
+    stays where it is; there is no bag to move it to.
+    """
+    if not merged_positions:
+        return
+    a = components[a_name]
+    kept: list[FlattenedEquation] = []
+    moved: list[tuple[str, FlattenedEquation]] = []
+    for i, eq in enumerate(a.equations):
+        owner: str | None = None
+        if i in merged_positions:
+            dep = _lhs_dependent_var(eq.lhs)
+            if dep is not None:
+                owner = dep.split(".", 1)[0]
+        if owner is None or owner == a_name or owner not in components:
+            kept.append(eq)
+        else:
+            moved.append((owner, eq))
+    if not moved:
+        return
+    a.equations = kept
+    for owner, eq in moved:
+        components[owner].equations.append(eq)
 
 
 def _retarget_merged_names(

--- a/pkg/earthsci-ast-py/tests/test_flatten.py
+++ b/pkg/earthsci-ast-py/tests/test_flatten.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from earthsci_ast.display import to_ascii
 from earthsci_ast.flatten import (
     ConflictingDerivativeError,
     _namespace_expr,
@@ -277,6 +278,104 @@ def test_flatten_operator_compose_var_placeholder_expansion():
     rhs_strs = [e.rhs_str for e in chem_eqs]
     assert any("Chem.A" in r and "grad" in r for r in rhs_strs)
     assert any("Chem.B" in r and "grad" in r for r in rhs_strs)
+
+
+def test_flatten_operator_compose_chained_with_operator_as_a():
+    """Chained compose entries over one state, with the OPERATOR as A, keep merging.
+
+    Issue #173. `Sink` and `Src` each author `D(Chem.X, t)` directly -- B's
+    variable under A's authorship, which §4.7.1 permits and `reseact.esm` is
+    built on. Entry 1 consumes Chem's own equation and the sum lands in the
+    component bag of `Sink`; unless step 4's attribution rule relocates it to
+    `Chem`, entry 2 walks `Src` and `Chem`, sees no equation for `Chem.O3`, and
+    merges nothing -- leaving TWO equations claiming `D(Chem.O3, t)` and a
+    ConflictingDerivativeError for a document that is spec-valid.
+
+    Independent of the shared corpus on purpose: the corpus is GENERATED from
+    this binding, so a regression here would rewrite the expected answer rather
+    than fail against it.
+    """
+    chem = Model(
+        name="Chem",
+        variables={
+            "O3": ModelVariable(type="unknown"),
+            "NO": ModelVariable(type="unknown"),
+            "k1": ModelVariable(type="parameter", default=0.1),
+            "k2": ModelVariable(type="parameter", default=0.2),
+        },
+        equations=[
+            Equation(
+                lhs=ExprNode(op="D", args=["O3"], wrt="t"),
+                rhs=ExprNode(op="*", args=[ExprNode(op="-", args=["k1"]), "O3"]),
+            ),
+            Equation(
+                lhs=ExprNode(op="D", args=["NO"], wrt="t"),
+                rhs=ExprNode(op="*", args=[ExprNode(op="-", args=["k2"]), "NO"]),
+            ),
+        ],
+    )
+    sink = Model(
+        name="Sink",
+        variables={"kd": ModelVariable(type="parameter", default=0.01)},
+        equations=[
+            Equation(
+                lhs=ExprNode(op="D", args=["Chem.O3"], wrt="t"),
+                rhs=ExprNode(op="*", args=[ExprNode(op="-", args=["kd"]), "Chem.O3"]),
+            ),
+            Equation(
+                lhs=ExprNode(op="D", args=["Chem.NO"], wrt="t"),
+                rhs=ExprNode(op="*", args=[ExprNode(op="-", args=["kd"]), "Chem.NO"]),
+            ),
+        ],
+    )
+    src = Model(
+        name="Src",
+        variables={"e": ModelVariable(type="parameter", default=2.0)},
+        equations=[Equation(lhs=ExprNode(op="D", args=["Chem.O3"], wrt="t"), rhs="e")],
+    )
+    adv = Model(
+        name="Adv",
+        variables={"wind": ModelVariable(type="parameter", default=3.0)},
+        equations=[
+            Equation(
+                lhs=ExprNode(op="D", args=["_var"], wrt="t"),
+                rhs=ExprNode(
+                    op="*",
+                    args=[
+                        ExprNode(op="-", args=["wind"]),
+                        ExprNode(op="grad", args=["_var"]),
+                    ],
+                ),
+            )
+        ],
+    )
+
+    flat = flatten(
+        _empty_file(
+            models={"Chem": chem, "Sink": sink, "Src": src, "Adv": adv},
+            coupling=[
+                OperatorComposeCoupling(systems=["Sink", "Chem"]),
+                OperatorComposeCoupling(systems=["Src", "Chem"]),
+                OperatorComposeCoupling(systems=["Chem", "Adv"], lifting="pointwise"),
+            ],
+        )
+    )
+
+    # ONE equation per species, every chained contribution in its RHS. The
+    # POSITIONS are the merge trail: each species trails to the entry that
+    # merged it LAST, so NO (entry 1) comes ahead of O3 (entry 2).
+    assert [(to_ascii(eq.lhs), to_ascii(eq.rhs)) for eq in flat.equations] == [
+        (
+            "D(Chem.NO)/Dt",
+            "(-Sink.kd) * Chem.NO + (-Chem.k2) * Chem.NO + (-Adv.wind) * grad(Chem.NO)",
+        ),
+        (
+            "D(Chem.O3)/Dt",
+            "Src.e + (-Sink.kd) * Chem.O3 + (-Chem.k1) * Chem.O3 + (-Adv.wind) * grad(Chem.O3)",
+        ),
+    ]
+    assert sorted(flat.state_variables) == ["Chem.NO", "Chem.O3"]
+    assert not flat.algebraic_variables
 
 
 # ----------------------------------------------------------------------------

--- a/pkg/earthsci-ast-rs/src/flatten.rs
+++ b/pkg/earthsci-ast-rs/src/flatten.rs
@@ -2378,6 +2378,12 @@ fn apply_operator_compose(
     // (step 4's "the merged-away name does not survive"). Insertion-ordered so
     // the prune below is deterministic.
     let mut merged_away: IndexMap<String, String> = IndexMap::new();
+    // Positions in A's equation vector this entry merged INTO, for the
+    // reattribution below. Collected rather than acted on in place because
+    // `a_index` indexes that vector POSITIONALLY and stays live until the last
+    // B equation has been matched — relocating an equation mid-loop would
+    // invalidate it.
+    let mut merged_positions: HashSet<usize> = HashSet::new();
     for b_eq in b_equations {
         let Some(b_dep) = compose_dependent(&b_eq.lhs) else {
             surviving.push(b_eq);
@@ -2432,11 +2438,14 @@ fn apply_operator_compose(
         }
         let rhs_a = std::mem::replace(&mut per_system[a_idx].equations[i].rhs, Expr::Integer(0));
         per_system[a_idx].equations[i].rhs = sum_exprs(rhs_a, rhs_b);
+        merged_positions.insert(i);
         if target != b_dep {
             merged_away.insert(b_dep, target);
         }
     }
     per_system[b_idx].equations = surviving;
+
+    reattribute_merged_equations(a_idx, &merged_positions, per_system);
 
     // Step 4, second half: a RENAMING match — a translation match, or the
     // bare-name fallback, which is a name-based translation — has just consumed
@@ -2461,6 +2470,92 @@ fn apply_operator_compose(
     }
 
     Ok(())
+}
+
+/// Move each freshly merged equation into its dependent variable's block.
+///
+/// A composed tendency is no longer any single author's contribution, so
+/// esm-libraries-spec §4.7.1 step 4 attributes it to the system that OWNS its
+/// dependent variable rather than to the `systems[0]` that happened to carry
+/// the surviving equation. Where A already IS that system — the ordinary
+/// `["Chemistry", "Advection"]` spelling, and every fixture in the shared tree
+/// before this one — the move is the identity and nothing changes.
+///
+/// Where it is NOT the identity is a document that CHAINS compose entries over
+/// one state with the OPERATOR as A:
+///
+/// ```json
+/// {"type": "operator_compose", "systems": ["Sink", "Chem"]}
+/// {"type": "operator_compose", "systems": ["Src",  "Chem"]}
+/// {"type": "operator_compose", "systems": ["Chem", "Adv"], "lifting": "pointwise"}
+/// ```
+///
+/// with `Sink` and `Src` authoring `D(Chem.X, t) = …` directly. §4.7.1 permits
+/// it and `reseact.esm` is built on it (deposition, then emission, then the
+/// transport lift). Entry 1 consumes Chem's own equation and leaves the sum in
+/// the `Sink` block; entry 2 then walks the `Src` and `Chem` blocks and cannot
+/// see it. Both the composed tendency and Src's un-merged contribution survive
+/// to assembly, which reports two systems defining `Chem.O3` — loud rather than
+/// corrupt, but the document is spec-valid and must flatten. Relocating the
+/// merge to the `Chem` block is what puts it back where the next entry looks for
+/// it, in either role.
+///
+/// The per-system block is this binding's analogue of the reference
+/// implementation's per-equation owner (Julia `coupling_apply.jl`, the
+/// `new_owners[j] = _component_root(dep)` line): which block an equation sits in
+/// is the only record of who authored it, and after namespacing an operator's
+/// equation for a chemistry species is textually indistinguishable from the
+/// chemistry component's own.
+///
+/// POSITION. §4.7.5 step 4 makes document order normative, and a relocated
+/// equation is APPENDED to the owner's block rather than inserted at the slot of
+/// the B equation it consumed. Appending is what reproduces the reference order:
+/// each merge trails the ones before it, so a species whose chain ends at a
+/// later entry ends up after one whose chain ended earlier — `Chem.NO` (last
+/// merged by entry 1) ahead of `Chem.O3` (last merged by entry 2) in the
+/// document above. Inserting at the consumed equation's slot instead would
+/// freeze both at Chem's original declaration order and disagree with every
+/// other binding.
+///
+/// An equation whose dependent variable names no block of this document stays
+/// where it is; there is nowhere to move it to.
+fn reattribute_merged_equations(
+    a_idx: usize,
+    merged_positions: &HashSet<usize>,
+    per_system: &mut [SystemBlock],
+) {
+    if merged_positions.is_empty() {
+        return;
+    }
+    let a_name = per_system[a_idx].name.clone();
+    let mut kept: Vec<Equation> = Vec::new();
+    let mut moved: Vec<(String, Equation)> = Vec::new();
+    for (i, eq) in std::mem::take(&mut per_system[a_idx].equations)
+        .into_iter()
+        .enumerate()
+    {
+        let owner = if merged_positions.contains(&i) {
+            compose_dependent(&eq.lhs).map(|dep| {
+                dep.split_once('.')
+                    .map(|(root, _)| root.to_string())
+                    .unwrap_or(dep)
+            })
+        } else {
+            None
+        };
+        match owner {
+            Some(owner) if owner != a_name && per_system.iter().any(|blk| blk.name == owner) => {
+                moved.push((owner, eq));
+            }
+            _ => kept.push(eq),
+        }
+    }
+    per_system[a_idx].equations = kept;
+    for (owner, eq) in moved {
+        if let Some(blk) = per_system.iter_mut().find(|blk| blk.name == owner) {
+            blk.equations.push(eq);
+        }
+    }
 }
 
 /// Rewrite every reference to a merged-away dependent variable, EVERYWHERE

--- a/pkg/earthsci-ast-ts/src/flatten-conformance.test.ts
+++ b/pkg/earthsci-ast-ts/src/flatten-conformance.test.ts
@@ -145,14 +145,16 @@ function eventRecord(e: ContinuousEvent | DiscreteEvent): EventCase {
 
 describe('flatten conformance corpus (esm-libraries-spec §4.7.5 step 4)', () => {
   it('covers every corpus case', () => {
-    // 23 = the 19 of the earlier recording, plus the `operator_compose` tier
+    // 24 = the 19 of the earlier recording, plus the `operator_compose` tier
     // (minimal_chemistry, metadata_inheritance_coupled,
     // bare_reference_resolution) — the three shared fixtures whose operator
     // model is really spelled with `_var`, which is what makes a composition
     // observable at all — plus `operator_compose_translate`, the one document in
     // the tree that pins a real TRANSLATION match (§4.7.1 step 2's namespaced
-    // endpoints and step 4's merged-away-name prune).
-    expect(corpus.cases.length).toBe(23)
+    // endpoints and step 4's merged-away-name prune), plus the
+    // `chained_compose` tier: three entries chained over one state with the
+    // OPERATOR as A, which is what makes step 4's ownership rule observable.
+    expect(corpus.cases.length).toBe(24)
     expect(corpus.refusals.length).toBe(3)
     expect(corpus.oracle).toContain('earthsci_ast.flatten')
   })

--- a/pkg/earthsci-ast-ts/src/flatten.ts
+++ b/pkg/earthsci-ast-ts/src/flatten.ts
@@ -1283,6 +1283,11 @@ function applyOperatorCompose(
   const survivingB: FlattenedEquation[] = []
   // `bDep -> targetDep` for every match that RENAMED the dependent variable.
   const mergedAway: Record<string, string> = {}
+  // Positions in `a.equations` this entry merged INTO, for the reattribution
+  // below. Collected rather than acted on in place because `aIndex` indexes
+  // `a.equations` POSITIONALLY and stays live until the last B equation has been
+  // matched — relocating an equation mid-loop would invalidate it.
+  const mergedPositions = new Set<number>()
   for (const bEq of b.equations) {
     const bDep = lhsDependentVar(bEq.lhs)
     if (bDep === undefined) {
@@ -1338,12 +1343,20 @@ function applyOperatorCompose(
         rhs: addExprs(aEq.rhs, rhs),
         sourceSystem: aEq.sourceSystem,
       }
+      mergedPositions.add(i)
       if (targetDep !== bDep) mergedAway[bDep] = targetDep
     } else {
       survivingB.push(bEq)
     }
   }
   b.equations = survivingB
+
+  // `a === b` is a self-compose (`"systems": ["X", "X"]`), which nothing rejects
+  // and which has just rebound the one shared array out from under
+  // `mergedPositions`. The reattribution would be the identity there anyway — A
+  // and the variable owner are the same component — so skip it rather than index
+  // an array the positions no longer describe.
+  if (a !== b) reattributeMergedEquations(components, systems[0], mergedPositions)
 
   // §4.7.1 step 4, last bullet: THE MERGED-AWAY NAME DOES NOT SURVIVE. A
   // renaming match — a translation match, or the bare-name fallback, which is a
@@ -1366,6 +1379,85 @@ function applyOperatorCompose(
       delete b.observed[gone]
     }
   }
+}
+
+/**
+ * Move each freshly merged equation into its dependent variable's component.
+ *
+ * A composed tendency is no longer any single author's contribution, so
+ * esm-libraries-spec §4.7.1 step 4 attributes it to the system that OWNS its
+ * dependent variable rather than to the `systems[0]` that happened to carry the
+ * surviving equation. Where A already IS that system — the ordinary
+ * `["Chemistry", "Advection"]` spelling, and every fixture in the shared tree
+ * before this one — the move is the identity and nothing changes.
+ *
+ * Where it is NOT the identity is a document that CHAINS compose entries over
+ * one state with the OPERATOR as A:
+ *
+ * ```json
+ * {"type": "operator_compose", "systems": ["Sink", "Chem"]}
+ * {"type": "operator_compose", "systems": ["Src",  "Chem"]}
+ * {"type": "operator_compose", "systems": ["Chem", "Adv"], "lifting": "pointwise"}
+ * ```
+ *
+ * with `Sink` and `Src` authoring `D(Chem.X, t) = …` directly. §4.7.1 permits it
+ * and `reseact.esm` is built on it (deposition, then emission, then the
+ * transport lift). Entry 1 consumes Chem's own equation and leaves the sum in
+ * `components.Sink.equations`; entry 2 then walks `components.Src` and
+ * `components.Chem` and cannot see it. Both the composed tendency and Src's
+ * un-merged contribution reach {@link assembleSystem}, which raises
+ * `ConflictingDerivativeError` for `Chem.O3` — loud rather than corrupt, but the
+ * document is spec-valid and must flatten. Relocating the merge to
+ * `components.Chem` is what puts it back where the next entry looks for it, in
+ * either role.
+ *
+ * The component bag is this binding's analogue of the reference
+ * implementation's per-equation owner (Julia `coupling_apply.jl`, the
+ * `new_owners[j] = _component_root(dep)` line): membership in
+ * `components[X].equations` is the only record of who authored an equation, and
+ * after namespacing an operator's equation for a chemistry species is textually
+ * indistinguishable from the chemistry component's own.
+ *
+ * POSITION. §4.7.5 step 4 makes document order normative, and a relocated
+ * equation is APPENDED to the owner's list rather than inserted at the slot of
+ * the B equation it consumed. Appending is what reproduces the reference order:
+ * each merge trails the ones before it, so a species whose chain ends at a later
+ * entry ends up after one whose chain ended earlier — `Chem.NO` (last merged by
+ * entry 1) ahead of `Chem.O3` (last merged by entry 2) in the document above.
+ * Inserting at the consumed equation's slot instead would freeze both at Chem's
+ * original declaration order and disagree with every other binding.
+ *
+ * An equation whose dependent variable names no component of this document stays
+ * where it is; there is no bag to move it to.
+ */
+function reattributeMergedEquations(
+  components: Record<string, ComponentSystem>,
+  aName: string,
+  mergedPositions: Set<number>,
+): void {
+  if (mergedPositions.size === 0) return
+  const a = components[aName]
+  const kept: FlattenedEquation[] = []
+  const moved: Array<[string, FlattenedEquation]> = []
+  a.equations.forEach((eq, i) => {
+    let owner: string | undefined
+    if (mergedPositions.has(i)) {
+      const dep = lhsDependentVar(eq.lhs)
+      if (dep !== undefined) owner = dep.includes('.') ? dep.slice(0, dep.indexOf('.')) : dep
+    }
+    if (
+      owner === undefined ||
+      owner === aName ||
+      !Object.prototype.hasOwnProperty.call(components, owner)
+    ) {
+      kept.push(eq)
+    } else {
+      moved.push([owner, eq])
+    }
+  })
+  if (moved.length === 0) return
+  a.equations = kept
+  for (const [owner, eq] of moved) components[owner].equations.push(eq)
 }
 
 /**

--- a/scripts/generate-flatten-corpus.py
+++ b/scripts/generate-flatten-corpus.py
@@ -223,6 +223,28 @@ CASES: list[tuple[str, str, str]] = [
         "flatten_registry_merge_twins",
         "conformance/expression_templates/flatten_registry_merge_transitive/fixture_twins.esm",
     ),
+    # --- operator_compose CHAINED over one state, operator as A --------------
+    # Added 2026-09-05 with the issue #173 fix. Every `operator_compose` case
+    # above composes ONE operator onto a state, with the state's own system as
+    # `systems[0]`, so all of them leave the merged equation exactly where the
+    # binding happened to keep it and none can tell the two attributions apart.
+    #
+    # This document chains THREE entries over the same two species with the
+    # OPERATOR as A (`["Sink", "Chem"]`, the sink authoring `D(Chem.O3, t)`
+    # directly) -- the shape `reseact.esm` composes SuperFast with, and the one
+    # that makes §4.7.1 step 4's OWNERSHIP rule observable: a merged equation
+    # left attributed to the operator is invisible to the next entry, so the
+    # chain stops after the first merge and the flattened system carries two
+    # equations claiming `D(Chem.O3)`. Three of five bindings did exactly that.
+    #
+    # It also pins the resulting ORDER, which is the part prose cannot fix: the
+    # equations come out `Chem.NO` then `Chem.O3` -- each species trailing to the
+    # slot of the LAST entry that merged it, not to Chem's declaration order.
+    (
+        "chained_compose",
+        "chained_operator_compose",
+        "coupling/chained_operator_compose.esm",
+    ),
     # --- reaction system: species -> derived ODEs, initial values ------------
     (
         "reaction_system",

--- a/tests/conformance/flatten/cases.json
+++ b/tests/conformance/flatten/cases.json
@@ -3540,6 +3540,130 @@
       "lifted_shapes": {}
     },
     {
+      "id": "chained_operator_compose",
+      "tier": "chained_compose",
+      "fixture": "coupling/chained_operator_compose.esm",
+      "system_kind": "pde",
+      "independent_variables": [
+        "t"
+      ],
+      "state_variables": [
+        {
+          "name": "Chem.O3",
+          "role": "state",
+          "units": "mol/mol",
+          "default": 1.0,
+          "shape": null,
+          "update_kinds": [],
+          "distribution_kind": null,
+          "source_system": "Chem"
+        },
+        {
+          "name": "Chem.NO",
+          "role": "state",
+          "units": "mol/mol",
+          "default": 1.0,
+          "shape": null,
+          "update_kinds": [],
+          "distribution_kind": null,
+          "source_system": "Chem"
+        }
+      ],
+      "parameters": [
+        {
+          "name": "Chem.k1",
+          "role": "parameter",
+          "units": "1/s",
+          "default": 0.1,
+          "shape": null,
+          "update_kinds": [],
+          "distribution_kind": null,
+          "source_system": "Chem"
+        },
+        {
+          "name": "Chem.k2",
+          "role": "parameter",
+          "units": "1/s",
+          "default": 0.2,
+          "shape": null,
+          "update_kinds": [],
+          "distribution_kind": null,
+          "source_system": "Chem"
+        },
+        {
+          "name": "Sink.kd",
+          "role": "parameter",
+          "units": "1/s",
+          "default": 0.01,
+          "shape": null,
+          "update_kinds": [],
+          "distribution_kind": null,
+          "source_system": "Sink"
+        },
+        {
+          "name": "Src.e",
+          "role": "parameter",
+          "units": "mol/mol/s",
+          "default": 2.0,
+          "shape": null,
+          "update_kinds": [],
+          "distribution_kind": null,
+          "source_system": "Src"
+        },
+        {
+          "name": "Adv.wind",
+          "role": "parameter",
+          "units": "m/s",
+          "default": 3.0,
+          "shape": null,
+          "update_kinds": [],
+          "distribution_kind": null,
+          "source_system": "Adv"
+        }
+      ],
+      "observed_variables": [],
+      "algebraic_variables": [],
+      "brownian_parameters": [],
+      "discrete_parameters": [],
+      "equation_count": 2,
+      "equations": [
+        {
+          "lhs": "D(Chem.NO)/Dt",
+          "rhs": "(-Sink.kd) * Chem.NO + (-Chem.k2) * Chem.NO + (-Adv.wind) * grad(Chem.NO)",
+          "source_system": "Sink"
+        },
+        {
+          "lhs": "D(Chem.O3)/Dt",
+          "rhs": "Src.e + (-Sink.kd) * Chem.O3 + (-Chem.k1) * Chem.O3 + (-Adv.wind) * grad(Chem.O3)",
+          "source_system": "Src"
+        }
+      ],
+      "continuous_events": [],
+      "discrete_events": [],
+      "domain": null,
+      "metadata": {
+        "source_systems": [
+          "Chem",
+          "Sink",
+          "Src",
+          "Adv"
+        ],
+        "coupling_rules": [
+          "operator_compose(Sink + Chem)",
+          "operator_compose(Src + Chem)",
+          "operator_compose(Chem + Adv)"
+        ],
+        "operator_applies": [],
+        "callbacks": []
+      },
+      "index_sets": [],
+      "function_tables": [],
+      "template_registry": [],
+      "field_ics": [],
+      "loader_fields": [],
+      "lifted_shapes": {}
+    },
+    {
       "id": "autocatalytic_reaction",
       "tier": "reaction_system",
       "fixture": "simulation/autocatalytic_reaction.esm",

--- a/tests/coupling/chained_operator_compose.esm
+++ b/tests/coupling/chained_operator_compose.esm
@@ -1,0 +1,216 @@
+{
+  "esm": "1.0.0",
+  "metadata": {
+    "name": "ChainedCompose",
+    "description": "Three operator_compose entries chained over one state, with the OPERATOR as system A.\n\nThe shape reseact.esm uses: a deposition sink and an emission source each author D(Chem.*) directly -- B's variable, A's authorship -- and are composed onto the chemistry in turn, then the whole thing is lifted onto a transport operator. Entry 1's merge must leave an equation entries 2 and 3 can still find, which is what makes the merged equation's OWNERSHIP observable (esm-libraries-spec 4.7.1 step 4).",
+    "authors": [
+      "EarthSciAST test suite"
+    ],
+    "created": "2026-08-25T00:00:00Z"
+  },
+  "models": {
+    "Chem": {
+      "variables": {
+        "O3": {
+          "type": "unknown",
+          "units": "mol/mol",
+          "default": 1.0
+        },
+        "NO": {
+          "type": "unknown",
+          "units": "mol/mol",
+          "default": 1.0
+        },
+        "k1": {
+          "type": "parameter",
+          "units": "1/s",
+          "default": 0.1
+        },
+        "k2": {
+          "type": "parameter",
+          "units": "1/s",
+          "default": 0.2
+        }
+      },
+      "equations": [
+        {
+          "lhs": {
+            "op": "D",
+            "args": [
+              "O3"
+            ],
+            "wrt": "t"
+          },
+          "rhs": {
+            "op": "*",
+            "args": [
+              {
+                "op": "-",
+                "args": [
+                  "k1"
+                ]
+              },
+              "O3"
+            ]
+          }
+        },
+        {
+          "lhs": {
+            "op": "D",
+            "args": [
+              "NO"
+            ],
+            "wrt": "t"
+          },
+          "rhs": {
+            "op": "*",
+            "args": [
+              {
+                "op": "-",
+                "args": [
+                  "k2"
+                ]
+              },
+              "NO"
+            ]
+          }
+        }
+      ]
+    },
+    "Sink": {
+      "variables": {
+        "kd": {
+          "type": "parameter",
+          "units": "1/s",
+          "default": 0.01
+        }
+      },
+      "equations": [
+        {
+          "lhs": {
+            "op": "D",
+            "args": [
+              "Chem.O3"
+            ],
+            "wrt": "t"
+          },
+          "rhs": {
+            "op": "*",
+            "args": [
+              {
+                "op": "-",
+                "args": [
+                  "kd"
+                ]
+              },
+              "Chem.O3"
+            ]
+          }
+        },
+        {
+          "lhs": {
+            "op": "D",
+            "args": [
+              "Chem.NO"
+            ],
+            "wrt": "t"
+          },
+          "rhs": {
+            "op": "*",
+            "args": [
+              {
+                "op": "-",
+                "args": [
+                  "kd"
+                ]
+              },
+              "Chem.NO"
+            ]
+          }
+        }
+      ]
+    },
+    "Src": {
+      "variables": {
+        "e": {
+          "type": "parameter",
+          "units": "mol/mol/s",
+          "default": 2.0
+        }
+      },
+      "equations": [
+        {
+          "lhs": {
+            "op": "D",
+            "args": [
+              "Chem.O3"
+            ],
+            "wrt": "t"
+          },
+          "rhs": "e"
+        }
+      ]
+    },
+    "Adv": {
+      "variables": {
+        "wind": {
+          "type": "parameter",
+          "units": "m/s",
+          "default": 3.0
+        }
+      },
+      "equations": [
+        {
+          "lhs": {
+            "op": "D",
+            "args": [
+              "_var"
+            ],
+            "wrt": "t"
+          },
+          "rhs": {
+            "op": "*",
+            "args": [
+              {
+                "op": "-",
+                "args": [
+                  "wind"
+                ]
+              },
+              {
+                "op": "grad",
+                "args": [
+                  "_var"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "coupling": [
+    {
+      "type": "operator_compose",
+      "systems": [
+        "Sink",
+        "Chem"
+      ]
+    },
+    {
+      "type": "operator_compose",
+      "systems": [
+        "Src",
+        "Chem"
+      ]
+    },
+    {
+      "type": "operator_compose",
+      "systems": [
+        "Chem",
+        "Adv"
+      ],
+      "lifting": "pointwise"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #173.

## The gap

Chained `operator_compose` entries over one state, with the OPERATOR as system A, stopped merging after the first entry in the Python oracle, TypeScript, Rust and Go. The shape is not hypothetical — it is how `reseact.esm` composes SuperFast:

```json
"coupling": [
  {"type": "operator_compose", "systems": ["SuperFastDepositionSink", "SuperFast"]},
  {"type": "operator_compose", "systems": ["SuperFastEmissionSource", "SuperFast"]},
  {"type": "operator_compose", "systems": ["SuperFast", "Transport3D"], "lifting": "pointwise"}
]
```

with the sink and source authoring `D(SuperFast.X, t)` directly — B's variable under A's authorship, which §4.7.1 permits.

All four bindings merge into A's equation, and in all four *"who authored this equation"* **is** which component's equation list it sits in. So entry 1's sum stayed filed under the sink; entry 2 walked the source's and the chemistry's lists, could not see it, and merged nothing. Both the composed tendency and the source's un-merged contribution reached assembly:

```
ConflictingDerivativeError: Two systems define non-additive equations for variable 'Chem.O3': Sink vs Src
```

Loud rather than corrupt — but the document is spec-valid and must flatten.

## The fix

Julia already does the right thing (the #172 fix): after summing, it reattributes the merged equation to the system that owns its dependent variable, on the reasoning that a composed tendency is no longer any single author's contribution. The other four now do the same, by relocating the equation into that component's list.

It is **appended** to the owner's list, which is what reproduces Julia's order: each merge trails the ones before it, so a species whose chain ends at a later entry lands after one whose chain ended earlier. Inserting at the consumed B equation's slot instead would freeze both at the state's original declaration order and disagree with every other binding.

Where A already is the variable's system — every corpus case before this one — the move is the identity. Regenerating the corpus confirms it: the only change to `cases.json` is the new case (+124 lines, 0 modified).

## What's in the change

| | |
|---|---|
| `esm-libraries-spec.md` | §4.7.1 step 4 gains the attribution rule. It said nothing about the ownership of a merged equation, which is why four bindings could disagree with the reference and still read as correct. |
| `tests/coupling/chained_operator_compose.esm` | The shared fixture — the minimal 4-system document from the issue. |
| `tests/conformance/flatten/cases.json` | Carries it as the new `chained_compose` tier, so the pin that has been Julia-local since #172 is now cross-language. |
| `pkg/EarthSciAST.jl/test/flatten_conformance_test.jl` | That testset now drives the shared file instead of an inline copy. |
| `flatten.py` / `flatten.ts` / `flatten.rs` / `flatten.go` | `_reattribute_merged_equations` and its three counterparts, called after the merge loop (positions are collected during it, because A's index is live until the last B equation is matched). Self-compose (`["X", "X"]`, which nothing rejects) is skipped: the shared list has just been rebound, and the move would be the identity there anyway. |
| `pkg/earthsci-ast-py/tests/test_flatten.py` | A fixture-independent regression test. The corpus is *generated* from the Python binding, so a regression there would rewrite the expected answer rather than fail against it. |

## Verification

The flattened answer now agrees with Julia's, exactly:

```
D(Chem.NO)/Dt = (-Sink.kd) * Chem.NO + (-Chem.k2) * Chem.NO + (-Adv.wind) * grad(Chem.NO)
D(Chem.O3)/Dt = Src.e + (-Sink.kd) * Chem.O3 + (-Chem.k1) * Chem.O3 + (-Adv.wind) * grad(Chem.O3)
```

- **Python** — full suite green (3133 passed, 23 skipped, 3 xfailed); `ruff check` / `ruff format --check` clean on every touched file.
- **TypeScript** — full suite green (2539 tests); prettier clean.
- **Go** — `go test ./...` green; `gofmt` clean.
- **Rust** — `cargo test --test flatten_conformance` green (5/5); `cargo fmt --check` clean for `flatten.rs`.

Each of Go and TypeScript was also re-run with its fix reverted, and both fail on the new corpus case — so the case is doing its job rather than passing vacuously.

Julia is unchanged by this PR (it has been correct since #172); its conformance run in CI is what confirms the new corpus case against the reference implementation.

## Notes for review

- Equation `source_system` is deliberately left as A's on a merge: Python, TypeScript and Go all already did that, the corpus compares the field for those three, and it is the provenance the `ConflictingDerivativeError` diagnostic reads. The *attribution* that moved is the component bag, which is the analogue of Julia's per-equation `owners` vector.
- The two attributions genuinely coincide in the bucket-based bindings, so relocating changes position as well as ownership. The spec text says so explicitly rather than claiming position is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cy5mPaV6B54dPUP5v7eYt2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy5mPaV6B54dPUP5v7eYt2)_