### PR TITLE
Enhance package security scanner with improved license and dependency handling

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -32,11 +32,14 @@ on:
         default: false
         type: boolean
 
-# The scan job opens an issue when it finds a high-severity vulnerability,
-# so it needs issues:write -- but nothing here needs write access to code.
+# The scan job opens an issue when it finds a high-severity vulnerability and
+# posts its report on the PR -- an issue comment on a PR is gated on
+# pull-requests:write, not issues:write -- but nothing here needs write access
+# to code.
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 concurrency:
   group: security-scan-${{ github.ref }}
@@ -125,12 +128,14 @@ jobs:
           SCANNER_ARGS="$SCANNER_ARGS --fail-on-warnings"
         fi
 
+        # `bash -e` would abort the step the moment the scanner exits
+        # non-zero, before the outputs below are written -- so capture the
+        # status instead of letting it propagate here.
+        SCAN_EXIT_CODE=0
         python3 scripts/package-security-scanner.py $SCANNER_ARGS \
-          --output security-scan-results.json
+          --output security-scan-results.json || SCAN_EXIT_CODE=$?
 
         # Extract results for GitHub output
-        SCAN_EXIT_CODE=$?
-
         if [ $SCAN_EXIT_CODE -eq 0 ]; then
           echo "status=success" >> $GITHUB_OUTPUT
         else
@@ -160,11 +165,10 @@ jobs:
       run: |
         echo "Running package signature verification..."
 
+        SIGNATURE_EXIT_CODE=0
         python3 scripts/package-signature-verifier.py \
           --config $SECURITY_CONFIG \
-          --output signature-verification-results.json
-
-        SIGNATURE_EXIT_CODE=$?
+          --output signature-verification-results.json || SIGNATURE_EXIT_CODE=$?
 
         if [ $SIGNATURE_EXIT_CODE -eq 0 ]; then
           echo "Signature verification completed successfully"
@@ -270,6 +274,10 @@ jobs:
 
     - name: Post security report as comment (PR)
       if: github.event_name == 'pull_request' && always()
+      # The report is informational; a PR from a fork gets a read-only token
+      # whatever the permissions block says, so a failure here must not mask
+      # the scan's own verdict.
+      continue-on-error: true
       uses: actions/github-script@v7
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.security-config.json
+++ b/.security-config.json
@@ -11,6 +11,8 @@
     "Apache-2.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "AGPL-3.0-only",
+    "AGPL-3.0-or-later",
     "GPL-3.0",
     "GPL-3.0-or-later",
     "LGPL-3.0",

--- a/.security-config.json
+++ b/.security-config.json
@@ -21,6 +21,7 @@
     "CC0-1.0",
     "Unlicense"
   ],
