### PR TITLE
fix(rust): drop the duplicated ReactionSystem fields that break every rust-tests job

### DIFF
--- a/pkg/earthsci-ast-rs/tests/performance.rs
+++ b/pkg/earthsci-ast-rs/tests/performance.rs
@@ -600,9 +600,6 @@ fn test_parallel_stoichiometric_matrix_computation() {
         constraint_equations: None,
         discrete_events: None,
         continuous_events: None,
-        tolerance: None,
-        tests: None,
-        analyses: None,
     };
 
     let matrix = evaluator


### PR DESCRIPTION
`tests/performance.rs` constructs one `ReactionSystem` literal that specifies `tolerance`, `tests` and `analyses` **twice each** — `E0062: field specified more than once`, a hard compile error. Two commits each added the same `None` block to that literal and a merge kept both copies.

## Why this is worth its own PR

The Rust test target fails to build on `main` and on every branch cut from it. That cascades through `.github/workflows/conformance-testing.yml`:

- `standard-conformance-testing` has `needs: [julia-tests, typescript-tests, python-tests, rust-tests, go-tests]` → **skipped**
- `conformance-results` has `needs: [standard-conformance-testing]` → **fails** on a missing artifact

So a duplicate struct field surfaces as three red `rust-tests` jobs plus what looks like a conformance regression. It is currently the only remaining red on #204, #199 and #197.

## The change

Both copies are `None`, so removing the second is semantics-preserving. The retained block keeps declaration order.

## Verification

`cargo check --test performance --all-features` → 0 errors.

Found while reviewing the open PR queue. #201 and #202 each fixed this independently on their own branches; landing it here lets both drop their copy.