### PR TITLE
fix(rust): SolveOptions tolerances are Option<f64>, unbreak every rust job on main

### DIFF
--- a/pkg/earthsci-ast-rs/tests/pde_inline_reference_dimension_names_conformance.rs
+++ b/pkg/earthsci-ast-rs/tests/pde_inline_reference_dimension_names_conformance.rs
@@ -62,8 +62,8 @@ fn reference_dimension_names_are_bound_per_cell() {
     assert_eq!(rs["solver"].as_str(), Some("Erk"));
     let opts = SolveOptions {
         alg: Alg::Erk,
-        reltol: rs["reltol"].as_f64().expect("reltol"),
-        abstol: rs["abstol"].as_f64().expect("abstol"),
+        reltol: Some(rs["reltol"].as_f64().expect("reltol")),
+        abstol: Some(rs["abstol"].as_f64().expect("abstol")),
         ..Default::default()
     };
     let rtol = manifest["tolerances"]["assertion_rtol"]


### PR DESCRIPTION
`main` does not compile its Rust test targets, so **all three `rust-tests` legs and `cargo clippy` are red on `main` and on every branch cut from it** ([run 34161007806](https://github.com/EarthSciML/EarthSciAST/actions/runs/34161007806)).

## The break

`SolveOptions::reltol`/`abstol` became `Option<f64>` — deliberately, so that a caller with no opinion stays distinguishable from one who set the binding default. esm-spec §2.2.2 puts the document's `solver` block *between* the two, and a bare `f64` could not express that. One test literal was not updated:

```
error[E0308]: mismatched types
  --> tests/pde_inline_reference_dimension_names_conformance.rs:65:17
   |
65 |         reltol: rs["reltol"].as_f64().expect("reltol"),
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Option<f64>`, found `f64`
```

`cargo test --all-features` never gets to run a test. Same repo-wide shape as the `performance.rs` E0062 that #221 cleared: one stale literal, every Rust job red, and the downstream `conformance-results` red behind it.

## The fix

Two lines, wrapped in `Some(...)`.

Worth one sentence of justification, because there is a shorter fix that is wrong: `as_f64()` already returns `Option<f64>`, so `reltol: rs["reltol"].as_f64()` compiles and is tempting. It would silently read a manifest that is *missing* the key as "caller has no opinion", turning a broken manifest into a passing test at the binding default. Keeping the `.expect()` inside the `Some(...)` preserves the loud failure.

## Verification

`cargo check --all-features --test pde_inline_reference_dimension_names_conformance` — exit 0.

Per the campaign testing policy I ran only that target, not the full suite; CI covers the rest.

## Why it is separate

Found by the agent working #223 (PR #240), which flagged it rather than fixing another PR's file. It blocks every open PR's Rust signal, so it should merge on its own rather than riding with any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oB5AKeaD2Uf3go2mYz6og