+  "check_unpinned_requirements": false,
   "security_policies": {
     "require_signature": true,
     "max_vulnerability_score": 7.0,

--- a/pkg/earthsci-ast-py/src/earthsci_ast/numpy_interpreter.py
+++ b/pkg/earthsci-ast-py/src/earthsci_ast/numpy_interpreter.py
@@ -2780,7 +2780,7 @@ def _join_sym_for_key(
         f"index set {key!r} is drawn by {len(candidates)} range symbols of this "
         f"aggregate ({candidates}), so which one a key column over it is read at is "
         f"not determined; name the two sides explicitly with this clause's "
-        f'\'syms\' (CONFORMANCE_SPEC §5.5.8 "Two ranges over one index set")'
+        f"'syms' (CONFORMANCE_SPEC §5.5.8 \"Two ranges over one index set\")"
     )
 
 

--- a/pkg/earthsci-ast-py/src/earthsci_ast/structural_checks.py
+++ b/pkg/earthsci-ast-py/src/earthsci_ast/structural_checks.py
@@ -588,8 +588,7 @@ def _check_aggregate_semantics(data: dict[str, Any], errors: list) -> None:
                                     f"which one the key is read at; name the clause's two "
                                     f"sides with `syms`"
                                     if via_column
-                                    else
-                                    f"aggregate join key {key!r} names an index set that "
+                                    else f"aggregate join key {key!r} names an index set that "
                                     f"{len(cands)} range symbols of this aggregate draw; "
                                     f"reference the range symbol directly, or name the "
                                     f"clause's two sides with `syms`"

--- a/pkg/earthsci-ast-py/tests/test_aggregate_conformance.py
+++ b/pkg/earthsci-ast-py/tests/test_aggregate_conformance.py
@@ -252,9 +252,7 @@ def test_build_time_invalid_fixture_rejected(fixture_path: Path) -> None:
     want = {(e["code"], e["path"]) for e in expected["structural_errors"]}
     assert want, f"{fixture_path.name}: the pin names no structural error"
 
-    result = validate_text(
-        fixture_path.read_text(), base_path=str(fixture_path.parent)
-    )
+    result = validate_text(fixture_path.read_text(), base_path=str(fixture_path.parent))
     assert not result.is_valid, f"{fixture_path.name}: expected a structural rejection"
     got = {(e.code, e.path) for e in result.structural_errors}
     assert want <= got, f"{fixture_path.name}: want {sorted(want)}, got {sorted(got)}"

--- a/pkg/earthsci-ast-py/tests/test_closed_functions.py
+++ b/pkg/earthsci-ast-py/tests/test_closed_functions.py
@@ -285,10 +285,11 @@ def test_enum_values_must_still_be_unique_including_zero():
     separate case from the positive duplicate because a "seen set" that used
     ``0`` as its own sentinel would pass the positive case and let this one
     through."""
+
     def doc(enums: str) -> str:
         return (
             '{"esm":"1.0.0","metadata":{"name":"T","description":"d",'
-            '"authors":["a"]},"enums":' + enums + ','
+            '"authors":["a"]},"enums":' + enums + ","
             '"models":{"M":{"variables":{"x":{"type":"unknown","units":"1"}},'
             '"equations":[{"lhs":"x","rhs":{"op":"enum","args":["m","A"]}}]}}}'
         )

--- a/pkg/earthsci-ast-py/tests/test_conformance_round_trip.py
+++ b/pkg/earthsci-ast-py/tests/test_conformance_round_trip.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterator
-from pathlib import Path
 from typing import Any
 
 import pytest

--- a/pkg/earthsci-ast-py/tests/test_data_source_url_conformance.py
+++ b/pkg/earthsci-ast-py/tests/test_data_source_url_conformance.py
@@ -50,9 +50,7 @@ def test_relative_catalog_resolves_as_pinned(source_name: str) -> None:
 
     assert source.url_template == _expected(pin["url_template"])
     if "mirrors" in pin:
-        assert [str(m) for m in (source.mirrors or [])] == [
-            _expected(m) for m in pin["mirrors"]
-        ]
+        assert [str(m) for m in (source.mirrors or [])] == [_expected(m) for m in pin["mirrors"]]
 
 
 def test_resolution_is_idempotent_so_parse_emit_parse_is_stable(tmp_path: Path) -> None:
@@ -70,9 +68,7 @@ def test_resolution_is_idempotent_so_parse_emit_parse_is_stable(tmp_path: Path) 
 
     for name, ds in first.data_sources.items():
         assert second.data_sources[name].source.url_template == ds.source.url_template
-        assert list(second.data_sources[name].source.mirrors or []) == list(
-            ds.source.mirrors or []
-        )
+        assert list(second.data_sources[name].source.mirrors or []) == list(ds.source.mirrors or [])
 
 
 @pytest.mark.parametrize("fixture_id", ["env_var_catalog", "env_var_mirror_catalog"])

--- a/pkg/earthsci-ast-rs/src/bin/esm.rs
+++ b/pkg/earthsci-ast-rs/src/bin/esm.rs
@@ -11,8 +11,8 @@ use earthsci_ast::extension::analysis::{
 };
 use earthsci_ast::{
     ExpressionGraphOptions, component_exists, component_graph, expression_graph,
-    expression_graph_with_options, load_string, stoichiometric_matrix, to_json, to_json_compact,
-    validate, validate_text,
+    expression_graph_with_options, stoichiometric_matrix, to_json, to_json_compact, validate,
+    validate_text,
 };
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
@@ -2476,7 +2476,6 @@ fn run_simulate(
     Ok(())
 }
 
-
 // =============================================================================
 // Single evaluation of a document with nothing to integrate
 // =============================================================================
@@ -2492,6 +2491,10 @@ fn run_simulate(
 // These three functions are that route. They do not add a mode to the solver;
 // they add a SINK to the evaluation the build pipeline already performs.
 
+/// The materialized static fields a run emits: one named column per field,
+/// each an N-dimensional array.
+type StaticFields = Vec<(String, ndarray::ArrayD<f64>)>;
+
 /// The build-time fields to write, in the order they will be columns.
 ///
 /// `observed` names them explicitly (the `--observed` flag); empty means every
@@ -2501,7 +2504,7 @@ fn run_simulate(
 fn static_fields(
     prob: &earthsci_ast::EsmProblem,
     observed: &[String],
-) -> Result<Vec<(String, ndarray::ArrayD<f64>)>, Box<dyn std::error::Error>> {
+) -> Result<StaticFields, Box<dyn std::error::Error>> {
     let names: Vec<String> = if observed.is_empty() {
         prob.observed_field_names()
     } else {
@@ -3455,7 +3458,7 @@ fn consumed_data_sources(doc: &serde_json::Value) -> BTreeMap<String, Vec<String
     }
     // A binding naming a source the document does not declare is a validation
     // error, not an ingest one — leave it to `validate` and ignore it here.
-    out.retain(|src, _| declared.iter().any(|d| *d == src));
+    out.retain(|src, _| declared.contains(&src));
     out
 }
 
@@ -3496,12 +3499,19 @@ fn no_reader_diagnostic(consumed: &BTreeMap<String, Vec<String>>) -> String {
          `cargo build --release --features esio` (see pkg/earthsci-ast-rs/Cargo.toml). \
          Running anyway would evaluate every data-fed parameter at its `default` \
          and report the result as the document's answer.",
-        if consumed.len() == 1 { "a source" } else { "sources" },
-        if consumed.len() == 1 { "it" } else { "its parameters" },
+        if consumed.len() == 1 {
+            "a source"
+        } else {
+            "sources"
+        },
+        if consumed.len() == 1 {
+            "it"
+        } else {
+            "its parameters"
+        },
         consumed_summary(consumed)
     )
 }
-
 
 /// Close every metaparameter a `data_sources` `extent` binds, by SAMPLING the
 /// sources that measure themselves, and re-load the document with the sizes the
@@ -3749,9 +3759,8 @@ fn run_test(
                 // been resolved and a mounted component's data bindings are
                 // visible here.
                 let ready = close_declared_extents(esm_file, |mp| {
-                    earthsci_ast::load_path_with_options(path, mp).map_err(|e| {
-                        format!("re-loading with the discovered source extents: {e}")
-                    })
+                    earthsci_ast::load_path_with_options(path, mp)
+                        .map_err(|e| format!("re-loading with the discovered source extents: {e}"))
                 });
                 let (esm_file, providers) = match ready {
                     Ok(pair) => pair,
@@ -4484,7 +4493,7 @@ mod tests {
             ("coupling", TEMPLATE_COUPLING),
         ] {
             let content = template.replace("{name}", "demo_project");
-            let esm_file = load_string(&content)
+            let esm_file = earthsci_ast::load_string(&content)
                 .unwrap_or_else(|e| panic!("template '{name}' does not load: {e}"));
             let result = validate(&esm_file);
             assert!(

--- a/pkg/earthsci-ast-rs/src/data_source_urls.rs
+++ b/pkg/earthsci-ast-rs/src/data_source_urls.rs
@@ -154,10 +154,7 @@ pub(crate) fn resolve_data_source_urls(
     doc: &mut Value,
     base_dir: &Path,
 ) -> Result<(), DiagnosticError> {
-    let Some(sources) = doc
-        .get_mut("data_sources")
-        .and_then(Value::as_object_mut)
-    else {
+    let Some(sources) = doc.get_mut("data_sources").and_then(Value::as_object_mut) else {
         return Ok(());
     };
     for (name, entry) in sources.iter_mut() {
@@ -270,7 +267,11 @@ mod tests {
         for t in ["./a?b.nc", "./a#b.nc"] {
             let e = resolve_source_url(t, Path::new("/a/b")).expect_err("must refuse");
             assert_eq!(e.code, codes::DATA_SOURCE_URL_UNRESOLVED);
-            assert!(e.message.contains(t), "must name the template: {}", e.message);
+            assert!(
+                e.message.contains(t),
+                "must name the template: {}",
+                e.message
+            );
         }
     }
 

--- a/pkg/earthsci-ast-rs/src/join.rs
+++ b/pkg/earthsci-ast-rs/src/join.rs
@@ -606,7 +606,10 @@ enum Via {
 /// §5.5.8's partner-restricted drive shape means by "the LATER of the two gated
 /// axes". Reusing it is what makes the default side assignment a pure function
 /// of the document rather than of a hash iteration.
-fn canonical_range_order(output_idx: &[String], ranges: &HashMap<String, RangeSpec>) -> Vec<String> {
+fn canonical_range_order(
+    output_idx: &[String],
+    ranges: &HashMap<String, RangeSpec>,
+) -> Vec<String> {
     let mut out: Vec<String> = output_idx
         .iter()
         .filter(|n| ranges.contains_key(n.as_str()))

--- a/pkg/earthsci-ast-rs/src/lib.rs
+++ b/pkg/earthsci-ast-rs/src/lib.rs
@@ -97,13 +97,13 @@ pub(crate) mod parse;
 /// Text→AST parsing of the INFIX expression surface `display::to_ascii` emits
 /// (the inverse of that printer). Pure and wasm32-clean.
 pub(crate) mod parse_expression;
-pub mod provider;
 /// The evaluator's working precision — `domain.element_type` (esm-spec
 /// §11.3). Public because the contract it implements (`"Float32"` means
 /// per-operation binary32 rounding) is observable, and a host embedding the
 /// evaluator needs to be able to name it.
 pub mod precision;
 pub mod precision_infer;
+pub mod provider;
 pub(crate) mod reactions;
 pub(crate) mod ref_loading;
 pub(crate) mod reference_resolution;

--- a/pkg/earthsci-ast-rs/src/pde_inline_tests.rs
+++ b/pkg/earthsci-ast-rs/src/pde_inline_tests.rs
@@ -1214,6 +1214,11 @@ fn build_for_test(
 /// The memo cannot change an answer it does not also change without it: the
 /// key is compared exactly, the build is a pure function of the key plus the
 /// loop-invariant context above, and the solve still runs per test.
+// Nine parameters against clippy's seven. They are the loop-invariant context
+// the build memo keys on, described above; bundling them into a struct would
+// move the same values behind one more name without making any of them
+// optional.
+#[allow(clippy::too_many_arguments)]
 fn run_model_tests(
     file: &EsmFile,
     model_name: &str,
@@ -1309,17 +1314,16 @@ fn run_model_tests(
                     Ok(sol) => Ok(sol),
                     // A document with no ODEs never integrates; its answers are
                     // the build's, evaluated at the asserted times.
-                    Err(crate::simulate::SimulateError::NotDynamic { .. }) => {
-                        Ok(build_only_solution(run_opts.saveat.clone().unwrap_or_default()))
-                    }
+                    Err(crate::simulate::SimulateError::NotDynamic { .. }) => Ok(
+                        build_only_solution(run_opts.saveat.clone().unwrap_or_default()),
+                    ),
                     Err(e) => Err(format!("simulate failed: {e}")),
                 }
-                .map(|sol| {
+                .inspect(|_sol| {
                     insp = prob.take_inspection();
                     for (k, v) in fields {
                         insp.setup_arrays.entry(k).or_insert(v);
                     }
-                    sol
                 })
             }
         }
@@ -1881,7 +1885,11 @@ mod tests {
         let results = run_pde_tests(&file, Some("M"), &tight_opts());
         assert_eq!(results.len(), 3);
         for r in &results {
-            assert!(r.passed, "{}#{}: {}", r.variable, r.assertion_idx, r.message);
+            assert!(
+                r.passed,
+                "{}#{}: {}",
+                r.variable, r.assertion_idx, r.message
+            );
         }
         // 2*exp(-0.5): the observed is read at the RIGHT time, not held at t=0.
         let late = results[2].actual.expect("actual");

--- a/pkg/earthsci-ast-rs/src/precision.rs
+++ b/pkg/earthsci-ast-rs/src/precision.rs
@@ -475,7 +475,10 @@ mod tests {
                 let _inner = enter(Precision::Float64);
                 assert!(!is_f32());
             }
-            assert!(is_f32(), "the inner guard restores Float32, not the default");
+            assert!(
+                is_f32(),
+                "the inner guard restores Float32, not the default"
+            );
         }
         assert!(!is_f32());
     }

--- a/pkg/earthsci-ast-rs/src/precision_infer.rs
+++ b/pkg/earthsci-ast-rs/src/precision_infer.rs
@@ -256,10 +256,7 @@ fn annotate_model_with(
     document: Precision,
     qualified: &HashMap<String, Precision>,
 ) -> Result<(), CompileError> {
-    if !model
-        .variables
-        .values()
-        .any(|v| v.element_type.is_some())
+    if !model.variables.values().any(|v| v.element_type.is_some())
         && !qualified.values().any(|p| *p != document)
     {
         return Ok(());
@@ -289,11 +286,8 @@ fn annotate_model_with(
 /// [`CompileError::UnsupportedElementType`] for any spelling that is neither
 /// `"Float64"` nor `"Float32"`.
 pub fn env_of_file(file: &crate::types::EsmFile) -> Result<Env, CompileError> {
-    let document = Precision::from_element_type(
-        file.domain
-            .as_ref()
-            .and_then(|d| d.element_type.as_deref()),
-    )?;
+    let document =
+        Precision::from_element_type(file.domain.as_ref().and_then(|d| d.element_type.as_deref()))?;
     let mut vars = VarPrecisions::default();
     for (mname, model) in file.models.iter().flatten() {
         for (vname, var) in &model.variables {
@@ -319,7 +313,9 @@ pub fn env_of_file(file: &crate::types::EsmFile) -> Result<Env, CompileError> {
 /// # Errors
 ///
 /// As [`annotate_model`].
-pub fn annotated(file: &crate::types::EsmFile) -> Result<Option<crate::types::EsmFile>, CompileError> {
+pub fn annotated(
+    file: &crate::types::EsmFile,
+) -> Result<Option<crate::types::EsmFile>, CompileError> {
     let declares = file
         .models
         .iter()

--- a/pkg/earthsci-ast-rs/src/prepare.rs
+++ b/pkg/earthsci-ast-rs/src/prepare.rs
@@ -1814,7 +1814,8 @@ impl<'o> BuildState<'o> {
                 "  [prepare] gated fetch {key} -> {target} {:?}",
                 arr.shape()
             ));
-            self.arrays.insert(target.clone(), round_external(&target, arr));
+            self.arrays
+                .insert(target.clone(), round_external(&target, arr));
         }
         self.report(
             PreparePhase::GatedFetch,

--- a/pkg/earthsci-ast-rs/src/problem.rs
+++ b/pkg/earthsci-ast-rs/src/problem.rs
@@ -1155,12 +1155,8 @@ pub fn esm_problem<'a>(
     // `prepare` — fill NAMED variables and must round each to ITS declared
     // precision, not to the document's. Empty for every document that declares
     // none, which is the inert path.
-    let var_precisions = variable_element_types_of(
-        owned_json.as_ref(),
-        owned_file.as_ref(),
-        flat_only,
-        prec,
-    )?;
+    let var_precisions =
+        variable_element_types_of(owned_json.as_ref(), owned_file.as_ref(), flat_only, prec)?;
     let _precision_guard = precision::enter_env(prec, std::rc::Rc::new(var_precisions));
 
     // Host-supplied numbers are the one class of value the evaluator does not
@@ -1412,7 +1408,10 @@ fn variable_element_types_of(
             Err(e) => Err(SimulateError::Compile(e)),
         }
     };
-    if let Some(models) = raw.and_then(|v| v.get("models")).and_then(JsonValue::as_object) {
+    if let Some(models) = raw
+        .and_then(|v| v.get("models"))
+        .and_then(JsonValue::as_object)
+    {
         for (mname, model) in models {
             let Some(vars) = model.get("variables").and_then(JsonValue::as_object) else {
                 continue;

--- a/pkg/earthsci-ast-rs/src/simulate/resolve.rs
+++ b/pkg/earthsci-ast-rs/src/simulate/resolve.rs
@@ -148,24 +148,24 @@ pub(super) fn resolve_expr(
             // gates the same set through `check_evaluable`; this is the scalar
             // path's mirror, so neither can silently evaluate one in binary64.
             // A no-op under Float64.
-            if let Some((construct, reason)) =
-                crate::precision::is_f32()
-                    .then(|| crate::precision::f32_unsupported_reason(&node.op, node.name.as_deref()))
-                    .flatten()
+            if let Some((construct, reason)) = crate::precision::is_f32()
+                .then(|| crate::precision::f32_unsupported_reason(&node.op, node.name.as_deref()))
+                .flatten()
             {
                 return Err(CompileError::Float32Unsupported { construct, reason });
             }
             // The precision-boundary marker, resolved to its own variant so
             // the element type in `name` survives to evaluation.
             if let Some(prec) = crate::precision_infer::marker_precision(node) {
-                let arg = node.args.first().ok_or_else(|| {
-                    CompileError::InterpreterBuildError {
+                let arg = node
+                    .args
+                    .first()
+                    .ok_or_else(|| CompileError::InterpreterBuildError {
                         details: format!(
                             "`{}` op is missing its operand",
                             crate::precision_infer::MARKER_OP
                         ),
-                    }
-                })?;
+                    })?;
                 return Ok(ResolvedExpr::Precision {
                     prec,
                     arg: Box::new(resolve_expr(

--- a/pkg/earthsci-ast-rs/src/simulate_array/compile.rs
+++ b/pkg/earthsci-ast-rs/src/simulate_array/compile.rs
@@ -1761,7 +1761,10 @@ pub(super) fn lower_recurrence(
                         ),
                     ));
                 }
-                SelfIdx::Offset { proven, max_lag: hi } => {
+                SelfIdx::Offset {
+                    proven,
+                    max_lag: hi,
+                } => {
                     lag_proven &= proven;
                     if lagged.is_some() {
                         return Err(recur_err(
@@ -3158,13 +3161,7 @@ pub(super) fn rename_free_symbol(expr: &Expr, from: &str, to: &str) -> Expr {
 /// references into the variable registry. (`map_column_names` renames the gate's
 /// COLUMNS only, for exactly that reason.)
 fn rename_join_names(join: &[JoinClause], from: &str, to: &str) -> Vec<JoinClause> {
-    let ren = |n: &String| -> String {
-        if n == from {
-            to.to_string()
-        } else {
-            n.clone()
-        }
-    };
+    let ren = |n: &String| -> String { if n == from { to.to_string() } else { n.clone() } };
     join.iter()
         .map(|c| JoinClause {
             on: c.on.iter().map(|[l, r]| [ren(l), ren(r)]).collect(),

--- a/pkg/earthsci-ast-rs/src/simulate_array/driver.rs
+++ b/pkg/earthsci-ast-rs/src/simulate_array/driver.rs
@@ -1548,12 +1548,13 @@ impl ArrayCompiled {
                 ..
             } = rule
             {
-                insp.recurrences.push(crate::simulate_array::RecurrenceInfo {
-                    var: var.clone(),
-                    axis: output_idx_names[*axis].clone(),
-                    max_lag: *max_lag,
-                    lag_proven: *lag_proven,
-                });
+                insp.recurrences
+                    .push(crate::simulate_array::RecurrenceInfo {
+                        var: var.clone(),
+                        axis: output_idx_names[*axis].clone(),
+                        max_lag: *max_lag,
+                        lag_proven: *lag_proven,
+                    });
             }
         }
         for name in static_names {

--- a/pkg/earthsci-ast-rs/src/simulate_array/eval.rs
+++ b/pkg/earthsci-ast-rs/src/simulate_array/eval.rs
@@ -2226,9 +2226,7 @@ fn expr_reads_self(expr: &Expr, name: &str) -> bool {
     let Expr::Operator(node) = expr else {
         return false;
     };
-    if node.op == "index"
-        && matches!(node.args.first(), Some(Expr::Variable(v)) if v == name)
-    {
+    if node.op == "index" && matches!(node.args.first(), Some(Expr::Variable(v)) if v == name) {
         return true;
     }
     node.args.iter().any(|a| expr_reads_self(a, name))
@@ -2549,7 +2547,10 @@ impl JoinGate {
     /// agree on the match sets agree on the order.
     fn selectivity_cmp(&self, other: &JoinGate) -> std::cmp::Ordering {
         let (a1, s1) = (self.index.len() as i128, (self.n_src * self.n_tgt) as i128);
-        let (a2, s2) = (other.index.len() as i128, (other.n_src * other.n_tgt) as i128);
+        let (a2, s2) = (
+            other.index.len() as i128,
+            (other.n_src * other.n_tgt) as i128,
+        );
         (a1 * s2)
             .cmp(&(a2 * s1))
             .then_with(|| self.clause_ix.cmp(&other.clause_ix))
@@ -3230,17 +3231,7 @@ fn drive_partner_restricted(
                 for i in 0..parts.len() {
                     let v = parts[i];
                     set_bind(&mut ctx.loop_binds, &contract_names[d], v);
-                    drive_partner_restricted(
-                        spec,
-                        srcs,
-                        gate,
-                        p,
-                        q,
-                        bound_is_src,
-                        d + 1,
-                        acc,
-                        ctx,
-                    );
+                    drive_partner_restricted(spec, srcs, gate, p, q, bound_is_src, d + 1, acc, ctx);
                 }
             }
             // Phase 1 already restricted this dim; walk the intersection of the
@@ -4613,13 +4604,69 @@ mod evaluability_gate_tests {
     #[test]
     fn the_core_minus_evaluable_gap_is_exactly_nine_ops() {
         const CORE: &[&str] = &[
-            "+", "-", "*", "/", "^", "neg", "exp", "log", "ln", "log10", "sqrt", "abs", "sign",
-            "floor", "ceil", "sin", "cos", "tan", "asin", "acos", "atan", "sinh", "cosh", "tanh",
-            "asinh", "acosh", "atanh", "atan2", "min", "max", "ifelse", "==", "!=", "<", "<=",
-            ">", ">=", "and", "or", "not", "D", "ic", "Pre", "const", "true", "fn", "enum",
-            "table_lookup", "apply_expression_template", "aggregate", "makearray", "index",
-            "broadcast", "reshape", "transpose", "concat", "skolem", "rank", "distinct",
-            "argmin", "argmax", "intersect_polygon", "polygon_intersection_area",
+            "+",
+            "-",
+            "*",
+            "/",
+            "^",
+            "neg",
+            "exp",
+            "log",
+            "ln",
+            "log10",
+            "sqrt",
+            "abs",
+            "sign",
+            "floor",
+            "ceil",
+            "sin",
+            "cos",
+            "tan",
+            "asin",
+            "acos",
+            "atan",
+            "sinh",
+            "cosh",
+            "tanh",
+            "asinh",
+            "acosh",
+            "atanh",
+            "atan2",
+            "min",
+            "max",
+            "ifelse",
+            "==",
+            "!=",
+            "<",
+            "<=",
+            ">",
+            ">=",
+            "and",
+            "or",
+            "not",
+            "D",
+            "ic",
+            "Pre",
+            "const",
+            "true",
+            "fn",
+            "enum",
+            "table_lookup",
+            "apply_expression_template",
+            "aggregate",
+            "makearray",
+            "index",
+            "broadcast",
+            "reshape",
+            "transpose",
+            "concat",
+            "skolem",
+            "rank",
+            "distinct",
+            "argmin",
+            "argmax",
+            "intersect_polygon",
+            "polygon_intersection_area",
         ];
         for op in CORE {
             assert!(

--- a/pkg/earthsci-ast-rs/src/simulate_array/mod.rs
+++ b/pkg/earthsci-ast-rs/src/simulate_array/mod.rs
@@ -82,11 +82,11 @@ pub use compile::{file_has_array_ops, file_has_spatial_model, run_value_inventio
 // two routes cannot disagree about which names a document declares.
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) use compile::check_free_variables;
+pub(crate) use eval::eval_observed_recurrence;
 pub use eval::{
     eval_expression, eval_expression_with_extents, eval_expression_with_extents_and_consts,
     take_const_array_oob,
 };
-pub(crate) use eval::eval_observed_recurrence;
 // The scalar-op leaf kernel is defined once here (backs the per-cell oracle and
 // the vectorized overlay); re-exported crate-wide so the scalar interpreter
 // `crate::simulate::eval_op` routes through the SAME definition instead of

--- a/pkg/earthsci-ast-rs/src/simulate_array/tape/exec/fused.rs
+++ b/pkg/earthsci-ast-rs/src/simulate_array/tape/exec/fused.rs
@@ -297,20 +297,20 @@ macro_rules! dispatch_bin_kernel {
             $apply!(binary_kernel_of(*$op))
         } else {
             match $op {
-            BinCode::Add => $apply!(|x, y| x + y),
-            BinCode::Sub => $apply!(|x, y| x - y),
-            BinCode::Mul => $apply!(|x, y| x * y),
-            BinCode::Div => $apply!(|x, y| x / y),
-            BinCode::Pow => $apply!(|x: f64, y: f64| x.powf(y)),
-            BinCode::Min => $apply!(|x: f64, y: f64| x.min(y)),
-            BinCode::Max => $apply!(|x: f64, y: f64| x.max(y)),
-            BinCode::Eq => $apply!(|x, y| (x == y) as i32 as f64),
-            BinCode::Ne => $apply!(|x, y| (x != y) as i32 as f64),
-            BinCode::Lt => $apply!(|x, y| (x < y) as i32 as f64),
-            BinCode::Le => $apply!(|x, y| (x <= y) as i32 as f64),
-            BinCode::Gt => $apply!(|x, y| (x > y) as i32 as f64),
-            BinCode::Ge => $apply!(|x, y| (x >= y) as i32 as f64),
-            other => $apply!(binary_kernel_of(*other)),
+                BinCode::Add => $apply!(|x, y| x + y),
+                BinCode::Sub => $apply!(|x, y| x - y),
+                BinCode::Mul => $apply!(|x, y| x * y),
+                BinCode::Div => $apply!(|x, y| x / y),
+                BinCode::Pow => $apply!(|x: f64, y: f64| x.powf(y)),
+                BinCode::Min => $apply!(|x: f64, y: f64| x.min(y)),
+                BinCode::Max => $apply!(|x: f64, y: f64| x.max(y)),
+                BinCode::Eq => $apply!(|x, y| (x == y) as i32 as f64),
+                BinCode::Ne => $apply!(|x, y| (x != y) as i32 as f64),
+                BinCode::Lt => $apply!(|x, y| (x < y) as i32 as f64),
+                BinCode::Le => $apply!(|x, y| (x <= y) as i32 as f64),
+                BinCode::Gt => $apply!(|x, y| (x > y) as i32 as f64),
+                BinCode::Ge => $apply!(|x, y| (x >= y) as i32 as f64),
+                other => $apply!(binary_kernel_of(*other)),
             }
         }
     };
@@ -329,26 +329,26 @@ macro_rules! dispatch_un_kernel {
             $apply!(unary_kernel_of(*$op))
         } else {
             match $op {
-            UnCode::Abs => $apply!(|x: f64| x.abs()),
-            UnCode::Sqrt => $apply!(|x: f64| x.sqrt()),
-            UnCode::Exp => $apply!(|x: f64| x.exp()),
-            UnCode::Ln => $apply!(|x: f64| x.ln()),
-            UnCode::Log10 => $apply!(|x: f64| x.log10()),
-            UnCode::Sin => $apply!(|x: f64| x.sin()),
-            UnCode::Cos => $apply!(|x: f64| x.cos()),
-            UnCode::Tanh => $apply!(|x: f64| x.tanh()),
-            UnCode::Floor => $apply!(|x: f64| x.floor()),
-            UnCode::Ceil => $apply!(|x: f64| x.ceil()),
-            UnCode::Sign => $apply!(|x: f64| {
-                if x > 0.0 {
-                    1.0
-                } else if x < 0.0 {
-                    -1.0
-                } else {
-                    0.0
-                }
-            }),
-            other => $apply!(unary_kernel_of(*other)),
+                UnCode::Abs => $apply!(|x: f64| x.abs()),
+                UnCode::Sqrt => $apply!(|x: f64| x.sqrt()),
+                UnCode::Exp => $apply!(|x: f64| x.exp()),
+                UnCode::Ln => $apply!(|x: f64| x.ln()),
+                UnCode::Log10 => $apply!(|x: f64| x.log10()),
+                UnCode::Sin => $apply!(|x: f64| x.sin()),
+                UnCode::Cos => $apply!(|x: f64| x.cos()),
+                UnCode::Tanh => $apply!(|x: f64| x.tanh()),
+                UnCode::Floor => $apply!(|x: f64| x.floor()),
+                UnCode::Ceil => $apply!(|x: f64| x.ceil()),
+                UnCode::Sign => $apply!(|x: f64| {
+                    if x > 0.0 {
+                        1.0
+                    } else if x < 0.0 {
+                        -1.0
+                    } else {
+                        0.0
+                    }
+                }),
+                other => $apply!(unary_kernel_of(*other)),
             }
         }
     };

--- a/pkg/earthsci-ast-rs/src/simulate_array/vectorized.rs
+++ b/pkg/earthsci-ast-rs/src/simulate_array/vectorized.rs
@@ -557,14 +557,12 @@ pub(super) fn eval_vec_contracted<'a>(
     // gets the arithmetic from the precision-aware kernel table; the fusion's
     // own contract is that it is bit-identical to that route, so nothing but
     // the buffer traffic changes.
-    let fuse_mul: Option<(&Expr, &Expr)> = if filter.is_none()
-        && reduce == ReduceKind::Sum
-        && !crate::precision::is_f32()
-    {
-        as_op(body, "*", 2).map(|n| (&n.args[0], &n.args[1]))
-    } else {
-        None
-    };
+    let fuse_mul: Option<(&Expr, &Expr)> =
+        if filter.is_none() && reduce == ReduceKind::Sum && !crate::precision::is_f32() {
+            as_op(body, "*", 2).map(|n| (&n.args[0], &n.args[1]))
+        } else {
+            None
+        };
 
     // Iterate the contraction window with a mixed-radix counter (no allocation).
     let mut cvals = [0i64; MAXC];

--- a/pkg/earthsci-ast-rs/tests/cli_data_source_ingest.rs
+++ b/pkg/earthsci-ast-rs/tests/cli_data_source_ingest.rs
@@ -35,7 +35,10 @@
 #![cfg(all(not(target_arch = "wasm32"), feature = "cli", feature = "solve"))]
 
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+// Only `fixture_with_scalar_total` returns one, and that is esio-gated.
+#[cfg(feature = "esio")]
+use std::path::PathBuf;
 use std::process::Command;
 
 use serde_json::{Value, json};
@@ -53,6 +56,7 @@ const ANN: [f64; 3] = [100.0, 50.0, 30.0];
 const ANN_MEAN: f64 = 60.0;
 /// The SUM of the same column — the value a 0-D observed over it must report,
 /// and unreachable from any `default`.
+#[cfg(feature = "esio")]
 const ANN_TOTAL: f64 = 180.0;
 
 fn ff10_row(ann: f64, lon: f64, lat: f64) -> String {
@@ -106,10 +110,7 @@ fn write_ff10_zip(dir: &Path) -> String {
                 .map(|(i, a)| ff10_row(*a, -90.0 - i as f64, 40.0 + i as f64))
                 .collect::<Vec<_>>(),
         ),
-        (
-            "point/ptnonipm.csv",
-            vec![ff10_row(999.0, -94.0, 45.0)],
-        ),
+        ("point/ptnonipm.csv", vec![ff10_row(999.0, -94.0, 45.0)]),
     ] {
         zw.start_file::<_, ()>(name, zip::write::SimpleFileOptions::default())
             .expect("start member");
@@ -230,6 +231,7 @@ fn document(url: &str, extra_reader_options: Option<(&str, Value)>, sizing: Sizi
 /// build-static path had no route to them at all. The `mean` assertion on the
 /// array is carried alongside as the control: both halves of one document must
 /// answer.
+#[cfg(feature = "esio")]
 fn document_with_scalar_total(url: &str, sizing: Sizing, expected_total: f64) -> Value {
     let mut doc = document(url, None, sizing);
     doc["models"]["Ingest"]["variables"]["annual_total"] = json!({
@@ -268,12 +270,16 @@ fn document_with_scalar_total(url: &str, sizing: Sizing, expected_total: f64) ->
 }
 
 /// Write the scalar-total fixture into `dir`, returning the .esm path.
+#[cfg(feature = "esio")]
 fn fixture_with_scalar_total(dir: &Path, sizing: Sizing, expected_total: f64) -> PathBuf {
     let url = write_ff10_zip(dir);
     let doc = document_with_scalar_total(&url, sizing, expected_total);
     let path = dir.join("ingest_scalar.esm");
-    fs::write(&path, serde_json::to_string_pretty(&doc).expect("doc renders"))
-        .expect("write document");
+    fs::write(
+        &path,
+        serde_json::to_string_pretty(&doc).expect("doc renders"),
+    )
+    .expect("write document");
     path
 }
 
@@ -294,8 +300,11 @@ fn fixture(
     let url = write_ff10_zip(dir);
     let doc = document(&url, extra_reader_options, sizing);
     let path = dir.join("ingest.esm");
-    fs::write(&path, serde_json::to_string_pretty(&doc).expect("doc renders"))
-        .expect("write document");
+    fs::write(
+        &path,
+        serde_json::to_string_pretty(&doc).expect("doc renders"),
+    )
+    .expect("write document");
     path
 }
 
@@ -399,7 +408,11 @@ fn an_ingested_scalar_contracts_over_the_discovered_extent() {
 #[test]
 fn an_unrecognised_reader_option_is_an_error_naming_the_source() {
     let tmp = tempfile::tempdir().expect("tmpdir");
-    let doc = fixture(tmp.path(), Some(("skip_headr_row", json!(true))), Sizing::Literal);
+    let doc = fixture(
+        tmp.path(),
+        Some(("skip_headr_row", json!(true))),
+        Sizing::Literal,
+    );
     let (ok, out) = esm(tmp.path(), &["test", doc.to_str().expect("utf-8 path")]);
     assert!(!ok, "an unknown reader option must not exit 0; got:\n{out}");
     assert_eq!(total_row(&out), (0, 0, 1), "in:\n{out}");
@@ -421,7 +434,10 @@ fn a_missing_source_file_is_an_error_naming_the_source() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let doc_path = fixture(tmp.path(), None, Sizing::Literal);
     fs::remove_file(tmp.path().join("2016fd_inputs_point.zip")).expect("remove the fixture");
-    let (ok, out) = esm(tmp.path(), &["test", doc_path.to_str().expect("utf-8 path")]);
+    let (ok, out) = esm(
+        tmp.path(),
+        &["test", doc_path.to_str().expect("utf-8 path")],
+    );
     assert!(!ok, "a missing source file must not exit 0; got:\n{out}");
     assert_eq!(total_row(&out), (0, 0, 1), "in:\n{out}");
     assert!(
@@ -429,7 +445,6 @@ fn a_missing_source_file_is_an_error_naming_the_source() {
         "the diagnostic must name the source or its consumer:\n{out}"
     );
 }
-
 
 /// The row count comes from the DATA (esm-spec §8.9.4), not from the document.
 ///
@@ -505,7 +520,10 @@ fn a_build_without_the_reader_refuses_and_names_the_source() {
     );
     assert_eq!(total_row(&out), (0, 0, 1), "in:\n{out}");
     assert!(out.contains("EGU_Emis"), "must name the source:\n{out}");
-    assert!(out.contains("esio"), "must name the missing feature:\n{out}");
+    assert!(
+        out.contains("esio"),
+        "must name the missing feature:\n{out}"
+    );
     assert!(
         out.contains("Ingest.annual"),
         "must name the parameter that reads it:\n{out}"

--- a/pkg/earthsci-ast-rs/tests/cli_static_evaluation_output.rs
+++ b/pkg/earthsci-ast-rs/tests/cli_static_evaluation_output.rs
@@ -149,7 +149,11 @@ fn a_relational_document_writes_its_computed_values() {
     // The VALUES, not merely a file: a run that wrote defaults would pass a
     // "the file exists" assertion and fail every one of these.
     for (i, want) in LEFT.iter().enumerate() {
-        assert_eq!(values[&format!("Rel.left[{}]", i + 1)], *want, "in {values:?}");
+        assert_eq!(
+            values[&format!("Rel.left[{}]", i + 1)],
+            *want,
+            "in {values:?}"
+        );
     }
     for (i, want) in RIGHT.iter().enumerate() {
         assert_eq!(
@@ -230,7 +234,10 @@ fn a_named_field_the_build_did_not_produce_is_an_error() {
         "--output",
         out.to_str().expect("utf-8"),
     ]);
-    assert!(!ok, "a missing field must not silently drop a column:\n{text}");
+    assert!(
+        !ok,
+        "a missing field must not silently drop a column:\n{text}"
+    );
     assert!(text.contains("not_a_field"), "in:\n{text}");
 }
 

--- a/pkg/earthsci-ast-rs/tests/data_source_url_conformance.rs
+++ b/pkg/earthsci-ast-rs/tests/data_source_url_conformance.rs
@@ -28,9 +28,10 @@ fn suite_dir() -> PathBuf {
 
 fn manifest() -> Value {
     let p = suite_dir().join("manifest.json");
-    serde_json::from_str(&std::fs::read_to_string(&p).unwrap_or_else(|e| {
-        panic!("the shared pin {} must be readable: {e}", p.display())
-    }))
+    serde_json::from_str(
+        &std::fs::read_to_string(&p)
+            .unwrap_or_else(|e| panic!("the shared pin {} must be readable: {e}", p.display())),
+    )
     .expect("manifest.json is JSON")
 }
 
@@ -86,7 +87,7 @@ fn resolution_is_idempotent_so_parse_emit_parse_is_stable() {
     // resolving to the same place by accident.
     let m = manifest();
     let f = fixture(&m, "relative_catalog");
-    let first = earthsci_ast::load_path(&suite_dir().join(f["path"].as_str().expect("path")))
+    let first = earthsci_ast::load_path(suite_dir().join(f["path"].as_str().expect("path")))
         .expect("the catalog must load");
     let emitted = earthsci_ast::to_json(&first).expect("emits");
 

--- a/pkg/earthsci-ast-rs/tests/evaluable_core_gate.rs
+++ b/pkg/earthsci-ast-rs/tests/evaluable_core_gate.rs
@@ -92,9 +92,21 @@ fn every_unevaluable_core_op_ends_in_a_diagnostic_not_a_panic() {
     let cases: [(&str, RefusedBy, serde_json::Value); 9] = [
         // Stripped as a value-invention producer: the observed never reaches
         // the evaluator, and the runner reports the missing observed.
-        ("skolem", ValueInvention, json!({ "op": "skolem", "args": ["row"] })),
-        ("rank", EvaluabilityGate, json!({ "op": "rank", "args": ["row"] })),
-        ("distinct", EvaluabilityGate, json!({ "op": "distinct", "args": ["row"] })),
+        (
+            "skolem",
+            ValueInvention,
+            json!({ "op": "skolem", "args": ["row"] }),
+        ),
+        (
+            "rank",
+            EvaluabilityGate,
+            json!({ "op": "rank", "args": ["row"] }),
+        ),
+        (
+            "distinct",
+            EvaluabilityGate,
+            json!({ "op": "distinct", "args": ["row"] }),
+        ),
         // Refused by the VI materializer (an arg-witness needs one output index).
         (
             "argmin",
@@ -108,9 +120,21 @@ fn every_unevaluable_core_op_ends_in_a_diagnostic_not_a_panic() {
             json!({ "op": "argmax", "args": [], "arg": "i",
                     "ranges": { "i": [1, 3] }, "expr": "row" }),
         ),
-        ("ic", EvaluabilityGate, json!({ "op": "ic", "args": ["row"] })),
-        ("enum", EvaluabilityGate, json!({ "op": "enum", "args": ["colors", "red"] })),
-        ("table_lookup", EvaluabilityGate, json!({ "op": "table_lookup", "args": [] })),
+        (
+            "ic",
+            EvaluabilityGate,
+            json!({ "op": "ic", "args": ["row"] }),
+        ),
+        (
+            "enum",
+            EvaluabilityGate,
+            json!({ "op": "enum", "args": ["colors", "red"] }),
+        ),
+        (
+            "table_lookup",
+            EvaluabilityGate,
+            json!({ "op": "table_lookup", "args": [] }),
+        ),
         (
             "apply_expression_template",
             EvaluabilityGate,
@@ -145,7 +169,10 @@ fn every_unevaluable_core_op_ends_in_a_diagnostic_not_a_panic() {
         let results = run_pde_tests(&file, Some("M"), &SolveOptions::default());
         assert_eq!(results.len(), 1, "`{op}`: one assertion, got {results:?}");
         let r = &results[0];
-        assert!(!r.passed, "`{op}` has no evaluation rule; it must not answer");
+        assert!(
+            !r.passed,
+            "`{op}` has no evaluation rule; it must not answer"
+        );
         assert!(
             !r.message.is_empty(),
             "`{op}` must fail with a message an author can act on"

--- a/pkg/earthsci-ast-rs/tests/inline_test_build_memo.rs
+++ b/pkg/earthsci-ast-rs/tests/inline_test_build_memo.rs
@@ -23,8 +23,8 @@
 //! `rebuilds_when_*` test fails on both counts.
 
 use earthsci_ast::{
-    BuildProviderFactory, PdeAssertionResult, SolveOptions, load_string,
-    run_pde_tests_filtered, run_pde_tests_with_base_dir, run_pde_tests_with_providers,
+    BuildProviderFactory, PdeAssertionResult, SolveOptions, load_string, run_pde_tests_filtered,
+    run_pde_tests_with_base_dir, run_pde_tests_with_providers,
 };
 use serde_json::{Value, json};
 use std::cell::Cell;
@@ -157,7 +157,10 @@ fn absent_and_empty_overrides_are_one_key() {
     set["parameter_overrides"] = json!({"k": 5.0});
     let (results, builds) = run_counting(&doc(json!([none, empty, set])), None);
     assert_all_pass(&results);
-    assert_eq!(builds, 2, "absent and empty are one build; the override is another");
+    assert_eq!(
+        builds, 2,
+        "absent and empty are one build; the override is another"
+    );
 }
 
 /// `initial_conditions` — `x(1) = x0 + 1`, so a memo that ignored `u0` would
@@ -350,19 +353,20 @@ fn filter_matching_nothing_builds_nothing() {
 /// is `run_pde_tests_filtered(.., None)`.
 #[test]
 fn unfiltered_entry_point_runs_everything() {
-    let file = load_string(&doc(json!([
-        test_entry("a", 0.0, 1.0, 1.0, 1.0),
-        test_entry("b", 0.0, 1.0, 1.0, 1.0),
-    ]))
-    .to_string())
+    let file = load_string(
+        &doc(json!([
+            test_entry("a", 0.0, 1.0, 1.0, 1.0),
+            test_entry("b", 0.0, 1.0, 1.0, 1.0),
+        ]))
+        .to_string(),
+    )
     .expect("document loads");
     let builds = Cell::new(0usize);
     let make: Box<BuildProviderFactory<'_>> = Box::new(|| {
         builds.set(builds.get() + 1);
         Ok(Vec::new())
     });
-    let results =
-        run_pde_tests_with_providers(&file, None, &opts(), None::<&Path>, Some(&*make));
+    let results = run_pde_tests_with_providers(&file, None, &opts(), None::<&Path>, Some(&*make));
     assert_eq!(results.len(), 2);
     assert_eq!(builds.get(), 1);
 }

--- a/pkg/earthsci-ast-rs/tests/join_on_self_join.rs
+++ b/pkg/earthsci-ast-rs/tests/join_on_self_join.rs
@@ -276,7 +276,11 @@ fn a_bounded_lookback_is_just_another_key_column() {
 
     assert_eq!(out.len(), 9);
     assert_eq!(bits(&out), bits(&t.back_oracle()), "got {out:?}");
-    assert_eq!(&out[0..3], &[0.0, 0.0, 0.0], "the first 3 rows are unmatched");
+    assert_eq!(
+        &out[0..3],
+        &[0.0, 0.0, 0.0],
+        "the first 3 rows are unmatched"
+    );
     assert_eq!(out[3], 4.0, "row 4 reads payload[1] = 4");
     assert_eq!(out[8], 39.0, "row 9 reads payload[6] = 39");
     assert_eq!(visits, t.match_count(BACK), "6 matched pairs, 6 visits");
@@ -478,7 +482,11 @@ fn three_ranges_are_spellable_with_explicit_syms() {
     )
     .expect("explicit syms resolve a three-candidate axis");
     set_join_gate_enabled(prev);
-    let out: Vec<f64> = observed_field(&prep, "out").unwrap().iter().copied().collect();
+    let out: Vec<f64> = observed_field(&prep, "out")
+        .unwrap()
+        .iter()
+        .copied()
+        .collect();
     let want: Vec<f64> = t.prior_oracle().iter().map(|v| v * t.n as f64).collect();
     assert_eq!(out.len(), 6);
     assert_eq!(bits(&out), bits(&want), "got {out:?}, want {want:?}");
@@ -505,5 +513,8 @@ fn syms_contradicting_a_key_that_names_its_own_range_symbol_is_refused() {
     let mut d = doc(&t, "row_prior", Spelling::Syms("b", "a"));
     d["models"]["S"]["equations"][0]["rhs"]["join"][0]["on"] = json!([["a", "row_id"]]);
     let msg = build_err(&d, 5);
-    assert!(msg.contains("names a range symbol") && msg.contains("'b'"), "got {msg}");
+    assert!(
+        msg.contains("names a range symbol") && msg.contains("'b'"),
+        "got {msg}"
+    );
 }

--- a/pkg/earthsci-ast-rs/tests/lower_enums_integration.rs
+++ b/pkg/earthsci-ast-rs/tests/lower_enums_integration.rs
@@ -172,7 +172,9 @@ fn zero_and_negative_enum_members_load_and_resolve_to_themselves() {
         .get("EnumsZeroAndNegative")
         .expect("EnumsZeroAndNegative model present");
     let defs = earthsci_ast::observed_definitions(model);
-    let expr = defs.get("mode_code").expect("mode_code has a defining equation");
+    let expr = defs
+        .get("mode_code")
+        .expect("mode_code has a defining equation");
     let Expr::Operator(node) = expr else {
         panic!("mode_code expression must be an Operator node, got {expr:?}");
     };
@@ -212,7 +214,10 @@ fn zero_and_negative_enum_members_round_trip() {
     let serialized = to_json(&file).expect("save");
     let reloaded: EsmFile = load_string(&serialized).expect("reload");
     assert_eq!(file.enums, reloaded.enums);
-    let enums = reloaded.enums.as_ref().expect("enums survive the round trip");
+    let enums = reloaded
+        .enums
+        .as_ref()
+        .expect("enums survive the round trip");
     assert_eq!(enums["operating_mode"]["Braking"], 0);
     assert_eq!(enums["pol_process"]["Unassociated"], -1);
 }

--- a/pkg/earthsci-ast-rs/tests/precision_element_type.rs
+++ b/pkg/earthsci-ast-rs/tests/precision_element_type.rs
@@ -39,7 +39,7 @@
 #![cfg(not(target_arch = "wasm32"))]
 
 use earthsci_ast::precision::{self, Precision};
-use earthsci_ast::{PdeAssertionResult, load_path, run_pde_tests, SolveOptions};
+use earthsci_ast::{PdeAssertionResult, SolveOptions, load_path, run_pde_tests};
 
 fn fixture(name: &str) -> std::path::PathBuf {
     std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -176,8 +176,8 @@ fn constructs_binary32_cannot_carry_are_named() {
         ("fn", Some("datetime.julian_day")),
     ] {
         let hit = precision::f32_unsupported_reason(op, name);
-        let (construct, _) = hit
-            .unwrap_or_else(|| panic!("{op}/{name:?} must be rejected under Float32"));
+        let (construct, _) =
+            hit.unwrap_or_else(|| panic!("{op}/{name:?} must be rejected under Float32"));
         let expected = name.unwrap_or(op);
         assert!(
             construct.contains(expected),
@@ -208,7 +208,10 @@ fn an_unaddressable_index_set_is_named() {
     let err = precision::check_index_set_extent("rows", precision::F32_EXACT_INT_LIMIT + 1)
         .unwrap_err()
         .to_string();
-    assert!(err.contains("float32_unsupported") && err.contains("rows"), "{err}");
+    assert!(
+        err.contains("float32_unsupported") && err.contains("rows"),
+        "{err}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -280,8 +283,14 @@ fn mixing_element_types_under_one_operator_is_refused() {
         .collect::<Vec<_>>()
         .join("\n");
     assert!(msg.contains("mixed_element_type"), "{msg}");
-    assert!(msg.contains("quant") && msg.contains("key"), "both operands: {msg}");
-    assert!(msg.contains("Float64") && msg.contains("Float32"), "both types: {msg}");
+    assert!(
+        msg.contains("quant") && msg.contains("key"),
+        "both operands: {msg}"
+    );
+    assert!(
+        msg.contains("Float64") && msg.contains("Float32"),
+        "both types: {msg}"
+    );
 }
 
 /// A document that declares NO per-variable element type is untouched: the

--- a/pkg/earthsci-ast-rs/tests/recurrence_causal_self_reference.rs
+++ b/pkg/earthsci-ast-rs/tests/recurrence_causal_self_reference.rs
@@ -296,10 +296,7 @@ fn unguarded_self_read_at_the_first_cell_is_a_fault() {
 
 fn assert_probe_rejected_with(body: Value, code: &str, what: &str) {
     let msg = probe_message(body);
-    assert!(
-        msg.contains(code),
-        "{what}: expected `{code}`, got: {msg}"
-    );
+    assert!(msg.contains(code), "{what}: expected `{code}`, got: {msg}");
 }
 
 #[test]
@@ -537,16 +534,14 @@ fn the_shared_rejection_corpus_agrees_on_code_and_path() {
         // asserting only on a code it cannot emit has written a comment, not a
         // check.
         assert!(
-            !got
-                .iter()
+            !got.iter()
                 .any(|(c, _)| c == "load_error" || c == "circular_dependency"),
             "{id}: the recurrence diagnosis was pre-empted by a whole-document / cycle \
              error — gate the self-edge exemption on CANDIDACY, not on the \
              well-foundedness verdict (CONFORMANCE_SPEC §5.19.5); got {got:?}"
         );
         assert!(
-            got.iter()
-                .any(|(c, p)| c == want_code && p == want_path),
+            got.iter().any(|(c, p)| c == want_code && p == want_path),
             "{id}: expected ({want_code}, {want_path}); got {got:?}. \
              Why this case is illegal: {}",
             case["why"].as_str().unwrap_or("")
@@ -807,14 +802,29 @@ macro_rules! pipeline_test {
 }
 
 pipeline_test!(pipeline_doubling, "01_recurrence_doubling.esm");
-pipeline_test!(pipeline_cancellation_ladder, "02_recurrence_cancellation_ladder.esm");
+pipeline_test!(
+    pipeline_cancellation_ladder,
+    "02_recurrence_cancellation_ladder.esm"
+);
 pipeline_test!(pipeline_multi_lag, "03_recurrence_multi_lag.esm");
-pipeline_test!(pipeline_banded_lag_fold, "04_recurrence_banded_lag_fold.esm");
+pipeline_test!(
+    pipeline_banded_lag_fold,
+    "04_recurrence_banded_lag_fold.esm"
+);
 pipeline_test!(pipeline_two_axes, "05_recurrence_two_axes.esm");
 pipeline_test!(pipeline_float32_state, "06_recurrence_float32_state.esm");
-pipeline_test!(pipeline_thirty_eight_lags, "07_recurrence_thirty_eight_lags.esm");
-pipeline_test!(pipeline_parameter_valued_lag, "08_recurrence_parameter_valued_lag.esm");
-pipeline_test!(pipeline_through_expression_template, "09_recurrence_through_expression_template.esm");
+pipeline_test!(
+    pipeline_thirty_eight_lags,
+    "07_recurrence_thirty_eight_lags.esm"
+);
+pipeline_test!(
+    pipeline_parameter_valued_lag,
+    "08_recurrence_parameter_valued_lag.esm"
+);
+pipeline_test!(
+    pipeline_through_expression_template,
+    "09_recurrence_through_expression_template.esm"
+);
 
 /// The regression itself, stated as a value that must NOT come back.
 ///

--- a/pkg/earthsci-ast-rs/tests/reserved_index_symbol.rs
+++ b/pkg/earthsci-ast-rs/tests/reserved_index_symbol.rs
@@ -100,12 +100,7 @@ fn the_const_array_key_column_variant_is_rejected_too() {
 fn the_control_spelling_loads_and_answers_two() {
     let path = fixture("loop_symbol_named_k_control.esm");
     let file = load_path(&path).expect("control loads");
-    let results = run_pde_tests_with_base_dir(
-        &file,
-        None,
-        &SolveOptions::default(),
-        path.parent(),
-    );
+    let results = run_pde_tests_with_base_dir(&file, None, &SolveOptions::default(), path.parent());
     assert_eq!(results.len(), 1, "one inline assertion: {results:?}");
     let r = &results[0];
     assert!(
@@ -113,7 +108,11 @@ fn the_control_spelling_loads_and_answers_two() {
         "the control must still count the two matching pairs: actual={:?} expected={} — {}",
         r.actual, r.expected, r.message
     );
-    assert_eq!(r.actual, Some(2.0), "renaming a bound index must not change a result");
+    assert_eq!(
+        r.actual,
+        Some(2.0),
+        "renaming a bound index must not change a result"
+    );
 }
 
 /// A minimal single-aggregate document binding `sym`, optionally under a
@@ -268,11 +267,14 @@ fn binds_reserved(doc: &Value) -> bool {
                     .get("ranges")
                     .and_then(Value::as_object)
                     .is_some_and(|r| r.keys().any(|k| k == independent || k == "_var"))
-                    || obj.get("output_idx").and_then(Value::as_array).is_some_and(|a| {
-                        a.iter()
-                            .filter_map(Value::as_str)
-                            .any(|s| s == independent || s == "_var")
-                    });
+                    || obj
+                        .get("output_idx")
+                        .and_then(Value::as_array)
+                        .is_some_and(|a| {
+                            a.iter()
+                                .filter_map(Value::as_str)
+                                .any(|s| s == independent || s == "_var")
+                        });
                 binds || obj.values().any(|c| go(c, independent))
             }
             Value::Array(arr) => arr.iter().any(|c| go(c, independent)),

--- a/pkg/earthsci-ast-rs/tests/structural_validation.rs
+++ b/pkg/earthsci-ast-rs/tests/structural_validation.rs
@@ -1178,11 +1178,11 @@ fn test_f6_null_in_key_column() {
     );
 }
 
-/// The self-join SIDE rejections (CONFORMANCE_SPEC §5.5.8). Each is stated
-/// about the DOCUMENT — the node's `ranges`, the declared variable shapes and
-/// the clause are all in the one file — and each is pinned for all five
-/// bindings in `tests/invalid/expected_errors.json`, which is what the shared
-/// corpus comparator enforces. These assert the Rust half of that pin directly.
+// The self-join SIDE rejections (CONFORMANCE_SPEC §5.5.8). Each is stated
+// about the DOCUMENT — the node's `ranges`, the declared variable shapes and
+// the clause are all in the one file — and each is pinned for all five
+// bindings in `tests/invalid/expected_errors.json`, which is what the shared
+// corpus comparator enforces. These assert the Rust half of that pin directly.
 
 /// Three ranges draw one index set, so a key column over it names three
 /// candidate range symbols and the pair says nothing about which two the clause

--- a/pkg/earthsci-ast-rs/tests/subsystem_mount_join_names.rs
+++ b/pkg/earthsci-ast-rs/tests/subsystem_mount_join_names.rs
@@ -42,8 +42,7 @@ fn fixture(name: &str) -> PathBuf {
 /// the `{"ref": "./join_leaf.esm"}` mount relative to the host document.
 fn assert_inline_tests_pass(path: &Path, expected: f64) {
     let file = load_path(path).unwrap_or_else(|e| panic!("{} does not load: {e}", path.display()));
-    let results =
-        run_pde_tests_with_base_dir(&file, None, &SolveOptions::default(), path.parent());
+    let results = run_pde_tests_with_base_dir(&file, None, &SolveOptions::default(), path.parent());
     assert_eq!(
         results.len(),
         1,

--- a/pkg/earthsci-ast-ts/package-lock.json
+++ b/pkg/earthsci-ast-ts/package-lock.json
@@ -2286,9 +2286,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/pkg/earthsci-ast-ts/src/data-source-urls.test.ts
+++ b/pkg/earthsci-ast-ts/src/data-source-urls.test.ts
@@ -68,7 +68,7 @@ describe('esm-spec §8.2.1 data-source location resolution', () => {
     const f = fixture('relative_catalog')
     const first = loadPath(path.join(SUITE, f.path))
     const again = JSON.parse(toJson(first)) as object
-    for (const [name, entry] of Object.entries(first.data_sources ?? {})) {
+    for (const [, entry] of Object.entries(first.data_sources ?? {})) {
       const source = (entry as { source?: { url_template?: string } }).source
       expect(resolveSourceUrl(source?.url_template as string, '/somewhere/else')).toBe(
         source?.url_template,

--- a/pkg/earthsci-ast-ts/src/join-syms.test.ts
+++ b/pkg/earthsci-ast-ts/src/join-syms.test.ts
@@ -85,9 +85,7 @@ describe('join.syms (CONFORMANCE_SPEC §5.5.8)', () => {
 
     // Exactly two entries — a left side and a right side.
     const short = structuredClone(base)
-    short.models.SelfJoin.equations[3].rhs.join = [
-      { on: [['row_prior', 'row_id']], syms: ['a'] },
-    ]
+    short.models.SelfJoin.equations[3].rhs.join = [{ on: [['row_prior', 'row_id']], syms: ['a'] }]
     expect(validateText(JSON.stringify(short)).is_valid).toBe(false)
   })
 })

--- a/scripts/package-security-scanner.py
+++ b/scripts/package-security-scanner.py
@@ -16,8 +16,9 @@ import subprocess
 import sys
 import hashlib
 import re
+import tempfile
 from pathlib import Path
-from typing import Dict, Optional, Any
+from typing import Dict, List, Optional, Any
 from datetime import datetime
 import logging
 
@@ -285,37 +286,99 @@ class PackageVerifier:
 
     def _check_julia_dependencies(self, deps: Dict[str, str], result: Dict[str, Any]) -> None:
         """Check Julia dependencies for known vulnerabilities."""
-        # This would integrate with Julia's security advisories if available
+        # Julia has no machine-readable advisory feed to query, so the
+        # dependency set is RECORDED rather than flagged. Warning that a
+        # package has dependencies is a warning every package with
+        # dependencies always earns: it carries no signal, and it would fail
+        # every build the moment anyone passed --fail-on-warnings.
         result["checks"]["dependencies"] = "passed"
-        if deps:
-            result["warnings"].append(f"Found {len(deps)} dependencies (manual review recommended)")
+        result["dependency_count"] = len(deps)
+
+    def _declared_python_dependencies(self, package_path: str) -> List[str]:
+        """The package's own declared dependencies, runtime and optional."""
+        pyproject_path = os.path.join(package_path, "pyproject.toml")
+        if not os.path.exists(pyproject_path):
+            return []
+
+        try:
+            import toml
+
+            with open(pyproject_path, "r") as f:
+                project_info = toml.load(f).get("project", {})
+        except Exception as e:
+            logger.debug(f"Could not read dependencies from {pyproject_path}: {e}")
+            return []
+
+        dependencies = list(project_info.get("dependencies", []))
+        for extra in project_info.get("optional-dependencies", {}).values():
+            dependencies.extend(extra)
+
+        return dependencies
+
+    @staticmethod
+    def _parse_safety_json(output: str) -> Optional[Dict[str, Any]]:
+        """Pull safety's JSON report out of the output it is embedded in.
+
+        `safety check` prints a deprecation banner BEFORE the report and
+        another one after it, so its stdout is not JSON end to end and
+        json.loads on the whole of it fails -- which is why every scan warned
+        "Failed to parse safety scan results" and read no advisory at all.
+        Decode the first JSON value and let whatever follows it go.
+        """
+        start = output.find("{")
+        if start == -1:
+            return None
+
+        try:
+            report, _ = json.JSONDecoder().raw_decode(output[start:])
+        except json.JSONDecodeError:
+            return None
+
+        return report if isinstance(report, dict) else None
 
     def _run_python_safety_scan(self, package_path: str, result: Dict[str, Any]) -> None:
         """Run Python safety scan if available."""
+        # Given no target, `safety check` scans the AMBIENT environment, which
+        # on CI is the runner's own toolchain -- advisories against pip and
+        # setuptools would be reported as this package's own. Scan what the
+        # package declares instead.
+        requirements = self._declared_python_dependencies(package_path)
+        if not requirements:
+            result["warnings"].append("No declared dependencies to scan with safety")
+            return
+
+        requirements_path = ""
         try:
-            cmd = ["safety", "check", "--json", "--full-report"]
+            with tempfile.NamedTemporaryFile(
+                "w", suffix=".txt", delete=False, encoding="utf-8"
+            ) as requirements_file:
+                requirements_file.write("\n".join(requirements) + "\n")
+                requirements_path = requirements_file.name
+
+            cmd = ["safety", "check", "--json", "-r", requirements_path]
             proc = subprocess.run(cmd, cwd=package_path, capture_output=True, text=True, timeout=60)
 
             if proc.returncode == 0:
                 result["checks"]["safety_scan"] = "passed"
             else:
-                # Parse safety output for vulnerabilities
-                try:
-                    safety_data = json.loads(proc.stdout)
+                safety_data = self._parse_safety_json(proc.stdout)
+                if safety_data is None:
+                    result["warnings"].append("Failed to parse safety scan results")
+                    result["checks"]["safety_scan"] = "warning"
+                else:
                     vulnerabilities = safety_data.get("vulnerabilities", [])
                     for vuln in vulnerabilities:
                         result["vulnerabilities"].append(
                             {
                                 "package": vuln.get("package_name"),
-                                "version": vuln.get("installed_version"),
+                                "version": vuln.get("analyzed_version")
+                                or vuln.get("installed_version"),
                                 "vulnerability": vuln.get("vulnerability_id"),
-                                "severity": vuln.get("severity", "unknown"),
+                                # The free advisory feed leaves severity null.
+                                "severity": vuln.get("severity") or "unknown",
                             }
                         )
                     result["checks"]["safety_scan"] = "failed" if vulnerabilities else "passed"
-                except json.JSONDecodeError:
-                    result["warnings"].append("Failed to parse safety scan results")
-                    result["checks"]["safety_scan"] = "warning"
 
         except FileNotFoundError:
             result["warnings"].append("Python safety tool not installed")
@@ -323,6 +386,9 @@ class PackageVerifier:
             result["warnings"].append("Safety scan timed out")
         except Exception as e:
             result["warnings"].append(f"Safety scan failed: {e}")
+        finally:
+            if requirements_path and os.path.exists(requirements_path):
+                os.unlink(requirements_path)
 
     def _run_npm_audit(self, package_path: str, result: Dict[str, Any]) -> None:
         """Run npm audit if npm is available."""
@@ -397,6 +463,56 @@ class PackageVerifier:
         except Exception as e:
             result["warnings"].append(f"cargo audit failed: {e}")
 
+    # The header of a license FILE, mapped to the identifier it stands for.
+    # Ordered longest-name-first: every AGPL and LGPL text also contains the
+    # phrase the plain GPL is matched on.
+    LICENSE_FILE_MARKERS = (
+        ("GNU AFFERO GENERAL PUBLIC LICENSE", "AGPL-3.0-only"),
+        ("GNU LESSER GENERAL PUBLIC LICENSE", "LGPL-3.0"),
+        ("GNU GENERAL PUBLIC LICENSE", "GPL-3.0"),
+        ("Apache License", "Apache-2.0"),
+        ("MIT License", "MIT"),
+        ("BSD 3-Clause", "BSD-3-Clause"),
+        ("BSD 2-Clause", "BSD-2-Clause"),
+    )
+
+    def _license_from_file(self, license_path: str) -> str:
+        """Identify the license held in the file a manifest points at."""
+        try:
+            with open(license_path, "r", encoding="utf-8", errors="replace") as f:
+                header = f.read(4096)
+        except OSError as e:
+            logger.debug(f"Could not read license file {license_path}: {e}")
+            return ""
+
+        for marker, identifier in self.LICENSE_FILE_MARKERS:
+            if marker in header:
+                return identifier
+
+        return ""
+
+    def _license_allowed(self, license_text: str) -> bool:
+        """Whether a license declaration names one of the allowed licenses.
+
+        An SPDX identifier has to match OUTRIGHT: "GPL-3.0" is a substring of
+        "AGPL-3.0-only", so a containment test reads a stronger copyleft
+        license as whichever weaker one its name happens to contain. Free-form
+        license text, which only ever mentions its name in passing, still
+        matches on containment.
+        """
+        if not license_text:
+            return False
+
+        allowed = self.config["allowed_licenses"]
+        if license_text in allowed:
+            return True
+
+        is_spdx_identifier = " " not in license_text.strip()
+        if is_spdx_identifier:
+            return False
+
+        return any(a in license_text for a in allowed)
+
     def _scan_pyproject_toml(self, pyproject_path: str, result: Dict[str, Any]) -> Dict[str, Any]:
         """Scan pyproject.toml for package information and dependencies."""
         try:
@@ -412,14 +528,22 @@ class PackageVerifier:
             result["version"] = project_info.get("version", "unknown")
             result["checks"]["pyproject_structure"] = "passed"
 
-            # Check license
+            # Check license. PEP 621 spells this {text = ...} or
+            # {file = ...}; PEP 639 replaces both with a bare SPDX expression.
+            # Reading only the "text" key left the {file = ...} form -- what
+            # this package uses -- reporting an EMPTY license as disallowed.
             license_info = project_info.get("license", {})
             if isinstance(license_info, dict):
                 license_text = license_info.get("text", "")
+                license_file = license_info.get("file", "")
+                if not license_text and license_file:
+                    license_text = self._license_from_file(
+                        os.path.join(os.path.dirname(pyproject_path), license_file)
+                    )
             else:
                 license_text = str(license_info)
 
-            if any(allowed in license_text for allowed in self.config["allowed_licenses"]):
+            if self._license_allowed(license_text):
                 result["checks"]["license"] = "passed"
             else:
                 result["warnings"].append(f'License "{license_text}" not clearly in allowed list')
@@ -528,10 +652,12 @@ class PackageVerifier:
             return "error"
 
         # Check for high-severity vulnerabilities
+        # `or ""` rather than a get() default: safety records the key with a
+        # null value, so the default never fires and .lower() would raise.
         high_severity_vulns = [
             v
             for v in result["vulnerabilities"]
-            if v.get("severity", "").lower() in ["high", "critical"]
+            if str(v.get("severity") or "").lower() in ["high", "critical"]
         ]
 
         if high_severity_vulns:

--- a/scripts/package-security-scanner.py
+++ b/scripts/package-security-scanner.py
@@ -62,6 +62,11 @@ class PackageVerifier:
                 "ISC",
                 "CC0-1.0",
             ],
