### PR TITLE
fix(julia)!: a species in no reaction gets no equation, not D(X,t) = 0

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -58,6 +58,7 @@ green and your program does something different. Audit these first.
 | Go | `Substitute` | Single-pass, no longer transitive. `Substitute("a", {a: b, b: c})` returns `"b"`, not `"c"`. | Chained renames that were silently mis-applied now apply correctly. Goldens change. |
 | Julia, Python, Rust | `solve` default tolerances | `reltol = 1e-4`, `abstol = 1e-6` everywhere — **looser** than Rust's and Python's old defaults. | Trajectory assertions fail. |
 | Julia, Python, Rust | a failed **build** | Raises instead of returning a failed result. | Code inspecting `result.success` for build failures never sees it; the exception propagates. |
+| Julia | `derive_odes` / `flatten` on a reaction system | A species whose net stoichiometry is zero in every reaction gets **no equation**, where Julia used to emit `D(X, t) = 0`. The other four bindings already omitted it. | `equations`, `equation_count` and equation ORDER change; a `couple` `additive` edge onto such a species now BECOMES its tendency instead of summing onto a zero. Simulation results do not change — see the Julia section below. |
 | Python | `UnitWarning.path` | Was the string `"unit_validation"` at every site; is now `""` (the document root). | A consumer matching on that literal stops matching. |
 | Python | index-set merge | A model-nested `index_sets` now **merges over** the document-scoped registry instead of being invisible to it. | Different resolution verdicts on pre-0.8.0-shaped documents. |
 | Julia | diagnostic pointers | A scalar `update: {...}` no longer reports a synthetic `/0` segment. | A consumer matching on diagnostic JSON Pointers sees a different path. |
@@ -256,6 +257,36 @@ loaded from a stream therefore kept its subsystem refs as unresolved
 `SubsystemRef`s — and `flatten` **silently skips** an unresolved `SubsystemRef`.
 Same bytes, strictly smaller system, no error. All three entry points now share
 one pipeline; the successor of `load(::IO)` is `load_string(::IO)`.
+
+### A species in no reaction gets no equation (bug fix, silent)
+
+`derive_odes` and `flatten` emitted `D(X, t) = 0` for a species whose net
+stoichiometry is zero in every reaction — the empty sum. Python, Rust, Go and
+TypeScript all omit the equation, so Julia was the 4–1 outlier; the rule is now
+written down as **esm-libraries-spec §4.6.1** and Julia follows it.
+
+Nothing raises. What changes is the **shape of the flattened system**:
+
+| | Before | After |
+|---|---|---|
+| `equations` | carries `D(X, t) = 0` | no entry for `X` |
+| `equation_count` | counts the inert species | does not |
+| equation ORDER | an inert species that a later operator also touches kept the reaction system's position | it takes the operator's position instead |
+| `X` in `state_variables` | yes, DIFFERENTIAL | yes, but in `algebraic_variables` too |
+| a `couple` `additive` edge onto `X` | summed onto the zero (`D(X) = 0 + expr`) | **becomes** the tendency (`D(X) = expr`, §4.7.2) |
+| a `couple` `multiplicative` edge onto `X` | multiplied the zero | raises `couple_multiplicative_no_tendency` — there is no tendency to multiply |
+
+If you pin equation strings, counts, or order, expect those pins to move —
+toward the shared `tests/conformance/flatten` corpus, which the other four
+bindings already matched.
+
+**Simulation is unchanged.** `ModelingToolkit.System(flat)` closes a state that
+no equation mentions with `D(X, t) ~ 0` at the lowering (see
+`ext/mtk_ext/systems.jl`), so such a species stays in `unknowns`, still binds an
+initial condition, and is still held at its initial value in the solution —
+the same trajectory as before, and the same one Python's SciPy backend
+produces. The zero is a backend closure only; it is never written into
+`flat.equations`.
 
 ## TypeScript — `@earthsciml/ast`
 

--- a/esm-libraries-spec.md
+++ b/esm-libraries-spec.md
@@ -675,8 +675,11 @@ distinction matters because §4.7.5 step 1 defers to this section:
    equation TARGET only — it stays a mass-action factor in every rate law that references it, and
    it lowers to a parameter carrying its declared `default`.
 
-2. A species that appears in **no reaction**, so its net stoichiometry is zero in every column of
-   the stoichiometric matrix. Its sum is empty, and a library MUST NOT emit `D(X, t) = 0` for it.
+2. A species whose net stoichiometry is **zero in every column** of the stoichiometric matrix. Its
+   sum is empty, and a library MUST NOT emit `D(X, t) = 0` for it. The usual way to be such a
+   species is to appear in no reaction at all, but the test is on the NET column and a catalyst —
+   one that appears with equal substrate and product stoichiometry in every reaction it takes part
+   in — meets it too, and is skipped for the same reason.
 
 The second is the one worth arguing, because the empty sum really is zero and emitting it is
 defensible arithmetic. What settles it is that the two readings give the species **different
@@ -697,6 +700,17 @@ incomparable across documents that model the same chemistry.
 — §4.7.1 step 5 preserves an operator's unmatched equation, so a `_var` transport operator gives an
 inert species a transport-only tendency and it is differential after all. The point is that
 `derive_odes` does not decide that; the flattened system does, from what actually names `X`.
