### PR TITLE
fix(ci): let conformance-results comment on the PR it reports for

### DIFF
--- a/.github/workflows/conformance-testing.yml
+++ b/.github/workflows/conformance-testing.yml
@@ -633,6 +633,16 @@ jobs:
     timeout-minutes: 10
     needs: [standard-conformance-testing]
     if: always()
+    # This is the only job that writes to the PR. The workflow-level default
+    # is `contents: read`, under which the comment step below 403s on every
+    # pull request ("Resource not accessible by integration"), failing the job
+    # whatever the conformance outcome. Granted here rather than workflow-wide
+    # so the ~20 test jobs keep the read-only token. A job-level block replaces
+    # the workflow-level one outright, so `contents: read` is restated for
+    # `actions/checkout`.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -710,14 +720,14 @@ jobs:
 
                 comment += `\n📊 [View detailed conformance report](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
 
-                github.rest.issues.createComment({
+                await github.rest.issues.createComment({
                   issue_number: context.issue.number,
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   body: comment
                 });
               } else {
-                github.rest.issues.createComment({
+                await github.rest.issues.createComment({
                   issue_number: context.issue.number,
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -725,13 +735,20 @@ jobs:
                 });
               }
             } catch (error) {
+              // Reporting the result must not decide the result. A fork PR
+              // still carries a read-only token no `permissions:` block can
+              // widen, so this path stays reachable by design.
               console.error('Error posting conformance results:', error);
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: `❌ Error processing conformance test results: ${error.message}`
-              });
+              try {
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: `❌ Error processing conformance test results: ${error.message}`
+                });
+              } catch (postError) {
+                console.error('Could not post the failure comment either:', postError);
+              }
             }
 
       # Final status check


### PR DESCRIPTION
## The failure

`conformance-results` fails on **every** pull request, whatever the conformance outcome:

```
POST /repos/EarthSciML/EarthSciAST/issues/<n>/comments
403 Resource not accessible by integration
x-accepted-github-permissions: issues=write; pull_requests=write
```

`.github/workflows/conformance-testing.yml` declares:

```yaml
permissions:
  contents: read
```

and nothing else, so `GITHUB_TOKEN` cannot post the results comment that the job exists to post. Because the job is `if: always()`, it runs — and fails — even when the conformance run was cancelled or skipped, which is how an unrelated cancellation turns into a red check.

Observed on #202 ([job log](https://github.com/EarthSciML/EarthSciAST/actions/runs/34039834374/job/101506864910)); #184 reports the same 403 on the same job, so this is not specific to either branch.

## The fix

**1. A job-level `permissions` block granting `pull-requests: write`.**

Scoped to this job rather than the workflow because it is the only one that writes to the PR — the ~20 test jobs keep the read-only token. A job-level block *replaces* the workflow-level one outright, so `contents: read` is restated for `actions/checkout`.

`issues: write` would also satisfy the API (PR comments are issue comments), but the step is gated on `github.event_name == 'pull_request'`, so `pull-requests: write` is the narrower grant that covers it.

**2. `await` on the three `createComment` calls.**

They were fire-and-forget. A rejected request escaped the enclosing `try`/`catch` as an unhandled promise rejection and killed the job outright — which is why the 403 surfaced as `##[error]Unhandled error: HttpError` rather than being logged and swallowed. The catch-path comment is now itself wrapped, so a failure to *report* a failure cannot decide the job's result.

That path stays reachable by design rather than being dead code: a pull request **from a fork** carries a read-only token that no `permissions:` block can widen, so commenting will still 403 there. After this change that degrades to a log line instead of a red check.

Please drop the second change if you'd rather keep the diff to the permission grant alone — it is a separate commit-worthy concern that happens to live in the same step.

## Consistency

`security-scan.yml` already carries `issues: write` + `pull-requests: write`, and its PR comments post fine. This brings the conformance workflow in line with it. The other read-only workflows (`docs.yml`, `schema-sync-check.yml`) post no comments and need no grant — I checked each workflow's `permissions` block against whether it calls `createComment`.

## Verification

Workflow changes cannot be exercised locally, so I verified what can be:

- The workflow parses as YAML, with `jobs.conformance-results.permissions == {contents: read, pull-requests: write}` and the workflow-level default still `{contents: read}`.
- The inline `github-script` body extracts and passes `node --check`.

The real test is the next PR run, where `conformance-results` should post its comment instead of 403ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgVneGRbaX4guxxUpJx5Kp


---
_Generated by [Claude Code](https://claude.ai/code/session_01TgVneGRbaX4guxxUpJx5Kp)_