### PR TITLE
fix(python): accept the INDEXED LHS spelling for an array-shaped observed (#232)

### DIFF
--- a/pkg/earthsci-ast-py/src/earthsci_ast/classification.py
+++ b/pkg/earthsci-ast-py/src/earthsci_ast/classification.py
@@ -243,13 +243,27 @@ def parameters(model: Any) -> list[str]:
 
 def _base_name(expr: Any) -> str | None:
     """The variable an LHS position ultimately names: a bare string is itself,
-    ``index(u, …)`` is ``u``. Anything else has no single base name."""
+    ``index(u, …)`` is ``u``, and an ``aggregate`` whose ``expr`` is an ``index``
+    (the arrayed definition ``y[i] ~ f(…)`` as documents actually spell it) is
+    that index's base. Anything else has no single base name.
+
+    The aggregate unwrap is the mirror of :func:`_derivative_targets`' — that one
+    sees through the same shell for a ``D`` body, and §6.3.1 reads BOTH defining
+    spellings through the LHS's base name. Without it an array-shaped observed
+    written the indexed way was credited to nobody, so
+    :func:`observed_definitions` did not know it was an observed at all — which is
+    what made a §6.6.5 assertion on such an observed refuse to look up its field
+    (issue #232's Python half)."""
     if isinstance(expr, str):
         return expr
     op = _op(expr)
     if op == "index":
         args = _args(expr)
         return _base_name(args[0]) if args else None
+    if op == "aggregate":
+        inner = _slot(expr, "expr", "expr")
+        if inner is not None and _op(inner) == "index":
+            return _base_name(inner)
     return None
 
 

--- a/pkg/earthsci-ast-py/src/earthsci_ast/flatten.py
+++ b/pkg/earthsci-ast-py/src/earthsci_ast/flatten.py
@@ -16,7 +16,7 @@ from collections import OrderedDict
 from dataclasses import dataclass, field, replace
 from typing import Any
 
-from .classification import inlined_unknowns
+from .classification import inlined_unknowns, ode_states
 from .errors import EarthSciAstError
 from .esm_types import (
     ARRAY_OPS,
@@ -28,6 +28,7 @@ from .esm_types import (
     DataSource,
     DiscreteEvent,
     Domain,
+    Equation,
     EsmFile,
     Expr,
     ExprNode,
@@ -36,6 +37,7 @@ from .esm_types import (
     OperatorComposeCoupling,
     ReactionSystem,
     VariableMapCoupling,
+    is_aggregate_op,
 )
 from .expr_walk import any_child, iter_children, map_children, walk
 
@@ -973,6 +975,110 @@ def _data_source_fields(
     return fields
 
 
+def _frame_symbol_occurs_free(expr: Expr, syms: set[str]) -> bool:
+    """Does any of ``syms`` occur as a bare reference not rebound by an aggregate?
+
+    The discriminator for :func:`_normalize_indexed_observed_lhs`: a right-hand
+    side that mentions the LHS frame's own index symbols is a PER-CELL body and
+    needs the frame wrapped around it; one that does not (a literal, a whole-array
+    expression, or an aggregate that binds those symbols itself) is already the
+    whole array. Mirrors Julia's use of ``free_variables``, which subtracts
+    aggregate binders — :func:`earthsci_ast.expression.free_variables` does not,
+    so the binder-aware walk lives here.
+    """
+    if isinstance(expr, str):
+        return expr in syms
+    if not isinstance(expr, ExprNode):
+        return False
+    inner = syms
+    if is_aggregate_op(expr.op):
+        inner = syms - (set(expr.output_idx or []) | set(expr.ranges or {}))
+        if not inner:
+            return False
+    return any(_frame_symbol_occurs_free(child, inner) for child in iter_children(expr))
+
+
+def _normalized_indexed_definition(eq: Equation, model: Model, states: set[str]) -> Equation | None:
+    """The bare-LHS rewrite of one indexed array-observed definition, or None.
+
+    Recognition is deliberately narrow, mirroring Julia's
+    ``_normalize_indexed_observed_lhs``: the shell must carry no
+    ``filter`` / ``join`` / ``key`` / ``distinct``; the gather must be the
+    IDENTITY on the frame (``index(V, k…)``, same symbols in the same order, so
+    ``index(V, k+1)`` and permutations are not recognized); ``output_idx`` must be
+    non-empty (a scalar reduction is no frame); ``ranges`` must bind exactly those
+    symbols; and ``V`` must be a declared ``unknown`` of this model that is not an
+    ODE state and whose declared ``shape`` has the frame's rank. Anything else
+    returns None and the equation is passed through untouched.
+    """
+    lhs = eq.lhs
+    if not (isinstance(lhs, ExprNode) and is_aggregate_op(lhs.op)):
+        return None
+    if any(getattr(lhs, f, None) is not None for f in ("filter", "join", "key", "distinct")):
+        return None
+    frame = [s for s in (lhs.output_idx or []) if isinstance(s, str)]
+    if not frame or len(frame) != len(lhs.output_idx or []):
+        return None
+    ranges = lhs.ranges if isinstance(lhs.ranges, dict) else {}
+    if set(ranges) != set(frame):
+        return None
+    body = lhs.expr
+    if not (isinstance(body, ExprNode) and body.op == "index" and body.args):
+        return None
+    head = body.args[0]
+    if not isinstance(head, str) or list(body.args[1:]) != frame:
+        return None
+    var = model.variables.get(head)
+    if var is None or var.type != "unknown" or head in states:
+        return None
+    if len(var.shape or []) != len(frame):
+        return None
+    rhs = eq.rhs
+    if _frame_symbol_occurs_free(rhs, set(frame)):
+        # A per-cell body: wrap it in the LHS's own frame, so the definition
+        # denotes the whole array exactly as the bare spelling would.
+        rhs = replace(lhs, args=[], expr=rhs)
+    return replace(eq, lhs=head, rhs=rhs)
+
+
+def _normalize_indexed_observed_lhs(model: Model) -> list[Equation]:
+    """Rewrite the INDEXED spelling of an array-observed definition to the bare one.
+
+    esm-spec §6.3.1 admits two LHS spellings for the equation that DEFINES an
+    unknown — bare (``y ~ f(…)``) and indexed (``y[i] ~ f(…)``, "which defines the
+    whole array ``y``") — and reads the defining form through the LHS's BASE NAME:
+    "an arrayed definition is observed exactly as its scalar counterpart is".
+    Neither spelling is restricted by rank.
+
+    This binding classified by the LHS's SYNTAX instead, through
+    :func:`~earthsci_ast.classification.inlined_unknowns` — the strict
+    ``y ~ f(…)`` set §6.3.1 sanctions for *inlining specifically*, used here as if
+    it were the classification, which §6.3.1 says it is not ("does not narrow the
+    partition"). An array-shaped observed written the indexed way therefore landed
+    in ``state_vars``, where nothing ever wrote it, and three things went wrong at
+    once (issue #232's Python half): asserting the observed itself returned 0.0
+    from its never-written state slot; a per-cell RHS matched no driver case and
+    was dropped with the ``unrecognized algebraic equation`` warning, freezing the
+    state it constrained; and a bare whole-array reader (``D(u) ~ w``) read that
+    same zero slot, because the array build's algebraic elimination substitutes
+    only INDEXED reads.
+
+    Normalizing the spelling once, upstream of classification and of every
+    downstream consumer, fixes all three at their single cause and leaves exactly
+    one LHS form in the flattened system — upstream normalization, not runner
+    dispatch (``AGENTS.md``). Returns ``model.equations`` BY IDENTITY when nothing
+    matches.
+    """
+    states = set(ode_states(model))
+    out: list[Equation] = []
+    changed = False
+    for eq in model.equations:
+        rewritten = _normalized_indexed_definition(eq, model, states)
+        out.append(eq if rewritten is None else rewritten)
+        changed = changed or rewritten is not None
+    return out if changed else model.equations
+
+
 def _collect_model(
     name: str,
     model: Model,
@@ -983,14 +1089,20 @@ def _collect_model(
     full_prefix = prefix or name
     component = _ComponentSystem(name=full_prefix)
 
+    # esm-spec §6.3.1 admits BOTH LHS spellings for the equation that defines an
+    # unknown, and reads the defining form through the LHS's base name. Normalize
+    # the indexed one (`y[i] ~ f(…)`) to the bare one FIRST, so classification and
+    # every downstream consumer see exactly one form.
+    equations = _normalize_indexed_observed_lhs(model)
+    if equations is not model.equations:
+        model = replace(model, equations=equations)
+
     # The variable's role comes from the §6.3.1 classification, NOT from a
-    # declared type. `observed` is the INLINED form specifically -- an unknown a
-    # bare-variable LHS defines, which is substituted into its consumers. Every
-    # other unknown is SOLVED FOR and lands in `state_vars`: an ODE state, an
-    # algebraic unknown, and an ARRAYED definition (`y[i] ~ f(i)`) alike. The
-    # arrayed one is observed by §6.3.1 and its cadence resolves through its RHS,
-    # but it materializes into a buffer its consumers index rather than being
-    # inlined -- exactly the 0.x `state` + index-LHS shape.
+    # declared type. `observed` is the unknown a bare-variable LHS defines, which
+    # is substituted into its consumers; with the indexed spelling normalized
+    # above, an ARRAYED definition (`y[i] ~ f(i)`) reaches this as the bare form
+    # and is classified observed too, as §6.3.1 requires. Every other unknown is
+    # SOLVED FOR and lands in `state_vars`: an ODE state and an algebraic unknown.
     observed = set(inlined_unknowns(model))
 
     for var_name, var in model.variables.items():

--- a/pkg/earthsci-ast-py/tests/test_indexed_lhs_array_observed.py
+++ b/pkg/earthsci-ast-py/tests/test_indexed_lhs_array_observed.py
@@ -1,0 +1,317 @@
+"""esm-spec §6.3.1's INDEXED LHS spelling for an array-shaped observed (#232).
+
+§6.3.1 admits **two** LHS spellings for the equation that DEFINES an unknown —
+bare (``y ~ f(…)``) and indexed (``y[i] ~ f(…)``, "which defines the whole array
+``y``") — and reads the defining form through the LHS's **base name**: "an
+arrayed definition is observed exactly as its scalar counterpart is". Neither
+spelling is restricted by rank.
+
+This binding classified by the LHS's SYNTAX instead, through
+``classification.inlined_unknowns`` — the strict ``y ~ f(…)`` set §6.3.1
+sanctions for *inlining specifically*, used as if it were the classification,
+which §6.3.1 says it is not ("does not narrow the partition"). An array-shaped
+observed written the indexed way therefore landed in ``state_variables``, where
+nothing ever wrote it, and three things went wrong at once — all SILENT, which
+is why #232 read Python as passing:
+
+1. Asserting the observed itself at ``t > 0`` returned **0.0**, from its
+   never-written state slot.
+2. An indexed LHS with a **per-cell** RHS matched no driver case and was dropped
+   with ``RuntimeWarning: unrecognized algebraic equation …``, freezing the state
+   it constrained at its initial value.
+3. A **bare whole-array** reader (``D(u) ~ w``) read that same zero slot, because
+   the array build's algebraic elimination substitutes only INDEXED reads.
+
+One cause, one fix, in two halves: ``flatten._normalize_indexed_observed_lhs``
+rewrites the spelling to the bare one upstream of classification, and
+``classification._base_name`` sees through the aggregate shell so §6.6.5's
+observed-assertion lookup credits the name at all.
+
+Every test below pins the indexed spelling against the BARE-spelling twin of the
+same model. That is the actual contract: the spelling must not decide the answer.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import warnings
+
+import pytest
+
+from earthsci_ast.classification import is_observed_unknown, observed_unknowns
+from earthsci_ast.flatten import _normalize_indexed_observed_lhs, flatten
+from earthsci_ast.parse import load_path
+from earthsci_ast.pde_inline_tests import run_pde_tests
+from earthsci_ast.problem import esm_problem
+
+E2 = math.exp(2.0)
+
+
+def _agg(expr, sym="k"):
+    return {
+        "op": "aggregate",
+        "args": [],
+        "output_idx": [sym],
+        "ranges": {sym: {"from": "lev"}},
+        "expr": expr,
+    }
+
+
+def _idx(name, sym="k"):
+    return {"op": "index", "args": [name, sym]}
+
+
+# w[k] ~ aggregate{k}(2*u[k]) — INDEXED LHS, whole-array RHS.
+EQ_W_INDEXED = {"lhs": _agg(_idx("w")), "rhs": _agg({"op": "*", "args": [2.0, _idx("u")]})}
+# w[k] ~ 2*u[k] — INDEXED LHS, PER-CELL RHS (no RHS aggregate).
+EQ_W_INDEXED_PERCELL = {"lhs": _agg(_idx("w")), "rhs": {"op": "*", "args": [2.0, _idx("u")]}}
+# w ~ aggregate{k}(2*u[k]) — the BARE-LHS twin, the control for every case.
+EQ_W_BARE = {"lhs": "w", "rhs": _agg({"op": "*", "args": [2.0, _idx("u")]})}
+
+# aggregate{k}(D(u[k])) ~ aggregate{k}(w[k]) — the indexed derivative spelling.
+EQ_D_INDEXED = {
+    "lhs": _agg({"op": "D", "args": [_idx("u")], "wrt": "t"}),
+    "rhs": _agg(_idx("w")),
+}
+# D(u) ~ w — the BARE whole-array derivative spelling.
+EQ_D_BARE = {"lhs": {"op": "D", "args": ["u"], "wrt": "t"}, "rhs": "w"}
+
+
+def _doc(name, equations, assertions):
+    """#232's model: w = 2u and D(u) = w, so u(t) = e^(2t) and w(t) = 2e^(2t)."""
+    return {
+        "esm": "1.0.0",
+        "metadata": {"name": name, "authors": ["repro"]},
+        "index_sets": {"lev": {"kind": "interval", "size": 4}},
+        "models": {
+            "Column": {
+                "variables": {
+                    "w": {"type": "unknown", "units": "1", "shape": ["lev"]},
+                    "u": {
+                        "type": "unknown",
+                        "units": "1",
+                        "default": 1.0,
+                        "shape": ["lev"],
+                    },
+                },
+                "equations": equations,
+                "tests": [
+                    {
+                        "id": "t",
+                        "time_span": {"start": 0.0, "end": 1.0},
+                        "assertions": assertions,
+                    }
+                ],
+            }
+        },
+    }
+
+
+def _write(tmp_path, doc, name):
+    path = tmp_path / name
+    path.write_text(json.dumps(doc))
+    return str(path)
+
+
+def _actuals(tmp_path, name, equations, assertions):
+    """``{variable: actual}`` from running the document's inline test."""
+    path = _write(tmp_path, _doc(name, equations, assertions), name + ".esm.json")
+    return {r.variable: r.actual for r in run_pde_tests(path)}
+
+
+ASSERT_U = [{"variable": "u", "time": 1.0, "coords": {"lev": 1}, "expected": E2}]
+ASSERT_U_AND_W = ASSERT_U + [
+    {"variable": "w", "time": 1.0, "coords": {"lev": 1}, "expected": 2 * E2}
+]
+
+
+# --------------------------------------------------------------------------- #
+# Symptom 1 — asserting the indexed-LHS observed itself
+# --------------------------------------------------------------------------- #
+
+
+def test_symptom_1_the_indexed_lhs_observed_is_readable_at_a_later_time(tmp_path):
+    """Returned 0.0 — the never-written state slot — instead of 2·e²."""
+    got = _actuals(tmp_path, "s1", [EQ_W_INDEXED, EQ_D_INDEXED], ASSERT_U_AND_W)
+
+    assert got["w"] is not None
+    assert got["w"] == pytest.approx(2 * E2, rel=1e-6)
+    assert got["u"] == pytest.approx(E2, rel=1e-6)
+
+
+def test_symptom_1_agrees_with_the_bare_spelling_twin(tmp_path):
+    indexed = _actuals(tmp_path, "s1i", [EQ_W_INDEXED, EQ_D_INDEXED], ASSERT_U_AND_W)
+    bare = _actuals(tmp_path, "s1b", [EQ_W_BARE, EQ_D_INDEXED], ASSERT_U_AND_W)
+
+    assert indexed["w"] == pytest.approx(bare["w"], rel=1e-12)
+    assert indexed["u"] == pytest.approx(bare["u"], rel=1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# Symptom 2 — an indexed LHS with a per-cell RHS
+# --------------------------------------------------------------------------- #
+
+
+def test_symptom_2_a_per_cell_rhs_is_not_dropped(tmp_path):
+    """The equation matched no driver case, so it was dropped with a warning and
+    the state it constrains stayed frozen at its initial value 1.0."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        got = _actuals(tmp_path, "s2", [EQ_W_INDEXED_PERCELL, EQ_D_INDEXED], ASSERT_U)
+
+    dropped = [c for c in caught if "unrecognized algebraic equation" in str(c.message)]
+    assert not dropped, f"equation dropped: {dropped[0].message}"
+    assert got["u"] == pytest.approx(E2, rel=1e-6)
+
+
+def test_symptom_2_agrees_with_the_bare_spelling_twin(tmp_path):
+    """A per-cell RHS under the LHS's frame denotes the same whole array the
+    aggregate-wrapped RHS does, so the two must give the same number."""
+    percell = _actuals(tmp_path, "s2p", [EQ_W_INDEXED_PERCELL, EQ_D_INDEXED], ASSERT_U)
+    bare = _actuals(tmp_path, "s2b", [EQ_W_BARE, EQ_D_INDEXED], ASSERT_U)
+
+    assert percell["u"] == pytest.approx(bare["u"], rel=1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# Symptom 3 — a bare whole-array derivative reading the indexed-LHS observed
+# --------------------------------------------------------------------------- #
+
+
+def test_symptom_3_a_bare_whole_array_derivative_reads_the_observed(tmp_path):
+    """``D(u) ~ w`` read the zero state slot, because the array build's algebraic
+    elimination substitutes only INDEXED reads — so ``u`` stayed at 1.0."""
+    got = _actuals(tmp_path, "s3", [EQ_W_INDEXED, EQ_D_BARE], ASSERT_U)
+
+    assert got["u"] == pytest.approx(E2, rel=1e-6)
+
+
+def test_symptom_3_agrees_with_the_bare_spelling_twin(tmp_path):
+    indexed = _actuals(tmp_path, "s3i", [EQ_W_INDEXED, EQ_D_BARE], ASSERT_U)
+    bare = _actuals(tmp_path, "s3b", [EQ_W_BARE, EQ_D_BARE], ASSERT_U)
+
+    assert indexed["u"] == pytest.approx(bare["u"], rel=1e-12)
+
+
+def test_all_four_spelling_combinations_agree(tmp_path):
+    """Two observed spellings x two derivative spellings: one model, one answer."""
+    results = [
+        _actuals(tmp_path, f"m{i}", [obs, drv], ASSERT_U)["u"]
+        for i, (obs, drv) in enumerate(
+            [
+                (EQ_W_BARE, EQ_D_BARE),
+                (EQ_W_BARE, EQ_D_INDEXED),
+                (EQ_W_INDEXED, EQ_D_BARE),
+                (EQ_W_INDEXED, EQ_D_INDEXED),
+            ]
+        )
+    ]
+    for got in results:
+        assert got == pytest.approx(results[0], rel=1e-12)
+        assert got == pytest.approx(E2, rel=1e-6)
+
+
+# --------------------------------------------------------------------------- #
+# The two halves of the fix, directly
+# --------------------------------------------------------------------------- #
+
+
+def test_flatten_classifies_the_indexed_definition_as_an_observed(tmp_path):
+    """It landed in ``state_variables``, where nothing ever wrote it."""
+    path = _write(tmp_path, _doc("c", [EQ_W_INDEXED, EQ_D_INDEXED], ASSERT_U), "c.esm.json")
+    flat = flatten(load_path(path))
+
+    assert "Column.w" in flat.observed_variables
+    assert "Column.w" not in flat.state_variables
+    assert list(flat.state_variables) == ["Column.u"]
+
+
+def test_classification_credits_the_indexed_lhs_to_its_base_name(tmp_path):
+    """``_base_name`` did not see through the aggregate shell, so §6.6.5's
+    observed-assertion lookup was gated out before it ever looked."""
+    path = _write(tmp_path, _doc("c", [EQ_W_INDEXED, EQ_D_INDEXED], ASSERT_U), "c.esm.json")
+    model = load_path(path).models["Column"]
+
+    assert observed_unknowns(model) == ["w"]
+    assert is_observed_unknown(model, "w")
+
+
+def test_the_normalizer_returns_its_input_by_identity_when_nothing_matches(tmp_path):
+    """The bare spelling is already normal — no copy, no rewrite."""
+    path = _write(tmp_path, _doc("c", [EQ_W_BARE, EQ_D_INDEXED], ASSERT_U), "c.esm.json")
+    model = load_path(path).models["Column"]
+
+    assert _normalize_indexed_observed_lhs(model) is model.equations
+
+
+@pytest.mark.parametrize(
+    "name,equation",
+    [
+        # A NON-IDENTITY gather is not a definition of the whole array.
+        (
+            "offset_gather",
+            {
+                "lhs": _agg({"op": "index", "args": ["w", {"op": "+", "args": ["k", 1]}]}),
+                "rhs": _agg({"op": "*", "args": [2.0, _idx("u")]}),
+            },
+        ),
+        # A GATED shell restricts which cells contribute; it is not the frame.
+        (
+            "filtered_shell",
+            {
+                "lhs": {
+                    "op": "aggregate",
+                    "args": [],
+                    "output_idx": ["k"],
+                    "ranges": {"k": {"from": "lev"}},
+                    "expr": _idx("w"),
+                    "filter": {"op": ">", "args": ["k", 1]},
+                },
+                "rhs": _agg({"op": "*", "args": [2.0, _idx("u")]}),
+            },
+        ),
+        # A SCALAR reduction (no output_idx) is no frame at all.
+        (
+            "scalar_reduction",
+            {
+                "lhs": {
+                    "op": "aggregate",
+                    "args": [],
+                    "output_idx": [],
+                    "ranges": {"k": {"from": "lev"}},
+                    "expr": _idx("w"),
+                },
+                "rhs": _agg({"op": "*", "args": [2.0, _idx("u")]}),
+            },
+        ),
+    ],
+)
+def test_the_normalizer_declines_outside_its_narrow_recognition(tmp_path, name, equation):
+    """Recognition mirrors Julia's ``_normalize_indexed_observed_lhs``: identity
+    gather on the frame, no gating shell, non-empty ``output_idx``. Anything else
+    passes through untouched, so nothing else in the corpus can move."""
+    path = _write(tmp_path, _doc(name, [equation, EQ_D_INDEXED], ASSERT_U), name + ".esm.json")
+    model = load_path(path).models["Column"]
+
+    assert _normalize_indexed_observed_lhs(model) is model.equations
+
+
+def test_the_normalizer_declines_a_target_with_no_declared_shape(tmp_path):
+    """The two corpus equations that already use this LHS shape name a variable
+    with NO declared shape (``arrayop/02`` and ``arrayop/04``); the rank guard is
+    what leaves them byte-identical."""
+    doc = _doc("noshape", [EQ_W_INDEXED, EQ_D_INDEXED], ASSERT_U)
+    del doc["models"]["Column"]["variables"]["w"]["shape"]
+    path = _write(tmp_path, doc, "noshape.esm.json")
+    model = load_path(path).models["Column"]
+
+    assert _normalize_indexed_observed_lhs(model) is model.equations
+
+
+def test_the_indexed_spelling_still_routes_to_the_array_pathway(tmp_path):
+    """The #231 routing arm and this normalization compose: the declared shape
+    still decides the engine after the LHS is rewritten."""
+    path = _write(tmp_path, _doc("p", [EQ_W_INDEXED, EQ_D_BARE], ASSERT_U), "p.esm.json")
+
+    assert esm_problem(path, (0.0, 1.0)).pathway == "array"


### PR DESCRIPTION
Split out of PR #237.

This change did not originate in this branch: it was pushed as commit `57b72acad`
onto #237's branch (`claude/issue-231-python-shape-pathway-routing`) by a
concurrent session while #237 was being reviewed. #237 is scoped to
declared-`shape` pathway routing, and this is a different axis entirely — so on
the repo owner's ruling it has been cherry-picked onto a fresh branch off `main`
and reverted from #237, leaving both PRs scoped to one concern each.

**This is issue #232's Python half**, and the sibling of PR #250
(`claude/issue-232-julia-indexed-lhs-array-observed`), which carries the Julia
half of the same defect.

## What it does

esm-spec §6.3.1 admits **two** LHS spellings for the equation that defines an
unknown — bare (`y ~ f(…)`) and indexed (`y[i] ~ f(…)`, "which defines the whole
array `y`") — and reads the defining form through the LHS's **base name**: "an
arrayed definition is observed exactly as its scalar counterpart is". Neither
spelling is restricted by rank.

Python classified by the LHS's **syntax** instead, through
`classification.inlined_unknowns` — the strict `y ~ f(…)` set §6.3.1 sanctions
for *inlining* specifically, used as if it were the classification, which §6.3.1
says it is not ("does not narrow the partition"). An array-shaped observed
written the indexed way therefore landed in `state_variables`, where nothing ever
wrote it. That one misclassification produced three silent divergences from
Julia:

1. Asserting the observed itself at `t > 0` returned `0.0`, from its
   never-written state slot.
2. An indexed LHS with a per-cell RHS matched no driver case and was dropped with
   `unrecognized algebraic equation`, freezing the state it constrained.
3. A bare whole-array reader (`D(u) ~ w`) read that same zero slot, because the
   array build's algebraic elimination substitutes only *indexed* reads.

The fix normalizes the spelling once, upstream, in `flatten`, so the rest of the
pipeline sees a single form.

## Provenance and review status

I did not write `57b72acad` and have not reviewed its substance — I carried it
across verbatim, resolving nothing (the cherry-pick applied cleanly onto `main`).
Its author's own measurements are recorded in the commit message. What I did
verify is that it stands on its own on top of current `main`; see below.

## Verification

Run on this branch, on top of `main` at `68574b653`:

- `pytest tests/test_indexed_lhs_array_observed.py` — **15 passed** (the 317-line
  test file the commit adds).
- Full Python suite, excluding the three files broken by a stale local
  `earthsciio` install (`test_esio_provider.py`,
  `test_loader_ingest_and_select.py`,
  `test_loader_unit_conversion_conformance.py`) — see below.
- `ruff check src/ tests/ ../../scripts/` and `ruff format --check` — clean,
  225 files.

Note that `main` at `68574b653` does not currently compile on the Rust side
(two `E0308`s in `pde_inline_reference_dimension_names_conformance.rs`, fixed
independently by PR #252), so the `Lint and format` and `rust-tests` checks are
expected to be red here for a reason unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsYdzFvpToJitJ984AKsm4