+
+**And where nothing does name it, the BACKEND has to say what "solved for" means.** §4.7.1 is
+blunt that an unknown with no constraint is a structurally singular system, and §4.7.5's field
+table is equally clear that `X` is still in `state_variables` — it is part of the solved-for
+vector either way. Those are reconciled at the lowering, not in the document: a simulation
+backend MUST keep such a state in its solution and MUST NOT silently drop it, and holding it at
+its initial value (an implicit `D(X, t) = 0` introduced by the backend, never written back into
+the flattened equation list) is what the Julia and Python reference bindings both do. A backend
+that instead REFUSES the system is also conforming — what it may not do is return a solution the
+state is missing from, because a caller that seeded `X` through `initial_conditions` then gets no
+error and no `X`.
 
 > **Note (was a cross-binding divergence).** Julia emitted `D(X, t) = 0` here while Python, Rust,
 > Go and TypeScript omitted the equation — a 4-1 split, recorded in the Julia binding's

--- a/esm-libraries-spec.md
+++ b/esm-libraries-spec.md
@@ -665,6 +665,45 @@ Beyond expression-level substitution, libraries must support model-level editing
 - `derive_odes(reaction_system) → Model` — generate the ODE model from a reaction system's stoichiometry and rate laws.
 - `stoichiometric_matrix(reaction_system) → Matrix` — compute the net stoichiometric matrix.
 
+#### 4.6.1 Which species `derive_odes` emits an equation for (normative)
+
+`derive_odes` emits `D(X, t) = Σⱼ stoichᵢⱼ · rateⱼ` for each species `X`, in the order the
+reaction system declares its species. **Two kinds of species get no equation at all**, and the
+distinction matters because §4.7.5 step 1 defers to this section:
+
+1. A **reservoir** species (`constant: true`, esm-spec §7.4) is held fixed. It is skipped as an
+   equation TARGET only — it stays a mass-action factor in every rate law that references it, and
+   it lowers to a parameter carrying its declared `default`.
+
+2. A species that appears in **no reaction**, so its net stoichiometry is zero in every column of
+   the stoichiometric matrix. Its sum is empty, and a library MUST NOT emit `D(X, t) = 0` for it.
+
+The second is the one worth arguing, because the empty sum really is zero and emitting it is
+defensible arithmetic. What settles it is that the two readings give the species **different
+roles**, and esm-spec §6.3.1 classifies by COMPLEMENT:
+
+- *With* the zero equation, `X` is a DIFFERENTIAL unknown — a state the solver advances, whose
+  derivative happens to be zero. It joins the `u` vector and is integrated.
+- *Without* it, `X` is an unknown that no equation names, which is exactly §6.3.1's ALGEBRAIC
+  category.
+
+The second is what the species IS. A declared species that no reaction touches is not a quantity
+whose dynamics are known to be trivial; it is a quantity the reaction network says nothing about,
+and §6.3.1 has a category for precisely that. Emitting the zero also makes `equation_count`
+depend on how many inert species a document happens to declare, which makes the count
+incomparable across documents that model the same chemistry.
+
+**This does not leave `X` unconstrained in every case.** A later coupling rule may still define it
+— §4.7.1 step 5 preserves an operator's unmatched equation, so a `_var` transport operator gives an
+inert species a transport-only tendency and it is differential after all. The point is that
+`derive_odes` does not decide that; the flattened system does, from what actually names `X`.
+
+> **Note (was a cross-binding divergence).** Julia emitted `D(X, t) = 0` here while Python, Rust,
+> Go and TypeScript omitted the equation — a 4-1 split, recorded in the Julia binding's
+> `_FC_DIVERGENCES` ledger against `tests/valid/full_coupled.esm`, whose `AtmosphericChemistry.OH`
+> is declared and touched by no reaction. This clause is the ruling that closed it, in favour of
+> the four.
+
 ### 4.7 Coupling Resolution
 
 Libraries at **all tiers** (including Core) must implement coupling resolution as a **flattening** operation: transforming a set of coupled component systems into a single flat equation system with dot-namespaced variables. This flattened representation is the canonical intermediate form — it is the output of coupling resolution and the input to simulation backends, graph construction, and validation.
@@ -1021,7 +1060,7 @@ TypeScript `camelCase`, others verbatim).
 | Field | Type | Contents |
 |---|---|---|
 | `independent_variables` | list of name | Computed by the §4.7.6 algorithm: `["t"]` for a 0D system, `["t", <spatial axes>]` for a PDE. This is what selects `ODESystem` vs `PDESystem` downstream. NOT always `["t"]`. |
-| `state_variables` | ordered map name → variable | The **solved-for vector**: every unknown the solver advances or solves for. Differential unknowns (under `D(·,t)`, including every reaction-system species, which gets a derived `D` equation at step 1), PLUS `algebraic_variables`, PLUS any arrayed observed that materializes into a buffer. NOT the same set as esm-spec §6.3.1's `ode_states`. |
+| `state_variables` | ordered map name → variable | The **solved-for vector**: every unknown the solver advances or solves for. Differential unknowns (under `D(·,t)`, including each reaction-system species that step 1 derives a `D` equation for — which is not all of them: see §4.6.1 for the reservoir and no-reaction exceptions), PLUS `algebraic_variables`, PLUS any arrayed observed that materializes into a buffer. NOT the same set as esm-spec §6.3.1's `ode_states`. A species §4.6.1 emits no equation for is still IN this map — it is solved for either way; what changes is which half it lands in. |
 | `parameters` | ordered map name → variable | **ALL** parameters of every cadence, minus any promoted to variables by `variable_map`. |
 | `observed_variables` | ordered map name → variable | Unknowns DEFINED by an equation, bare-LHS or indexed-LHS (esm-spec §6.3.1). A scalar observed is eliminated by substitution and is NOT in `state_variables`; an arrayed observed materializes into a buffer and IS. |
 | `algebraic_variables` | ordered map name → variable | Unknowns CONSTRAINED only by an expression-LHS equation (esm-spec §6.3.1). A **subset** of `state_variables` — a DAE solves for them. |