+            # Safety evaluates only pinned (`==`) requirements by default. Turn
+            # this on to scan a declared RANGE as well -- which reports every
+            # advisory against any version the range admits, so it speaks to
+            # the declared floor rather than to what actually gets installed.
+            "check_unpinned_requirements": False,
             "security_policies": {
                 "require_signature": True,
                 "max_vulnerability_score": 7.0,
@@ -190,9 +195,19 @@ class PackageVerifier:
             result["version"] = package_data.get("version", "unknown")
             result["checks"]["package_json"] = "passed"
 
-            # Check license
+            # Check license. Matched through the same test as every other
+            # manifest, so an SPDX identifier is not read as whichever weaker
+            # license its name contains. npm spells "the text is in a file"
+            # as `SEE LICENSE IN <file>`, which is package.json's analogue of
+            # PEP 621's {file = ...} and is resolved the same way.
             license_info = package_data.get("license", "")
-            if license_info in self.config["allowed_licenses"]:
+            if not isinstance(license_info, str):
+                license_info = ""
+            if license_info.startswith("SEE LICENSE IN "):
+                license_info = self._license_from_file(
+                    os.path.join(package_path, license_info[len("SEE LICENSE IN ") :].strip())
+                )
+            if self._license_allowed(license_info):
                 result["checks"]["license"] = "passed"
             else:
                 result["warnings"].append(f'License "{license_info}" not in allowed list')
@@ -225,9 +240,13 @@ class PackageVerifier:
             result["version"] = package_info.get("version", "unknown")
             result["checks"]["cargo_structure"] = "passed"
 
-            # Check license
+            # Check license. Same test as every other manifest; Cargo's
+            # `license-file` is its spelling of PEP 621's {file = ...}.
             license_info = package_info.get("license", "")
-            if license_info in self.config["allowed_licenses"]:
+            license_file = package_info.get("license-file", "")
+            if not license_info and license_file:
+                license_info = self._license_from_file(os.path.join(package_path, license_file))
+            if self._license_allowed(license_info):
                 result["checks"]["license"] = "passed"
             else:
                 result["warnings"].append(f'License "{license_info}" not in allowed list')
@@ -345,6 +364,7 @@ class PackageVerifier:
         requirements = self._declared_python_dependencies(package_path)
         if not requirements:
             result["warnings"].append("No declared dependencies to scan with safety")
+            result["checks"]["safety_scan"] = "warning"
             return
 
         requirements_path = ""
@@ -356,39 +376,128 @@ class PackageVerifier:
                 requirements_path = requirements_file.name
 
             cmd = ["safety", "check", "--json", "-r", requirements_path]
+            # Safety evaluates only PINNED (`==`) requirements unless told
+            # otherwise, and a range is then reported against every version it
+            # admits -- so `numpy>=1.20` earns every numpy advisory since
+            # 1.20, which is a statement about the declared FLOOR rather than
+            # about what the package installs. Off by default for that reason;
+            # `check_unpinned_requirements` in the config turns it on.
+            if self.config.get("check_unpinned_requirements"):
+                cmd.append("--check-unpinned-requirements")
             proc = subprocess.run(cmd, cwd=package_path, capture_output=True, text=True, timeout=60)
 
-            if proc.returncode == 0:
-                result["checks"]["safety_scan"] = "passed"
-            else:
-                safety_data = self._parse_safety_json(proc.stdout)
-                if safety_data is None:
+            # Parse on EVERY exit code, not just a non-zero one. Exit 0 does
+            # not mean "nothing is wrong", it means "nothing was reported" --
+            # and safety exits 0 after evaluating no requirement at all,
+            # recording that fact in the report it prints and nowhere else.
+            safety_data = self._parse_safety_json(proc.stdout)
+            if safety_data is None:
+                if proc.returncode == 0:
+                    # Nothing to read, but nothing was flagged either.
+                    result["checks"]["safety_scan"] = "passed"
+                else:
                     result["warnings"].append("Failed to parse safety scan results")
                     result["checks"]["safety_scan"] = "warning"
-                else:
-                    vulnerabilities = safety_data.get("vulnerabilities", [])
-                    for vuln in vulnerabilities:
-                        result["vulnerabilities"].append(
-                            {
-                                "package": vuln.get("package_name"),
-                                "version": vuln.get("analyzed_version")
-                                or vuln.get("installed_version"),
-                                "vulnerability": vuln.get("vulnerability_id"),
-                                # The free advisory feed leaves severity null.
-                                "severity": vuln.get("severity") or "unknown",
-                            }
-                        )
-                    result["checks"]["safety_scan"] = "failed" if vulnerabilities else "passed"
+                return
+
+            vulnerabilities = safety_data.get("vulnerabilities", [])
+            for vuln in vulnerabilities:
+                result["vulnerabilities"].append(
+                    {
+                        "package": vuln.get("package_name"),
+                        # A range scan analyzes no single version; name the
+                        # vulnerable range instead of reporting a null.
+                        "version": vuln.get("analyzed_version")
+                        or vuln.get("installed_version")
+                        or ", ".join(vuln.get("vulnerable_spec") or [])
+                        or "unknown",
+                        "vulnerability": vuln.get("vulnerability_id"),
+                        # The free advisory feed leaves severity null.
+                        "severity": vuln.get("severity") or "unknown",
+                    }
+                )
+
+            covered = self._record_safety_coverage(
+                safety_data,
+                requirements,
+                bool(self.config.get("check_unpinned_requirements")),
+                result,
+            )
+            if vulnerabilities:
+                result["checks"]["safety_scan"] = "failed"
+            else:
+                # No advisory AND nothing evaluated is not a clean bill of
+                # health; only the first of those two earns a pass.
+                result["checks"]["safety_scan"] = "passed" if covered else "warning"
 
         except FileNotFoundError:
             result["warnings"].append("Python safety tool not installed")
+            result["checks"]["safety_scan"] = "warning"
         except subprocess.TimeoutExpired:
             result["warnings"].append("Safety scan timed out")
+            result["checks"]["safety_scan"] = "warning"
         except Exception as e:
             result["warnings"].append(f"Safety scan failed: {e}")
+            result["checks"]["safety_scan"] = "warning"
         finally:
             if requirements_path and os.path.exists(requirements_path):
                 os.unlink(requirements_path)
+
+    @staticmethod
+    def _record_safety_coverage(
+        safety_data: Dict[str, Any],
+        requirements: List[str],
+        check_unpinned: bool,
+        result: Dict[str, Any],
+    ) -> bool:
+        """Record how much of the declared dependency set safety evaluated.
+
+        Returns whether the scan evaluated anything at all.
+
+        A scan that evaluates NOTHING exits 0 and reports no vulnerability,
+        which in the summary is indistinguishable from a clean bill of health.
+        It is not one: every dependency of this package is declared as a
+        RANGE, and safety skips unpinned requirements unless asked not to. So
+        the counts are recorded and an empty scan is called out in its own
+        right, rather than being left to read as a passing one.
+
+        `scanned_packages` is what safety parsed out of the file, which
+        includes the requirements it then declined to evaluate -- pinning is
+        what separates the two, so that is what is counted here.
+        """
+        read = list(safety_data.get("scanned_packages") or {})
+        # `==` has to be looked for in the VERSION SPECIFIER, not in the
+        # environment marker that may follow it: `foo; python_version == "3.9"`
+        # is an unpinned requirement whose marker is an equality test.
+        pinned = sum("==" in r.split(";", 1)[0] for r in requirements)
+        evaluated = len(read) if check_unpinned else pinned
+        result["safety_coverage"] = {
+            "declared": len(requirements),
+            "read": len(read),
+            "evaluated": evaluated,
+        }
+
+        reported_unpinned = bool(requirements) and not evaluated
+        if reported_unpinned:
+            result["warnings"].append(
+                f"safety evaluated 0 of {len(requirements)} declared dependencies "
+                f'(all unpinned); set "check_unpinned_requirements": true in the '
+                f"security config to scan declared ranges instead"
+            )
+
+        # Safety states an unevaluated requirement in `announcements` and
+        # nowhere else -- not in its exit code, and not in `vulnerabilities`.
+        for announcement in safety_data.get("announcements") or []:
+            if announcement.get("type") not in ("warning", "error"):
+                continue
+            message = " ".join(str(announcement.get("message", "")).split())
+            # The unpinned notice is the one the warning above already makes,
+            # in this project's own terms; anything else safety announces is
+            # news and is relayed as it stands.
+            if message and not (reported_unpinned and "unpinned" in message.lower()):
+                result["warnings"].append(f"safety: {message}")
+
+        return bool(evaluated) or not requirements
 
     def _run_npm_audit(self, package_path: str, result: Dict[str, Any]) -> None:
         """Run npm audit if npm is available."""
@@ -491,27 +600,53 @@ class PackageVerifier:
 
         return ""
 
+    # An SPDX expression joins identifiers with these operators, optionally
+    # parenthesized: `MIT OR Apache-2.0`, `(MIT AND BSD-3-Clause)`. Splitting on
+    # them leaves the bare identifiers.
+    SPDX_OPERATORS = re.compile(r"\s+(?:OR|AND)\s+|[()]")
+    # `<license> WITH <exception>` qualifies the license on the LEFT; the
+    # exception is not itself a license and is not in any allowed list.
+    SPDX_EXCEPTION = re.compile(r"\s+WITH\s+\S+")
+
     def _license_allowed(self, license_text: str) -> bool:
-        """Whether a license declaration names one of the allowed licenses.
+        """Whether a license declaration names only allowed licenses.
 
         An SPDX identifier has to match OUTRIGHT: "GPL-3.0" is a substring of
         "AGPL-3.0-only", so a containment test reads a stronger copyleft
-        license as whichever weaker one its name happens to contain. Free-form
-        license text, which only ever mentions its name in passing, still
-        matches on containment.
+        license as whichever weaker one its name happens to contain. The same
+        hazard sits inside a compound EXPRESSION, where the identifiers are
+        joined by OR/AND rather than standing alone, so an expression is split
+        into its identifiers and every one of them is matched outright rather
+        than the whole string being searched. A disjunction is judged on its strictest
+        branch: a dual license is allowed only if BOTH halves are, which
+        warns on `MIT OR Proprietary` rather than reading the MIT and
+        stopping. Free-form license TEXT, which only ever mentions its name in
+        passing, is the one thing still matched on containment.
         """
         if not license_text:
             return False
 
         allowed = self.config["allowed_licenses"]
-        if license_text in allowed:
+        text = license_text.strip()
+        if text in allowed:
             return True
 
-        is_spdx_identifier = " " not in license_text.strip()
-        if is_spdx_identifier:
-            return False
+        # `GPL-3.0+` is SPDX's deprecated spelling of `GPL-3.0-or-later`; an
+        # allowed list naming either spelling should accept it.
+        def identifier_allowed(ident: str) -> bool:
+            return ident in allowed or (ident.endswith("+") and ident[:-1] in allowed)
 
-        return any(a in license_text for a in allowed)
+        parts = [
+            p.strip()
+            for p in self.SPDX_OPERATORS.split(self.SPDX_EXCEPTION.sub("", text))
+            if p.strip()
+        ]
+        # Every part being a bare identifier is what makes this an expression
+        # rather than prose; prose splits into fragments that contain spaces.
+        if parts and all(" " not in p for p in parts):
+            return all(identifier_allowed(p) for p in parts)
+
+        return any(a in text for a in allowed)
 
     def _scan_pyproject_toml(self, pyproject_path: str, result: Dict[str, Any]) -> Dict[str, Any]:
         """Scan pyproject.toml for package information and dependencies."""

--- a/scripts/run-property-corpus-conformance.py
+++ b/scripts/run-property-corpus-conformance.py
@@ -248,6 +248,7 @@ def compare(outputs: Dict[str, Dict[str, dict]]) -> List[dict]:
                     "ok": False,
                     "error": entry.get("error", "unknown"),
                 }
+
         # TWO SIGNALS, DELIBERATELY NOT MERGED. `diverged` keeps its exact
         # pre-SOURCE meaning — THE BINDINGS DISAGREE WITH EACH OTHER — because
         # folding the source into it would silently change what
@@ -428,8 +429,10 @@ def main() -> int:
                 if n != SOURCE_PARTICIPANT and r["ok"]
             )
             print(f"  {entry['fixture']}", file=sys.stderr)
-            print(f"    SOURCE   {entry['bindings'][SOURCE_PARTICIPANT]['canonical']}",
-                  file=sys.stderr)
+            print(
+                f"    SOURCE   {entry['bindings'][SOURCE_PARTICIPANT]['canonical']}",
+                file=sys.stderr,
+            )
             print(f"    bindings {got}", file=sys.stderr)
 
     if args.require_divergence and summary["diverged_count"] == 0:


### PR DESCRIPTION
## Summary

This PR significantly improves the package security scanner (`scripts/package-security-scanner.py`) with better license file handling, enhanced Python dependency scanning, and improved safety report parsing. It also includes code formatting improvements across the Rust codebase and updates to CI/CD workflows.

## Key Changes

### Security Scanner Enhancements
- **License file resolution**: Added support for reading licenses from files referenced in package manifests:
  - npm: `SEE LICENSE IN <file>` syntax in `package.json`
  - Rust: `license-file` field in `Cargo.toml`
  - Implemented `_license_from_file()` method with marker-based license identification (GPL, AGPL, LGPL, Apache, MIT, BSD variants)
  - Added `_license_allowed()` helper for consistent license checking across all package types

- **Python dependency scanning improvements**:
  - Added `_declared_python_dependencies()` to extract runtime and optional dependencies from `pyproject.toml`
  - Fixed safety scan to target declared dependencies instead of ambient environment (prevents false positives from CI toolchain)
  - Implemented `_parse_safety_json()` to correctly extract JSON reports from safety's mixed stdout (handles deprecation banners)
  - Added `_record_safety_coverage()` to track which dependencies were evaluated and warn when unpinned requirements are skipped
  - Added `check_unpinned_requirements` config option to optionally scan dependency ranges

- **Julia dependency handling**: Changed from warning on every dependency to recording dependency count, reducing noise in CI

- **Configuration updates**:
  - Added AGPL-3.0 variants to allowed licenses in `.security-config.json`
  - Added `check_unpinned_requirements` config option (defaults to false)

### CI/CD Workflow Updates
- Updated `.github/workflows/security-scan.yml`:
  - Added `pull-requests: write` permission for posting scan results on PRs
  - Improved error handling to capture scanner exit code before writing outputs
  - Enhanced comments explaining permission requirements

### Code Formatting
- Reformatted Rust code across multiple files for consistency:
  - `pkg/earthsci-ast-rs/src/simulate_array/eval.rs`: Improved line wrapping
  - `pkg/earthsci-ast-rs/src/simulate_array/tape/exec/fused.rs`: Fixed macro indentation
  - `pkg/earthsci-ast-rs/tests/`: Reformatted test arrays and assertions for readability
  - `pkg/earthsci-ast-rs/src/bin/esm.rs`: Reorganized imports and added type alias for clarity
  - Various other files: Improved formatting consistency

### Minor Improvements
- Added `tempfile` import for temporary requirements file handling
- Added `List` type import for type hints
- Improved docstrings with detailed explanations of safety scan behavior
- Added `#[allow(clippy::too_many_arguments)]` where appropriate with justification

## Implementation Details

The security scanner now properly handles:
1. **License file references** by reading file headers and matching against known license markers
2. **SPDX expressions** by splitting on operators (OR, AND) to extract individual identifiers
3. **Safety report parsing** by using `JSONDecoder.raw_decode()` to extract JSON from mixed output
4. **Dependency coverage tracking** to distinguish between "no vulnerabilities found" and "nothing was evaluated"

The changes maintain backward compatibility while significantly improving accuracy of security scans for Python packages and license compliance checking across all supported package types.

https://claude.ai/code/session_01KVb9dbL1KF4AvoSdxkg3gj