--- a/pkg/EarthSciAST.jl/ext/mtk_ext/systems.jl
+++ b/pkg/EarthSciAST.jl/ext/mtk_ext/systems.jl
@@ -84,6 +84,51 @@ function _apply_ic_defaults!(var_dict::Dict{String,Any}, states,
     return nothing
 end
 
+# ---- Close a state that NO equation mentions ----
+# esm-libraries-spec §4.6.1 says a species touched by no reaction gets no
+# `D(X, t)` equation: the flattened document leaves it an unknown that no
+# equation names, which esm-spec §6.3.1 classifies ALGEBRAIC. That is a
+# statement about the DOCUMENT. It is not a solver plan — §4.7.1 spells out
+# that an unknown with no constraint is a structurally singular system — and
+# `state_variables` still carries the species, because §4.7.5's field table
+# says it is solved for either way.
+#
+# So the BACKEND has to say what "solved for" means for it, and MTK's answer
+# by default is to say nothing: `mtkcompile` drops an unknown that appears in
+# no equation, so the state vanishes from `unknowns(simp)`, an
+# `initial_conditions` entry naming it cannot bind, and it is missing from
+# every solution the caller reads back. Emit `D(X, t) ~ 0` for it instead —
+# the species is held at its initial value, which is what a quantity the
+# network says nothing about does, and what Python's SciPy backend already
+# does for the same document (it keeps such a state in the vector at its u0).
+# The zero lives HERE, at the lowering, and is never written into
+# `flat.equations`, so the cross-binding flattened artifact is untouched.
+#
+# Only a state that appears NOWHERE is closed. An inert species that some
+# other equation still names is another rule's business and is left alone —
+# an operator's preserved `_var` clone (§4.7.1 step 5) names one, which is the
+# shape `tests/valid/full_coupled.esm` has. Array-shaped states are skipped: a
+# scalar `D(arr) ~ 0` is not the right closure for a buffer, and no path
+# produces an unmentioned one. This is the ODE constructor only; `PDESystem`
+# takes its initial values as explicit boundary conditions and is untouched.
+function _closures_for_unmentioned_states(flat::FlattenedSystem,
+                                          dyn_equations::Vector{Equation},
+                                          var_dict::Dict{String,Any})
+    mentioned = Set{String}()
+    for eq in dyn_equations
+        union!(mentioned, free_variables(eq.lhs))
+        union!(mentioned, free_variables(eq.rhs))
+    end
+    closures = Equation[]
+    for vname in keys(flat.state_variables)
+        vname in mentioned && continue
+        get(var_dict, vname, nothing) isa Num || continue   # scalars only
+        push!(closures,
+              Equation(OpExpr("D", EsmExpr[VarExpr(vname)], wrt="t"), NumExpr(0.0)))
+    end
+    return closures
+end
+
 """
     ModelingToolkit.System(flat::FlattenedSystem; name=:anonymous, kwargs...)
 
@@ -111,6 +156,10 @@ function ModelingToolkit.System(flat::FlattenedSystem;
 
     ic_values, dyn_equations = _split_ic_equations(flat, var_dict, t_sym, dim_dict)
     _apply_ic_defaults!(var_dict, states, ic_values)
+    # After the `ic` split, so a state whose only appearance is an initial
+    # value still counts as unmentioned and gets its closure (see above).
+    append!(dyn_equations,
+            _closures_for_unmentioned_states(flat, dyn_equations, var_dict))
 
     MTKEquation = ModelingToolkit.Equation
     eqs = Vector{MTKEquation}()

--- a/pkg/EarthSciAST.jl/src/flatten.jl
+++ b/pkg/EarthSciAST.jl/src/flatten.jl
@@ -355,6 +355,12 @@ A species with `constant: true` is a RESERVOIR (§7.4): it is held fixed, so no
 concentration to every rate law it appears in. It is therefore skipped as an
 equation TARGET only — it stays in `species` so `mass_action_rate` keeps
 reading it as a substrate/product factor.
+
+A species that appears in NO reaction likewise gets no equation. Its rate is the
+empty sum, and emitting `D(X, t) = 0` for it would make it a differential unknown
+that never moves; esm-spec §6.3.1 classifies by COMPLEMENT, so leaving the
+equation out is what makes it the ALGEBRAIC unknown it is. See the comment at the
+skip below.
 """
 function lower_reactions_to_equations(reactions::Vector{Reaction},
                                       species::Vector{Species})::Vector{Equation}
@@ -383,7 +389,6 @@ function lower_reactions_to_equations(reactions::Vector{Reaction},
         # mass-action contribution to the OTHER species' rates is untouched —
         # `mass_action_rate` reads it from `species` either way.
         species[i].constant === true && continue
-        lhs = OpExpr("D", ASTExpr[VarExpr(name)], wrt="t")
         terms = ASTExpr[]
         for (j, rxn) in enumerate(reactions)
             stoich = S[i, j]
@@ -398,13 +403,21 @@ function lower_reactions_to_equations(reactions::Vector{Reaction},
                     ASTExpr[NumExpr(Float64(stoich)), rate_expr]))
             end
         end
-        rhs = if isempty(terms)
-            NumExpr(0.0)
-        elseif length(terms) == 1
-            terms[1]
-        else
-            OpExpr("+", terms)
-        end
+        # A species with NO net contribution from any reaction gets NO equation,
+        # rather than a vacuous `D(X, t) = 0`. The empty sum is zero, so emitting
+        # it is defensible arithmetic — but esm-spec §6.3.1 classifies by
+        # COMPLEMENT, and the two readings give the species different roles: with
+        # the equation it is a differential unknown that never moves, without it
+        # an unknown no equation names, i.e. ALGEBRAIC. §6.3.1 is the operative
+        # rule and the second is its answer.
+        #
+        # This is also what the other four bindings do (Python `reactions.py`,
+        # Rust `reactions.rs`, Go `flatten.go`, TypeScript `flatten.ts`); Julia
+        # emitting the zero was a 4-1 outlier, and the divergence was recorded in
+        # `flatten_conformance_test.jl`'s `_FC_DIVERGENCES` until this changed.
+        isempty(terms) && continue
+        lhs = OpExpr("D", ASTExpr[VarExpr(name)], wrt="t")
+        rhs = length(terms) == 1 ? terms[1] : OpExpr("+", terms)
         push!(equations, Equation(lhs, rhs))
     end
 

--- a/pkg/EarthSciAST.jl/src/flatten.jl
+++ b/pkg/EarthSciAST.jl/src/flatten.jl
@@ -356,11 +356,13 @@ concentration to every rate law it appears in. It is therefore skipped as an
 equation TARGET only — it stays in `species` so `mass_action_rate` keeps
 reading it as a substrate/product factor.
 
-A species that appears in NO reaction likewise gets no equation. Its rate is the
-empty sum, and emitting `D(X, t) = 0` for it would make it a differential unknown
-that never moves; esm-spec §6.3.1 classifies by COMPLEMENT, so leaving the
-equation out is what makes it the ALGEBRAIC unknown it is. See the comment at the
-skip below.
+A species whose NET stoichiometry is zero in every reaction likewise gets no
+equation — usually because it appears in no reaction at all, but a catalyst
+(equal substrate and product stoichiometry everywhere it appears) meets the same
+test. Its rate is the empty sum, and emitting `D(X, t) = 0` for it would make it
+a differential unknown that never moves; esm-spec §6.3.1 classifies by
+COMPLEMENT, so leaving the equation out is what makes it the ALGEBRAIC unknown it
+is. See the comment at the skip below.
 """
 function lower_reactions_to_equations(reactions::Vector{Reaction},
                                       species::Vector{Species})::Vector{Equation}

--- a/pkg/EarthSciAST.jl/test/flatten_conformance_test.jl
+++ b/pkg/EarthSciAST.jl/test/flatten_conformance_test.jl
@@ -121,17 +121,30 @@ the condition because `_var` is in no component's `local_names`; the affect LHS
 is a plain NAME rather than an expression, so it took a different path with no
 placeholder carve-out. `_collect_model!` now applies the §6.4 rule on both
 halves and the field is compared normally.)
-* `equations` on `full_coupled` — what survives of the `OH` divergence above is
-  the equation's POSITION, and it follows from the two bindings' different
-  reaction lowerings rather than from anything about coupling. Julia emits
-  `D(OH,t) = 0`, so the transport terms MERGE ONTO that equation and it keeps
-  its position among the reaction system's four (§4.7.5 step 4: a merged entry
-  keeps the position of its first occurrence) — and the merged RHS still leads
-  with the `0 +` term. The oracle has no `OH` reaction equation to merge into,
-  so its `OH` equation is Transport's UNMATCHED placeholder clone and sits in
-  `models` order, ahead of the reaction system: `[OH, O3, NO, NO2]` against
-  Julia's `[O3, NO, NO2, OH]`. Same four equations, same terms. Pinned locally
-  below.
+(RESOLVED: the `OH` half of `equations` on `full_coupled`. Julia used to emit
+`D(OH,t) = 0` for the inert species — the empty stoichiometric sum — so the
+transport terms merged ONTO that equation, and it kept its position among the
+reaction system's four while the oracle's `OH` equation was Transport's
+UNMATCHED placeholder clone sitting ahead of them: `[OH, O3, NO, NO2]` against
+Julia's `[O3, NO, NO2, OH]`, with Julia's RHS leading `0 +`.
+
+That was a 4-1 split, not a Julia-vs-oracle one: Python, Rust, Go AND TypeScript
+all omit the equation, and Rust argues the case in its own `reactions.rs`
+comment. esm-libraries-spec §4.6.1 now rules on it and Julia was the outlier —
+§6.3.1 classifies by COMPLEMENT, so a species no equation names is ALGEBRAIC,
+which is what a species touched by no reaction IS; emitting the zero would make
+it a differential unknown that never moves. `lower_reactions_to_equations`
+(src/flatten.jl) now skips it, so both bindings put `OH` first, both lead with
+the transport term, and the equation ORDER agrees.)
+
+* `equations` on `full_coupled` — what survives is ONLY the reaction-lowering
+  coefficient rendering below: the `O3` and `NO` equations differ in that the
+  oracle writes `-1 * rate` where Julia writes `-rate`. The `OH` and `NO2`
+  equations now match the corpus EXACTLY, as do `equation_count`,
+  `algebraic_variables`, `state_variables` and the equation order. This case is
+  therefore no longer a case of its own — it is one of "the reaction-lowering
+  cases" bullet below, and it stays in `_FC_DIVERGENCES` only until that
+  rendering is reconciled. Pinned locally below.
 * `equations` / `independent_variables` on `operator_compose_translate` — two
   separate oracle gaps, neither about the composition this case exists to pin
   (the merge itself matches the corpus exactly and is asserted locally below).
@@ -613,37 +626,55 @@ end
         @test EarthSciAST.flattened_to_esm(flat)["domain"]["element_type"] == "Float32"
     end
 
-    @testset "inert reaction species: zero tendency, then transported" begin
+    @testset "inert reaction species: no tendency, transported only" begin
         # `AtmosphericChemistry.OH` is declared as a species and touched by no
-        # reaction. §4.7.5 step 1's lowering emits `D(species,t) = Σ stoich·rate`
-        # for every species; the empty sum is 0. Dropping the equation instead
-        # (what the oracle does) makes `OH` an unknown no LHS names — an
-        # unconstrained algebraic unknown, i.e. a structurally singular DAE.
+        # reaction, so its stoichiometric sum is EMPTY and esm-libraries-spec
+        # §4.6.1 emits no `D(OH,t)` for it. Julia used to emit `D(OH,t) = 0`
+        # instead, which made it a differential unknown that never moves; §6.3.1
+        # classifies by COMPLEMENT, so leaving the equation out is what makes it
+        # the ALGEBRAIC unknown it is. Julia was the 4-1 outlier here (Python,
+        # Rust, Go and TypeScript all omit) and §4.6.1 ruled against it.
         #
-        # `OH` is a STATE, so §4.7.1 step 3's placeholder expansion also gives it
-        # a transport term, and the merge folds that onto the zero tendency. The
-        # `0 +` is therefore the visible trace of the two lowerings differing:
-        # the oracle's `OH` equation is transport ALONE and lands in Transport's
-        # document position, Julia's is `0 + transport` in the reaction system's.
-        # Same four equations either way, which is why `equation_count` and
-        # `algebraic_variables` are ordinary compared fields again.
+        # `OH` does still get an equation in THIS document, from somewhere else:
+        # it is a state, so §4.7.1 step 3's placeholder expansion gives it a
+        # transport clone, and with no reaction equation to merge onto, step 5
+        # preserves that clone unmatched. So the flattened `OH` is transport
+        # ALONE and sits in Transport's document position — ahead of the reaction
+        # system's three — which is exactly what the corpus records.
         flat = flatten(load_path(joinpath(_FLATTEN_TESTS_DIR, "valid", "full_coupled.esm")))
         @test haskey(flat.state_variables, "AtmosphericChemistry.OH")
+        # NOT algebraic here: the surviving transport clone names it. The
+        # algebraic case is the one with no operator at all, pinned separately in
+        # `reactions_test.jl`.
         @test isempty(flat.algebraic_variables)
         eqs = String[to_ascii(eq) for eq in flat.equations]
         @test length(eqs) == 4
-        # Position: OH LAST (merged onto the reaction system's fourth equation),
-        # where the corpus records it first. This is the whole of what remains
-        # of the `equations` divergence on this case.
+        # Position: OH FIRST, in `models` order ahead of the reaction system —
+        # agreeing with the corpus, where Julia used to have it last.
         @test String[String(split(e, " = ")[1]) for e in eqs] ==
-              ["D(AtmosphericChemistry.O3)/Dt", "D(AtmosphericChemistry.NO)/Dt",
-               "D(AtmosphericChemistry.NO2)/Dt", "D(AtmosphericChemistry.OH)/Dt"]
-        @test eqs[4] == "D(AtmosphericChemistry.OH)/Dt = 0 + " *
+              ["D(AtmosphericChemistry.OH)/Dt", "D(AtmosphericChemistry.O3)/Dt",
+               "D(AtmosphericChemistry.NO)/Dt", "D(AtmosphericChemistry.NO2)/Dt"]
+        # Transport alone, with no leading `0 +`.
+        @test eqs[1] == "D(AtmosphericChemistry.OH)/Dt = " *
               "(-Transport.u) * grad(AtmosphericChemistry.OH) + " *
               "(-Transport.v) * grad(AtmosphericChemistry.OH) + " *
               "(-Transport.w) * grad(AtmosphericChemistry.OH) + " *
               "Transport.K_h * laplacian(AtmosphericChemistry.OH) + " *
               "Transport.K_v * laplacian(AtmosphericChemistry.OH)"
+        # ... and it is byte-identical to what the shared corpus records, which
+        # is the half of the `equations` divergence this closed. What remains is
+        # the `-1 * rate` vs `-rate` coefficient rendering on O3 and NO, and
+        # nothing else — asserted here so a regression cannot quietly widen the
+        # entry back out.
+        corpus_case = first(c for c in JSON3.read(read(_FLATTEN_CORPUS_PATH, String)).cases
+                            if String(c.id) == "full_coupled")
+        corpus_eqs = String["$(e.lhs) = $(e.rhs)" for e in corpus_case.equations]
+        @test eqs[1] == corpus_eqs[1]                       # OH  — exact
+        @test eqs[4] == corpus_eqs[4]                       # NO2 — exact
+        for i in (2, 3)                                     # O3, NO — only `-1 *`
+            @test eqs[i] != corpus_eqs[i]
+            @test replace(corpus_eqs[i], "-1 * " => "-") == eqs[i]
+        end
     end
 
     @testset "operator_compose tier: the composed equations, in full" begin

--- a/pkg/EarthSciAST.jl/test/flatten_test.jl
+++ b/pkg/EarthSciAST.jl/test/flatten_test.jl
@@ -410,9 +410,19 @@ end
     end
 
     @testset "8a. couple additive connector transform (esm-spec §10.3)" begin
-        # Chem: one species A (no reactions) → D(Chem.A) ~ 0.
-        # Sink: a parameter k. An additive couple edge Sink.k → Chem.A adds
-        # (-Sink.k)*Chem.A to A's tendency, so D(Chem.A) ~ 0 + (-k*A) = -k*A.
+        # Chem: one species A in NO reaction, so esm-libraries-spec §4.6.1 emits
+        # no equation for it and A has NO tendency yet. Sink: a parameter k.
+        #
+        # That makes this the case §4.7.2 spells out for `additive`: "If `to` has
+        # no tendency yet, `expression` BECOMES it (`D(to) ~ expression`) — an
+        # additive term against an absent tendency is well defined, because zero
+        # is the additive identity." So D(Chem.A) ~ (-Sink.k) * Chem.A exactly,
+        # with no summation node.
+        #
+        # This testset used to assert a `+` here, because Julia emitted a vacuous
+        # `D(Chem.A) = 0` for the inert species and the connector summed onto it.
+        # The `+` was pinning that artifact, not the coupling behaviour under
+        # test; §4.6.1 removed the artifact and §4.7.2's own rule is what is left.
         rsys = EarthSciAST.ReactionSystem(
             [EarthSciAST.Species("A", default=2.0)], EarthSciAST.Reaction[])
         sink = Model(
@@ -434,11 +444,13 @@ end
         @test isempty(flat.metadata.opaque_coupling_refs)
         eq_A = _find_eq(flat, "Chem.A")
         @test eq_A !== nothing
-        # The additive term was summed onto A's tendency: -k*A is present.
-        @test _has_op(eq_A.rhs, "+")          # 0 + <term>
+        # The expression BECAME the tendency (§4.7.2), rather than being summed
+        # onto a vacuous zero: `-k*A` is the whole RHS.
+        @test !_has_op(eq_A.rhs, "+")         # no `0 + <term>` left to sum onto
         @test _has_op(eq_A.rhs, "-")          # negation of Sink.k
         @test _uses_var(eq_A.rhs, "Sink.k")
         @test _uses_var(eq_A.rhs, "Chem.A")
+        @test to_ascii(eq_A.rhs) == "(-Sink.k) * Chem.A"
         # Exactly one D(Chem.A) equation (no over-determining duplicate).
         @test count(eq -> EarthSciAST.differential_lhs_variable(eq.lhs) == "Chem.A",
                     flat.equations) == 1

--- a/pkg/EarthSciAST.jl/test/reactions_test.jl
+++ b/pkg/EarthSciAST.jl/test/reactions_test.jl
@@ -426,6 +426,59 @@ include("testutils.jl")  # TESTUTILS_REPO_ROOT
         @test model.variables["HO2"].type == UnknownVariable
     end
 
+    @testset "A species in NO reaction gets no equation, and is ALGEBRAIC" begin
+        # esm-libraries-spec §4.6.1. A species touched by no reaction has an EMPTY
+        # stoichiometric sum. Emitting `D(X,t) = 0` for it — which Julia used to do
+        # — makes it a DIFFERENTIAL unknown that never moves; esm-spec §6.3.1
+        # classifies by COMPLEMENT, so omitting the equation is what makes it the
+        # ALGEBRAIC unknown it is: a quantity the reaction network says nothing
+        # about, not one whose dynamics are known to be trivial.
+        #
+        # Julia was the 4-1 outlier on this (Python, Rust, Go and TypeScript all
+        # omit; Rust argues the case in its own `reactions.rs` comment), and
+        # §4.6.1 ruled against it. This is the regression pin for that ruling.
+        species = [Species("A", default=1.0), Species("B", default=0.0),
+                   Species("Xe", default=5.0)]   # Xe: declared, in no reaction
+        rxn = Reaction(Dict("A" => 1), Dict("B" => 1), VarExpr("k"))
+        rxn_sys = ReactionSystem(species, [rxn], parameters=[Parameter("k", 0.1)])
+
+        eqs = lower_reactions_to_equations(rxn_sys.reactions, rxn_sys.species)
+        targets = Set(String(EarthSciAST.differential_lhs_variable(e.lhs)) for e in eqs)
+        @test targets == Set(["A", "B"])
+        @test !("Xe" in targets)          # no `D(Xe,t) = 0`
+
+        # It is still an UNKNOWN — the species is declared and solved for; what
+        # changed is which half of the solved-for vector it lands in.
+        model = derive_odes(rxn_sys)
+        @test model.variables["Xe"].type == UnknownVariable
+
+        # And through flatten it classifies ALGEBRAIC, which is the whole point:
+        # §6.3.1's partition-by-complement has a category for "no equation names
+        # it", and this is it.
+        doc = """
+        {"esm": "1.0.0",
+         "metadata": {"name": "InertSpecies",
+                      "description": "Xe is declared and appears in no reaction."},
+         "reaction_systems": {
+           "Chem": {
+             "species": {"A": {"units": "mol/mol", "default": 1.0},
+                         "B": {"units": "mol/mol", "default": 0.0},
+                         "Xe": {"units": "mol/mol", "default": 5.0}},
+             "parameters": {"k": {"units": "1/s", "default": 0.1}},
+             "reactions": [{"id": "R1",
+                            "substrates": [{"species": "A", "stoichiometry": 1}],
+                            "products": [{"species": "B", "stoichiometry": 1}],
+                            "rate": "k"}]}}}
+        """
+        tmp = joinpath(mktempdir(), "inert_species.esm")
+        write(tmp, doc)
+        flat = flatten(load_path(tmp))
+        @test haskey(flat.state_variables, "Chem.Xe")       # still solved for
+        @test haskey(flat.algebraic_variables, "Chem.Xe")   # …algebraically
+        @test !any(EarthSciAST.differential_lhs_variable(eq.lhs) == "Chem.Xe"
+                   for eq in flat.equations)
+    end
+
     @testset "Reservoir species stay fixed through flatten (shared fixture)" begin
         # The flatten path (namespacing.jl `_collect_reaction_system!`) must agree
         # with `derive_odes`. Asserted against the SHARED cross-binding fixture, so

--- a/pkg/EarthSciAST.jl/test/real_mtk_integration_test.jl
+++ b/pkg/EarthSciAST.jl/test/real_mtk_integration_test.jl
@@ -177,6 +177,40 @@ import Symbolics
                    eq_strs)
     end
 
+    @testset "A state no equation mentions survives into the compiled system" begin
+        # esm-libraries-spec §4.6.1: a species touched by no reaction gets NO
+        # `D(X, t)` equation, which leaves it an unknown nothing names. It is
+        # still in `state_variables` (§4.7.5's field table), so the BACKEND has
+        # to carry it — MTK on its own drops an unknown that appears in no
+        # equation, which would delete the species from `unknowns(simp)`, make
+        # an `initial_conditions` entry naming it unbindable, and drop it from
+        # every solution. `System(::FlattenedSystem)` closes it with
+        # `D(X, t) ~ 0` at the lowering instead.
+        rsys = EarthSciAST.ReactionSystem(
+            [EarthSciAST.Species("A", default=1.0),
+             EarthSciAST.Species("B", default=0.0),
+             EarthSciAST.Species("Xe", default=5.0)],   # in no reaction
+            [EarthSciAST.Reaction(Dict("A" => 1), Dict("B" => 1), VarExpr("k"))],
+            parameters=[EarthSciAST.Parameter("k", 0.1)])
+        flat = EarthSciAST.flatten(rsys; name="Chem")
+
+        # The DOCUMENT-level artifact is unchanged by the closure: no equation
+        # for Xe, and it classifies algebraic.
+        @test !any(EarthSciAST.differential_lhs_variable(eq.lhs) == "Chem.Xe"
+                   for eq in flat.equations)
+        @test haskey(flat.algebraic_variables, "Chem.Xe")
+
+        sys = ModelingToolkit.System(flat; name=:Chem)
+        simp = ModelingToolkit.mtkcompile(sys)
+        names = String[string(ModelingToolkit.getname(u))
+                       for u in ModelingToolkit.unknowns(simp)]
+        @test any(endswith(n, "Xe") for n in names)
+        # ...and the closure is a ZERO tendency, so it holds its initial value.
+        d_xe = only(eq for eq in ModelingToolkit.equations(simp)
+                    if occursin("Xe", string(eq.lhs)))
+        @test iszero(Symbolics.value(d_xe.rhs))
+    end
+
     @testset "Extension-gated: removed exports are gone" begin
         # These names were removed as part of the extension refactor. They
         # must not exist as exported symbols of the main package.


### PR DESCRIPTION
Julia emitted `D(X, t) = 0` for a reaction species touched by no reaction — the empty stoichiometric sum. The other four bindings omit the equation. Julia was a 4–1 outlier, and this makes it 5–0.

Found while reviewing #216, whose new `operator_compose` diagnostic surfaced the divergence as a partial-merge warning on `tests/valid/full_coupled.esm`. That warning is a true report about this, not about the fixture; this PR is what clears it.

## The split

| Binding | species in no reaction | site |
|---|---|---|
| **Julia** | emitted `D(X) = 0` | `flatten.jl` — `rhs = if isempty(terms) NumExpr(0.0)` |
| **Python** | omits | `reactions.py` — `if species_rates[name] != 0` |
| **Rust** | omits, **deliberately** | `reactions.rs` — `if rate_terms.is_empty() { continue; }` |
| **Go** | omits | `flatten.go` — `if isNumericZero(rates[name]) { continue }` |
| **TypeScript** | omits | `flatten.ts` — `if (numericValue(rates[name]) === 0) continue` |

Rust does not merely happen to omit; it argues the case and cites the operative rule:

> A species with NO net contribution from any reaction gets NO equation, rather than a vacuous `D(X, t) = 0`. Emitting the zero equation makes such a species an ODE state that never moves… omitting it leaves the species an unknown that no equation names, which esm-spec §6.3.1's partition-by-complement classifies ALGEBRAIC.

## Why omit is right

The empty sum really is zero, so emitting it is defensible *arithmetic*. What settles it is that the two readings give the species different **roles**, and §6.3.1 classifies by complement:

- **With** the zero equation, `X` is a DIFFERENTIAL unknown — a state the solver advances whose derivative happens to be zero. It joins the `u` vector and is integrated.
- **Without** it, `X` is an unknown no equation names — §6.3.1's ALGEBRAIC category.

The second is what the species *is*. A declared species no reaction touches is not a quantity whose dynamics are known to be trivial; it is one the reaction network says nothing about, and §6.3.1 has a category for exactly that. Emitting the zero also makes `equation_count` depend on how many inert species a document happens to declare.

## The change

`lower_reactions_to_equations` (`pkg/EarthSciAST.jl/src/flatten.jl`) skips a species whose term list is empty, alongside the existing reservoir skip. Two lines plus the reasoning.

## Spec: the rule lands in §4.6.1

Two sections could have hosted it, and I picked the one §4.7.5 step 1 **defers to** — step 1 says "as specified in Section 4.6 `derive_odes`", so a rule about what `derive_odes` emits belongs where `derive_odes` is specified. Putting it only in §4.7.5's field-set table would make that table the normative home for a lowering rule, which is the wrong shape: the table describes a *consequence*.

- **New §4.6.1 "Which species `derive_odes` emits an equation for"** — states both exceptions (reservoir, and no-reaction), gives the §6.3.1 argument above, and notes that a later coupling rule may still define the species, so `derive_odes` is not deciding its final classification.
- **§4.7.5's `state_variables` row corrected.** It said the vector includes "every reaction-system species, **which gets a derived `D` equation at step 1**" — flatly true only if you emit the zero, and it is what misled this binding. It now names the exceptions, points at §4.6.1, and adds that such a species is still *in* the map: what changes is which half of the solved-for vector it lands in.

## `_FC_DIVERGENCES` disposition: **narrowed, not removed** — and here is why

The entry `"full_coupled" => ["equations"]` **stays**. Its cause shrinks from two to one:

| Equation | Before | After |
|---|---|---|
| `D(OH)` | **differed** — Julia `0 + <transport>` at position 4; corpus `<transport>` at position 1 | ✅ **byte-identical to the corpus**, position 1 |
| `D(NO2)` | matched | ✅ matches |
| `D(O3)` | differed | ⚠️ still differs — corpus `-1 * 1.8e-12 * …`, Julia `-1.8e-12 * …` |
| `D(NO)` | differed | ⚠️ still differs — same rendering |

Also now matching exactly: `equation_count` (4), `algebraic_variables` (`[]`), `state_variables`, and the **equation order**, which the `OH` divergence was shifting.

What survives is only the `-1 * rate` vs `-rate` coefficient rendering — a `to_ascii`-level difference in how the two lowerings build a −1 stoichiometry term, which the ledger already documents as its own general bullet ("`equations` on the reaction-lowering cases"). So `full_coupled` is no longer a case of its own; it is one of those.

I could not narrow it *structurally*: the ledger's finer syntax addresses one field of a variable-list key (`"parameters.update_kinds"`), and there is no way to say "equations 2 and 3 only". So the narrowing is (a) the documented cause reduced to one, with the `OH` half moved to a RESOLVED block, and (b) **a local pin that now asserts exactly what still differs** —

```julia
@test eqs[1] == corpus_eqs[1]                       # OH  — exact
@test eqs[4] == corpus_eqs[4]                       # NO2 — exact
for i in (2, 3)                                     # O3, NO — only `-1 *`
    @test eqs[i] != corpus_eqs[i]
    @test replace(corpus_eqs[i], "-1 * " => "-") == eqs[i]
end
```

— so the entry cannot silently widen back out. If the rendering is reconciled later, the entry goes entirely and this pin is what tells you it is safe to delete.

## Goldens that shifted

**No shared-corpus golden moved.** `tests/conformance/flatten/cases.json` is generated from the Python oracle, which is unchanged; Julia moved *toward* it. Two Julia-local pins shifted, both of which were pinning the artifact rather than the behaviour:

**1. `flatten_conformance_test.jl` — "inert reaction species"** (renamed *zero tendency, then transported* → *no tendency, transported only*).

| | Before | After |
|---|---|---|
| equation order | `[O3, NO, NO2, OH]` | `[OH, O3, NO, NO2]` |
| `OH`'s RHS | `0 + (-Transport.u) * grad(OH) + …` | `(-Transport.u) * grad(OH) + …` |

**Why the new value is correct:** `OH` gets no reaction equation, so §4.7.1 step 3's `_var` placeholder clone has nothing to merge onto and step 5 preserves it unmatched. The `OH` equation is therefore Transport's own clone, sitting in `models` order ahead of the reaction system — which is precisely what the shared corpus records and what the other four bindings produce. The leading `0 +` is gone because there is no longer a zero to sum onto. `algebraic_variables` stays `[]`: the surviving transport clone *does* name `OH`, so it is differential here — the algebraic case is the one with no operator at all, pinned separately.

**2. `flatten_test.jl` — "8a. couple additive connector transform (esm-spec §10.3)"**

| | Before | After |
|---|---|---|
| `D(Chem.A)` RHS | `0 + (-Sink.k) * Chem.A` | `(-Sink.k) * Chem.A` |
| assertion | `@test _has_op(eq_A.rhs, "+")` | `@test !_has_op(...)` + exact string |

**Why the new value is correct:** the testset builds a species in no reaction, so with §4.6.1 in force it has no tendency — which is exactly the case §4.7.2 spells out for `additive`:

> If `to` has no tendency yet, `expression` BECOMES it (`D(to) ~ expression`) — an additive term against an absent tendency is well defined, because zero is the additive identity.

The old `+` was pinning the vacuous zero equation, not the coupling behaviour the testset exists to test. Every other assertion in it is unchanged and still passes. This one is worth a second look precisely because it is a *coupling* test that was quietly depending on the lowering.

## Coverage added

`reactions_test.jl` — "A species in NO reaction gets no equation, and is ALGEBRAIC": pins that the lowering emits no `D(Xe,t)`, that `Xe` is still an UNKNOWN (it is declared and solved for; only which half changes), and that through `flatten` it lands in `algebraic_variables` with no equation naming it. Verified directly:

```
states    : ["Chem.A", "Chem.B", "Chem.Xe"]
algebraic : ["Chem.Xe"]
equations : ["D(Chem.A)/Dt = -Chem.k * Chem.A", "D(Chem.B)/Dt = Chem.k * Chem.A"]
```

## Testing

Targeted only — **no `./scripts/test-conformance.sh` and no full suite; CI does that.** I ran every Julia suite that references the affected fixtures, `derive_odes`, `lower_reactions_to_equations`, or `algebraic_variables`:

| Suite | Result |
|---|---|
| `reactions_test.jl` | **140 passed** |
| `flatten_conformance_test.jl` | **2495 passed** (was 2489; the new pins) |
| `flatten_test.jl` | **174 passed** |
| `reaction_species_order_test.jl` | **29 passed** |
| `classification_test.jl` | **184 passed** |

The other four bindings are untouched — they already do this — so there is nothing to run there.

## Relationship to #216

Independent branches; no overlapping lines. #216 adds the `operator_compose` merge diagnostic that *found* this. Once both land, Julia and Python agree on `full_coupled.esm` including on the diagnostic: both emit the same partial-merge warning, for the same remaining reason (the `_var` clone for `OH` genuinely lands nowhere), rather than disagreeing about whether there is anything to report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oB5AKeaD2Uf3go2mYz6og
