### PR TITLE
perf(affine): a state gather on its OWN grid is affine — stop cutting and tabling it

### DIFF
--- a/pkg/EarthSciAST.jl/src/tree_walk/build.jl
+++ b/pkg/EarthSciAST.jl/src/tree_walk/build.jl
@@ -3200,10 +3200,18 @@ function _build_evaluator_impl(model::Model; kwargs...)
     prev = _LANE_INTERN_POOL[]
     _LANE_INTERN_POOL[] = _lane_intern_disabled() ? nothing :
                           Dict{_LaneInternKey,Any}()
+    # Same lifetime, same save/restore: the identity slot tables the lane-affine
+    # STATE-BOX lowering addresses through (`_state_slot_identity`,
+    # stencil_affine.jl) are shared across every equation of THIS build and
+    # dropped with it.
+    prev_sb = _STATE_SLOT_TBL_POOL[]
+    _STATE_SLOT_TBL_POOL[] = _state_box_disabled() ? nothing :
+                             Dict{Tuple{String,Int,Int},Vector{Int}}()
     try
         return _build_evaluator_impl_inner(model; kwargs...)
     finally
         _LANE_INTERN_POOL[] = prev
+        _STATE_SLOT_TBL_POOL[] = prev_sb
     end
 end
 

--- a/pkg/EarthSciAST.jl/src/tree_walk/stencil_affine.jl
+++ b/pkg/EarthSciAST.jl/src/tree_walk/stencil_affine.jl
@@ -195,8 +195,112 @@ mutable struct _AffineSig
     bmemo::IdDict{OpExpr,Bool}
     bio::IOBuffer
     state_scratch::Vector{Int}   # reused per `_cell_ckey!` for the state-lane slots
+    # LANE-AFFINE key support, per branch key: for every lane recipe, which of
+    # its index arguments are NOT structurally affine in the loop indices and
+    # therefore have to be differenced per keyed cell. Classified once per
+    # branch; see `_lane_nonaffine_args!`.
+    lane_ref::Dict{String,Vector{Vector{Bool}}}
+    back_scratch::Vector{Int}    # reused per keyed cell for the backward probe
 end
-_AffineSig() = _AffineSig(Dict{String,_StencilBranch}(), IdDict{OpExpr,Bool}(), IOBuffer(), Int[])
+_AffineSig() = _AffineSig(Dict{String,_StencilBranch}(), IdDict{OpExpr,Bool}(), IOBuffer(), Int[],
+                          Dict{String,Vector{Vector{Bool}}}(), Int[])
+
+# ── LANE-AFFINE SIGNATURE (the cut key measures the LANE, not the output) ─────
+#
+# The gather key historically recorded, per STATE lane, `Δ = slot − oln` — the
+# lane's slot relative to the OUTPUT cell's slot. That is the right key only for
+# a gather from an array laid out exactly like the output: a Cartesian stencil
+# neighbour. It is the WRONG key for a gather whose array has a DIFFERENT shape
+# from the output's — a lower-rank geometry column (`coslat_e[j]` read from an
+# (i,j,k) loop), a staggered face field (`Mx` on (NLON+1, NLAT, NLEV)), a 2-D
+# surface field. Those slots are perfectly affine in the loop indices, but with
+# their OWN strides, so `Δ` moves at every cell and the signature reads a
+# transition where there is none. Two costs follow, both O(grid):
+#
+#   * the edge-inward cut scan never stabilises (the key changes at every cell),
+#     so it walks the whole half-range of every axis instead of stopping after
+#     `_AFFINE_STABLE_GUARD` cells — the scan becomes O(axis length);
+#   * every scanned axis is cut into segments up to the `_AFFINE_MAX_DELTA_SEGS`
+#     cap, so the box count grows with the grid and every per-box cost
+#     (branch key, corner verification, lane derivation, spine memo key) is paid
+#     once per box.
+#
+# The fix keys each lane by its SUBSCRIPTS' own local behaviour instead: a
+# subscript that is STRUCTURALLY affine in the loop indices (`+ - neg *` over
+# loop names and integer literals) can never open a cut and is skipped outright,
+# and any other subscript contributes its per-dim BACKWARD DIFFERENCE
+# `v(loop) − v(loop − e_d)`. That difference is constant wherever the subscript
+# is affine — no cut, at any grid size — and changes exactly at the cell where a
+# clamp / fold / wrap engages, which is exactly where the box processor's corner
+# verification would fail. It is reference-free by construction: keying the
+# deviation from an affine model derived at some probe cell silently poisons the
+# scan whenever that probe sits on the clamped side of the transition being
+# looked for. Ghost membership (a state slot resolving to 0) keeps its own bit,
+# as before. `ESS_LANE_AFFINE_KEY_DISABLE=1` restores the Δ-keyed signature byte
+# for byte.
+_lane_affine_key_disabled() = get(ENV, "ESS_LANE_AFFINE_KEY_DISABLE", "") == "1"
+
+# Is this subscript expression an AFFINE function of the loop indices — a sum of
+# integer literals and loop-index terms with integer coefficients? Such an
+# expression cannot deviate from its own affine model at ANY cell, so it can
+# never open a cut and never has to be evaluated for the signature. Everything
+# else (a clamp `max(k-1,1)`, a fold, a `mod`, a gather through a const table, a
+# division, a registered function) is classified NON-affine and DOES get its
+# per-cell deviation keyed. Conservative in the safe direction: mis-classifying
+# an affine expression as non-affine only costs a per-cell evaluation, while the
+# reverse is impossible -- the recognizer admits nothing but `+ - neg *`.
+function _affine_idx_expr(e::ASTExpr, idxset)::Bool
+    e isa IntExpr && return true
+    e isa NumExpr && return (e::NumExpr).value == round((e::NumExpr).value)
+    e isa VarExpr && return ((e::VarExpr).name in idxset)
+    e isa OpExpr || return false
+    o = e::OpExpr
+    (o.ranges === nothing && o.output_idx === nothing && o.bindings === nothing &&
+     o.expr_body === nothing && o.lower === nothing && o.upper === nothing &&
+     o.filter === nothing && o.key === nothing && o.values === nothing) || return false
+    if o.op == "+" || o.op == "-"
+        return all(a -> _affine_idx_expr(a, idxset), o.args)
+    elseif o.op == "neg"
+        return length(o.args) == 1 && _affine_idx_expr(o.args[1], idxset)
+    elseif o.op == "*"
+        nvar = 0
+        for a in o.args
+            _affine_idx_expr(a, idxset) || return false
+            _const_idx_expr(a, idxset) || (nvar += 1)
+        end
+        return nvar <= 1
+    end
+    return false
+end
+# Loop-index-free (hence constant over the loop) -- the multiplication guard.
+function _const_idx_expr(e::ASTExpr, idxset)::Bool
+    e isa IntExpr && return true
+    e isa NumExpr && return true
+    e isa VarExpr && return !((e::VarExpr).name in idxset)
+    e isa OpExpr || return false
+    return all(a -> _const_idx_expr(a, idxset), (e::OpExpr).args)
+end
+
+# Classify (and cache) one branch's lane subscripts: `true` for an argument that
+# is NOT structurally affine in the loop indices and therefore has to be
+# differenced per keyed cell, `false` for one that can never open a cut. Once per
+# branch; the classification is a property of the EXPRESSION, not of any cell,
+# so no reference point is involved (an earlier version derived an affine model
+# at a reference cell and keyed the deviation from it — which silently poisons
+# the scan when the reference happens to sit on the clamped side of the very
+# transition being looked for, and then keys a change at EVERY cell).
+function _lane_nonaffine_args!(sig::_AffineSig, bkey::String,
+                               recipes::Vector{_LaneRecipe}, idxset)
+    cached = get(sig.lane_ref, bkey, nothing)
+    cached === nothing || return cached
+    ref = Vector{Vector{Bool}}(undef, length(recipes))
+    for k in eachindex(recipes)
+        rec = recipes[k]
+        ref[k] = Bool[!_affine_idx_expr(a, idxset) for a in rec.idx_args]
+    end
+    sig.lane_ref[bkey] = ref
+    return ref
+end
 
 @inline _set_env!(env, idx_names, loop) =
     (for d in eachindex(idx_names); env[idx_names[d]] = loop[d]; end; env)
@@ -311,11 +415,51 @@ function _cell_ckey!(sig::_AffineSig, loop, idx_names, body, ctx_proto,
         @inbounds for v in state_vals
             print(io, v == 0 ? '1' : '0')
         end
-    else
+    elseif _lane_affine_key_disabled()
         base, strides = okey
         oln = _box_oln(base, strides, loop, length(idx_names))
         @inbounds for v in state_vals
             v == 0 ? print(io, "G,") : print(io, v - oln, ',')
+        end
+    else
+        # LANE-AFFINE key (see `_lane_affine_ref!`): the ghost pattern, then
+        # every lane subscript's DEVIATION from its own affine model of the loop
+        # indices. Zero wherever the lane is affine — at any grid size — so a
+        # cross-shape gather (lower-rank geometry, staggered face, surface
+        # field) stops manufacturing a cut at every cell.
+        @inbounds for v in state_vals
+            print(io, v == 0 ? '1' : '0')
+        end
+        print(io, '|')
+        ref = _lane_nonaffine_args!(sig, bkey, recipes, ctx_proto.idxset)
+        D = length(idx_names)
+        ca = ctx_proto.const_arrays
+        back = sig.back_scratch
+        resize!(back, D)
+        @inbounds for k in eachindex(recipes)
+            rk = ref[k]
+            (isempty(rk) || !any(rk)) && continue
+            rec = recipes[k]
+            for m in eachindex(rk)
+                rk[m] || continue                  # structurally affine: no cut, ever
+                a = rec.idx_args[m]
+                v = _eval_const_int(a, env, ca)
+                # LOCAL BACKWARD DIFFERENCE per dim: constant wherever the
+                # subscript is affine, and changing exactly at the cell where a
+                # clamp / fold / wrap engages. Reference-free, so no probe point
+                # can poison it. `loop − e_d` may leave the range; a subscript is
+                # a total integer function of the loop, so evaluating there is
+                # always safe (unlike a slot, which can be a ghost).
+                print(io, k, ':')
+                for d in 1:D
+                    @inbounds for dd in 1:D; back[dd] = loop[dd]; end
+                    back[d] = loop[d] - 1
+                    vb = _eval_const_int(a, _set_env!(env, idx_names, back), ca)
+                    print(io, v - vb, ',')
+                end
+                _set_env!(env, idx_names, loop)    # restore for the next lane
+                print(io, ';')
+            end
         end
     end
     _const_fold_key!(io, recipes, env, ctx_proto.const_arrays)
@@ -645,6 +789,67 @@ function _ak_tbl_log!(kind::Symbol, rec::_LaneRecipe, len::Int)
     return nothing
 end
 
+# ── LANE-AFFINE STATE BOX (a state gather on its OWN grid) ────────────────
+#
+# `_AK_STATE_AFFINE` models `u[oln + Δ]` — a gather from an array laid out
+# EXACTLY like the output, which is every Cartesian stencil neighbour. It does
+# not model a gather whose array has a DIFFERENT shape: a lower-rank geometry
+# column (`coslat_e[j]` read from an (i,j,k) loop), a staggered face field on
+# (NLON+1, NLAT, NLEV), a 2-D surface field. Those slots are affine in the loop
+# indices too, but with the ARRAY's own strides, so `Δ` is not constant and the
+# derivation below fell through to a dense per-box slot table — one
+# `_eval_recipe` and one stored `Int` per box CELL, per lane. On ReSEACT
+# transport that is the single largest grid-dependent term in the build
+# (4.49 M table entries at 18x12x72 — 289 per cell — all of them state gathers
+# of exactly this shape).
+#
+# The const and live-forcing branches already have the right descriptor for
+# this: `_AccConstBox` / `_AccForcingBox` address their own grid as
+# `off + Σ(midx_d−1)·s_d`. `_AccStateTblBox` has the same addressing, and its
+# `conn` table only has to map that address to a slot — so a lane whose slot is
+# affine in the loop needs no per-cell table at all: it needs the strides, and a
+# table that is the IDENTITY over the variable's own slot block. That block is
+# one dense contiguous run per array variable (`_enumerate_array_cell_names`
+# lays cells out column-major, contiguously), it is shared by every lane, every
+# box and every equation of the build through the pool below, and it is the same
+# size as the variable — never O(#cells) per lane.
+#
+# `ESS_STATE_BOX_DISABLE=1` restores the dense per-box table byte for byte.
+_state_box_disabled() = get(ENV, "ESS_STATE_BOX_DISABLE", "") == "1"
+
+# Build-scoped, mirroring `_LANE_INTERN_POOL`: installed in
+# `_build_evaluator_impl`, torn down in its `finally`. `nothing` outside a build
+# (or under the kill switch) simply means the table is not shared.
+const _STATE_SLOT_TBL_POOL =
+    Base.RefValue{Union{Nothing,Dict{Tuple{String,Int,Int},Vector{Int}}}}(nothing)
+
+function _state_slot_identity(var_name::String, lo0::Int, hi0::Int)
+    pool = _STATE_SLOT_TBL_POOL[]
+    pool === nothing && return collect(lo0:hi0)
+    return get!(() -> collect(lo0:hi0), pool, (var_name, lo0, hi0))
+end
+
+# The variable's own contiguous slot block, from the affine slot map the recipe
+# already carries (`rec.affine`, corner-verified against `var_map` in
+# `_derive_var_affine`) and its `array_var_info` bounds. Strides are the
+# column-major products of the extents, so all-positive; the block runs from the
+# `lo` corner to the `hi` corner.
+function _state_slot_block(rec::_LaneRecipe)
+    aff = rec.affine
+    aff === nothing && return nothing
+    base, strides = aff
+    n = length(rec.lo)
+    (n == length(rec.hi) && n == length(strides)) || return nothing
+    lo0 = base; hi0 = base
+    @inbounds for d in 1:n
+        strides[d] >= 0 || return nothing
+        lo0 += rec.lo[d] * strides[d]
+        hi0 += rec.hi[d] * strides[d]
+    end
+    (lo0 >= 1 && hi0 >= lo0) || return nothing
+    return (lo0, hi0)
+end
+
 # Materialize a NON-AFFINE state lane as a per-box slot table (Stage 2 of the
 # array-IR unification): one `_eval_recipe` per box cell — the SAME resolution
 # the per-cell fallback would run — stored densely in box-local layout, with 0
@@ -763,13 +968,63 @@ function _derive_lane_repl(rec::_LaneRecipe, idx_names, rep, corners, thin,
             return _LitRepl(0.0)
         end
         Δ = slot_rep - oln_rep
+        uniform = true
         for cn in corners
             sc = ev(cn)
-            (sc != 0 && sc - _box_oln(base, strides, cn, D) == Δ) ||
-                return _materialize_state_tbl(rec, idx_names, box, D,
-                                              var_map, const_arrays)
+            if !(sc != 0 && sc - _box_oln(base, strides, cn, D) == Δ)
+                uniform = false
+                break
+            end
         end
-        return _AccRepl(_AccStateAffine(Δ))
+        uniform && return _AccRepl(_AccStateAffine(Δ))
+        # Not at a constant offset from the output slot. Before paying for a
+        # dense per-box table, try the lane's OWN affine map (see the LANE-AFFINE
+        # STATE BOX note above): finite-difference the slot across a unit step in
+        # each non-thin dim, then VERIFY at every corner — the same derivation
+        # and the same verification standard the const / live-forcing branches
+        # below use. A ghost anywhere in the probe or the corners declines (the
+        # table's per-cell 0 sentinel is what models a ghost).
+        if !_state_box_disabled()
+            blk = _state_slot_block(rec)
+            if blk !== nothing
+                lo0, hi0 = blk
+                ls = zeros(Int, 3)
+                ok = lo0 <= slot_rep <= hi0
+                if ok
+                    for d in 1:D
+                        thin[d] && continue
+                        l2 = copy(rep); l2[d] += 1
+                        v2 = ev(l2)
+                        if v2 == 0
+                            ok = false
+                            break
+                        end
+                        ls[d] = v2 - slot_rep
+                    end
+                end
+                if ok
+                    o = slot_rep - lo0 + 1
+                    @inbounds for d in 1:D
+                        o -= (rep[d] - 1) * ls[d]
+                    end
+                    for cn in corners
+                        sc = ev(cn)
+                        a = o
+                        @inbounds for d in 1:D
+                            a += (cn[d] - 1) * ls[d]
+                        end
+                        if !(sc != 0 && 1 <= a <= (hi0 - lo0 + 1) && lo0 + a - 1 == sc)
+                            ok = false
+                            break
+                        end
+                    end
+                end
+                ok && return _AccRepl(_AccStateTblBox(
+                    _state_slot_identity(rec.var_name, lo0, hi0),
+                    ls[1], ls[2], ls[3], o))
+            end
+        end
+        return _materialize_state_tbl(rec, idx_names, box, D, var_map, const_arrays)
     elseif rec.kind == LANE_LOOPLIT
         dim = findfirst(==(rec.loop_name), idx_names)
         dim === nothing && throw(_StencilFallback("loop-lit name not an output index"))

--- a/pkg/EarthSciAST.jl/src/tree_walk/stencil_affine.jl
+++ b/pkg/EarthSciAST.jl/src/tree_walk/stencil_affine.jl
@@ -396,7 +396,8 @@ function _cell_bkey!(sig::_AffineSig, loop, idx_names, body, ctx_proto,
 end
 function _cell_ckey!(sig::_AffineSig, loop, idx_names, body, ctx_proto,
                      var_map, param_sym_set, reg_funcs,
-                     okey::Union{Nothing,Tuple{Int,Vector{Int}}}=nothing)
+                     okey::Union{Nothing,Tuple{Int,Vector{Int}}}=nothing,
+                     ranges::Union{Nothing,Vector{UnitRange{Int}}}=nothing)
     bkey, branch = _cell_bkey!(sig, loop, idx_names, body, ctx_proto,
                                var_map, param_sym_set, reg_funcs)
     env = ctx_proto.idx_env    # left populated with `loop` by _cell_bkey! (branch_key restores its temp binds)
@@ -453,7 +454,16 @@ function _cell_ckey!(sig::_AffineSig, loop, idx_names, body, ctx_proto,
                 print(io, k, ':')
                 for d in 1:D
                     @inbounds for dd in 1:D; back[dd] = loop[dd]; end
-                    back[d] = loop[d] - 1
+                    # CLAMPED to the dim's own range. A subscript is NOT a total
+                    # function of an out-of-range loop point: an unstructured
+                    # gather (`index(cells_on_cell, i, n)`) resolves through a
+                    # const array and throws `E_TREEWALK_CONSTARRAY_OOB` at
+                    # `i = lo − 1`. At `lo` the difference degenerates to 0 for
+                    # every lane, which costs nothing: `lo` is a segment start
+                    # unconditionally, and the scan compares `lo` only against
+                    # `lo + 1`.
+                    back[d] = ranges === nothing ? loop[d] - 1 :
+                              max(first(ranges[d]), loop[d] - 1)
                     vb = _eval_const_int(a, _set_env!(env, idx_names, back), ca)
                     print(io, v - vb, ',')
                 end
@@ -633,7 +643,7 @@ function _scan_dim_cuts(sig::_AffineSig, body, idx_names, ranges, ctx_proto,
     loop = Vector{Int}(undef, D)
     ck(iv) = (loop[d] = iv;
               (_cell_ckey!(sig, loop, idx_names, body, ctx_proto,
-                           var_map, param_sym_set, reg_funcs, okey))[2])
+                           var_map, param_sym_set, reg_funcs, okey, ranges))[2])
     # Region boundaries in this dim, kept only where they open a real segment
     # (lo < C ≤ hi). Each is confirmed below by comparing C-1 to C.
     cand_d = sort!(Int[c for c in region_cands[d] if lo < c <= hi])

--- a/pkg/EarthSciAST.jl/src/tree_walk/stencil_affine.jl
+++ b/pkg/EarthSciAST.jl/src/tree_walk/stencil_affine.jl
@@ -423,7 +423,7 @@ function _cell_ckey!(sig::_AffineSig, loop, idx_names, body, ctx_proto,
             v == 0 ? print(io, "G,") : print(io, v - oln, ',')
         end
     else
-        # LANE-AFFINE key (see `_lane_affine_ref!`): the ghost pattern, then
+        # LANE-AFFINE key (see `_lane_nonaffine_args!`): the ghost pattern, then
         # every lane subscript's DEVIATION from its own affine model of the loop
         # indices. Zero wherever the lane is affine — at any grid size — so a
         # cross-shape gather (lower-rank geometry, staggered face, surface
@@ -808,10 +808,8 @@ end
 # (NLON+1, NLAT, NLEV), a 2-D surface field. Those slots are affine in the loop
 # indices too, but with the ARRAY's own strides, so `Δ` is not constant and the
 # derivation below fell through to a dense per-box slot table — one
-# `_eval_recipe` and one stored `Int` per box CELL, per lane. On ReSEACT
-# transport that is the single largest grid-dependent term in the build
-# (4.49 M table entries at 18x12x72 — 289 per cell — all of them state gathers
-# of exactly this shape).
+# `_eval_recipe` and one stored `Int` per box CELL, per lane, which is the
+# build's largest grid-dependent term on a transport model.
 #
 # The const and live-forcing branches already have the right descriptor for
 # this: `_AccConstBox` / `_AccForcingBox` address their own grid as
@@ -991,10 +989,26 @@ function _derive_lane_repl(rec::_LaneRecipe, idx_names, rep, corners, thin,
         # dense per-box table, try the lane's OWN affine map (see the LANE-AFFINE
         # STATE BOX note above): finite-difference the slot across a unit step in
         # each non-thin dim, then VERIFY at every corner — the same derivation
-        # and the same verification standard the const / live-forcing branches
-        # below use. A ghost anywhere in the probe or the corners declines (the
-        # table's per-cell 0 sentinel is what models a ghost).
-        if !_state_box_disabled()
+        # the const / live-forcing branches below use. A ghost anywhere in the
+        # probe or the corners declines (the table's per-cell 0 sentinel is what
+        # models a ghost).
+        #
+        # GUARD — every subscript must be STRUCTURALLY affine in the output loop
+        # indices. Corner verification alone does NOT license this lowering: a
+        # 2^D-corner check cannot see the interior, and a state subscript can be
+        # arbitrary data (an unstructured `index(conn, i)` gather, whose slot map
+        # is affine at the corners and at `rep + e_d` whenever the connectivity
+        # happens to agree there). The `_derive_var_affine` slot map is affine in
+        # the SUBSCRIPT VALUES, so the composed map is affine in the loop exactly
+        # when the subscripts are — and `_affine_idx_expr` admits nothing but
+        # `+ - neg *` over loop names and integer literals, which is a proof, not
+        # a sample. Anything else keeps the exact per-box table it had before.
+        # (This is the same reasoning the LANE_CONST branch below spells out: its
+        # index affinity holds "BY CONSTRUCTION within a box", not by corner
+        # agreement.) The motivating shapes — a lower-rank geometry column, a
+        # staggered face field, a 2-D surface field — all pass this guard.
+        if !_state_box_disabled() &&
+           all(a -> _affine_idx_expr(a, idx_names), rec.idx_args)
             blk = _state_slot_block(rec)
             if blk !== nothing
                 lo0, hi0 = blk

--- a/pkg/EarthSciAST.jl/test/runtests.jl
+++ b/pkg/EarthSciAST.jl/test/runtests.jl
@@ -131,6 +131,11 @@ include("testutils.jl")  # shared prelude: repo root, AST builders, _normj, _req
     include("scan_prefix_test.jl")                   # ess-scan O(N) prefix reduction ≡ per-cell
     include("stencil_affine_cse_test.jl")            # ess-affine per-cell CSE ≡ per-cell
     include("stencil_affine_invariant_test.jl")      # ess-affine invariant hoist ≡ per-cell
+    # Cross-shape state gather (a state array read from a loop of a DIFFERENT
+    # shape): the cut signature and the box lowering must both stay O(1) in the
+    # grid. Sits next to grid_invariance_test.jl because it pins the same
+    # property on the tier that was violating it.
+    include("stencil_affine_cross_shape_test.jl")
     include("grid_invariance_test.jl")               # compiled IR size is O(1) in the grid
     include("fn_content_cse_test.jl")                # fn specs keyed by CONTENT in per-kernel CSE
     include("array_obs_materialize_test.jl")         # factored array observeds ≡ ESS_ARRAY_OBS_INLINE=1

--- a/pkg/EarthSciAST.jl/test/stencil_affine_cross_shape_test.jl
+++ b/pkg/EarthSciAST.jl/test/stencil_affine_cross_shape_test.jl
@@ -1,0 +1,122 @@
+# CROSS-SHAPE STATE GATHER: a state array read from a loop of a DIFFERENT shape.
+#
+# `_AK_STATE_AFFINE` models `u[oln + Δ]` — a gather from an array laid out
+# exactly like the output. A gather from an array of a different shape (a
+# lower-rank geometry column read from a 2-D/3-D loop, a staggered face field, a
+# surface field) has a slot that is still AFFINE in the loop indices, but with
+# the array's own strides, so `Δ` moves at every cell. Two things followed, both
+# O(#cells):
+#
+#   * the per-cell cut signature keyed state lanes by `Δ`, so it read a
+#     transition at every cell — the edge-inward scan never stabilised and every
+#     axis was cut into segments up to the `_AFFINE_MAX_DELTA_SEGS` cap, making
+#     the BOX COUNT grow with the grid;
+#   * `_derive_lane_repl` then could not prove the lane uniform over its box and
+#     materialised a DENSE per-box slot table — one `_eval_recipe` and one stored
+#     `Int` per box CELL, per lane.
+#
+# The fix keys the lane by its own subscripts' deviation from affinity (which is
+# identically zero for an affine subscript, at any grid size) and lowers it to
+# `_AccStateTblBox` addressed through the variable's own IDENTITY slot block —
+# shared across every lane, box and equation of the build.
+#
+# This pins BOTH halves as grid-independent, and pins numeric equality against
+# the two kill switches (`ESS_LANE_AFFINE_KEY_DISABLE=1`, `ESS_STATE_BOX_DISABLE=1`)
+# which restore the pre-fix build.
+using Test
+using EarthSciAST
+include("testutils.jl")
+const ESM_CS = EarthSciAST
+
+# D(a[j])   = 0                          — a 1-D column, extent N
+# D(u[i,j]) = a[j] * u[i,j]              — a 2-D field, extent N×N
+# `a[j]` read from the (i,j) loop is the cross-shape gather: slot(a[j]) is
+# affine in `j` alone while the output slot moves with both `i` and `j`.
+function _cs_model(N)
+    vars = Dict{String,ESM_CS.ModelVariable}(
+        "a" => ESM_CS.ModelVariable(ESM_CS.UnknownVariable),
+        "u" => ESM_CS.ModelVariable(ESM_CS.UnknownVariable))
+    ao2(body, lhs) = ESM_CS.OpExpr("arrayop", ESM_CS.ASTExpr[];
+        output_idx = Any["i", "j"], expr_body = body,
+        ranges = Dict("i" => [1, N], "j" => [1, N]))
+    ESM_CS.Model(vars, [
+        ESM_CS.Equation(_ao1(_Didx("a", _v("j")), "j", 1, N),
+                        _ao1(_n(0.0), "j", 1, N)),
+        ESM_CS.Equation(ao2(_Didx("u", _v("i"), _v("j")), nothing),
+                        ao2(_op("*", _idx("a", _v("j")),
+                                     _idx("u", _v("i"), _v("j"))), nothing))])
+end
+
+function _cs_build(N)
+    ics = Dict{String,Float64}()
+    for j in 1:N
+        ics["a[$j]"] = 0.5 + 0.1j
+        for i in 1:N
+            ics["u[$i,$j]"] = sin(0.3i) + 0.2j
+        end
+    end
+    ESM_CS._reset_cascade_tally!()
+    f, u0, p, _t, vm, diag = ESM_CS._build_evaluator_impl(_cs_model(N);
+        initial_conditions = ics)
+    du = zero(u0); f(du, u0, p, 0.0)
+    ks = getfield(getfield(f, :kernel_section), :kernels)
+    (u0 = u0, du = du, diag = diag, kernels = ks,
+     tally = copy(ESM_CS._CASCADE_TALLY),
+     n_kernels = length(ks),
+     conn_entries = sum(sum(length(d.conn) for d in K.acc; init = 0)
+                        for K in ks; init = 0))
+end
+
+# `kernel_section.kernels` is complete only with the codegen tier off (the
+# oop_merge/xcse idiom used by grid_invariance_test.jl).
+_cs_run(N) = withenv("ESS_CODEGEN_DISABLE" => "1") do; _cs_build(N); end
+_cs_run_pre(N) = withenv("ESS_CODEGEN_DISABLE" => "1",
+                         "ESS_LANE_AFFINE_KEY_DISABLE" => "1",
+                         "ESS_STATE_BOX_DISABLE" => "1") do; _cs_build(N); end
+
+@testset "cross-shape state gather is grid-independent" begin
+    N1, N2 = 8, 24
+    A = _cs_run(N1)
+    B = _cs_run(N2)
+
+    @testset "both array equations took the affine tier" begin
+        @test get(A.tally, :affine, 0) == 2
+        @test get(A.tally, :percell_acc, 0) == 0
+        @test A.tally == B.tally
+    end
+
+    @testset "the box count does not grow with the grid" begin
+        @test A.n_kernels == B.n_kernels
+    end
+
+    @testset "no per-cell slot table: descriptor tables stay small" begin
+        # Pre-fix this was one `Int` per box CELL per cross-shape lane, i.e.
+        # Θ(N²); with the identity slot block it is Θ(N) (the `a` column) and
+        # the same object is shared, so the 3× grid must not be 9× the table.
+        @test B.conn_entries <= 4 * A.conn_entries
+        @test B.conn_entries < N2 * N2
+    end
+
+    @testset "RHS is bit-identical to the pre-fix build" begin
+        for N in (N1, N2)
+            post = _cs_run(N)
+            pre  = _cs_run_pre(N)
+            @test post.du == pre.du
+            @test all(isfinite, post.du)
+        end
+    end
+
+    @testset "the values are right" begin
+        # du[u[i,j]] = a[j]·u[i,j]; du[a[j]] = 0
+        vm = ESM_CS._build_evaluator_impl(_cs_model(N1);
+                initial_conditions = Dict("a[1]" => 0.0))[5]
+        for j in 1:N1, i in 1:N1
+            aj = 0.5 + 0.1j
+            uij = sin(0.3i) + 0.2j
+            @test A.du[vm["u[$i,$j]"]] ≈ aj * uij
+        end
+        for j in 1:N1
+            @test A.du[vm["a[$j]"]] == 0.0
+        end
+    end
+end

--- a/pkg/EarthSciAST.jl/test/stencil_affine_cross_shape_test.jl
+++ b/pkg/EarthSciAST.jl/test/stencil_affine_cross_shape_test.jl
@@ -120,3 +120,59 @@ _cs_run_pre(N) = withenv("ESS_CODEGEN_DISABLE" => "1",
         end
     end
 end
+
+# The lane-affine STATE BOX is licensed by a PROOF, not by a sample.
+#
+# `_derive_lane_repl` verifies a derived affine slot map at the 2^D box corners
+# and at `rep + e_d`. That is a sample of 2^D + D cells; it cannot see the box
+# interior. A state subscript may be arbitrary data — an unstructured
+# `index(conn, i)` gather — so agreement at the corners says nothing about the
+# cells between them, exactly as the `LANE_CONST` branch's comment says of the
+# value fold it removed for the same reason.
+#
+# The guard is that every subscript is STRUCTURALLY affine in the output loop
+# indices (`_affine_idx_expr`), which is a property of the expression and holds
+# at every cell. This pins it: a CROSS-SHAPE gather (so the Δ test fails and the
+# state-box branch is reached) whose connectivity is the identity except for one
+# swapped INTERIOR cell — affine at every corner and at `rep + e_d`, and far
+# enough from both ends that `_AFFINE_STABLE_GUARD` retires the cut scan before
+# it gets there. Without the guard the interior cell reads the wrong slot,
+# silently, with no error and no fallback.
+@testset "cross-shape state box is not licensed by corner agreement" begin
+    N, i0 = 40, 20
+    perm = collect(1:N); perm[i0] = i0 + 1        # identity but for one swap
+    vars = Dict{String,ESM_CS.ModelVariable}(
+        "w" => ESM_CS.ModelVariable(ESM_CS.UnknownVariable),
+        "u" => ESM_CS.ModelVariable(ESM_CS.UnknownVariable))
+    ao2(body) = ESM_CS.OpExpr("arrayop", ESM_CS.ASTExpr[];
+        output_idx = Any["i", "j"], expr_body = body,
+        ranges = Dict("i" => [1, N], "j" => [1, N]))
+    model = ESM_CS.Model(vars, [
+        ESM_CS.Equation(_ao1(_Didx("w", _v("i")), "i", 1, N),
+                        _ao1(_n(0.0), "i", 1, N)),
+        ESM_CS.Equation(ao2(_Didx("u", _v("i"), _v("j"))),
+                        ao2(_idx("w", _idx("conn", _v("i")))))])
+    ics = Dict{String,Float64}()
+    for k in 1:N
+        ics["w[$k]"] = 10.0k
+        for j in 1:N; ics["u[$k,$j]"] = 0.0; end
+    end
+    ca = Dict("conn" => Float64.(perm))
+
+    ev(envs...) = withenv(envs...) do
+        f, u0, p, _t, vm, _d = ESM_CS._build_evaluator_impl(model;
+            initial_conditions = ics, const_arrays = ca)
+        du = fill(NaN, length(u0)); f(du, u0, p, 0.0)
+        (du = du, vm = vm, u0 = u0)
+    end
+
+    got = ev()
+    ref = ev("ESS_STENCIL_DISABLE" => "1")        # forced per-cell walk
+    @test got.du == ref.du
+    # ... and spelled out around the swap, so a failure names the cell rather
+    # than a whole vector (`i0` is the wrong one; its neighbours are the
+    # control that the rest of the box is still right).
+    for i in (i0 - 1, i0, i0 + 1), j in (1, N)
+        @test got.du[got.vm["u[$i,$j]"]] == got.u0[got.vm["w[$(perm[i])]"]]
+    end
+end

--- a/pkg/EarthSciAST.jl/test/stencil_affine_pgather_tbl_test.jl
+++ b/pkg/EarthSciAST.jl/test/stencil_affine_pgather_tbl_test.jl
@@ -26,7 +26,15 @@ function _pgt_build3(model, ics, bufs)
     out = Dict{Symbol,Any}()
     for (tag, envs) in (
             (:tbl, ("ESS_OBSREF_DISABLE" => nothing, "ESS_STENCIL_DISABLE" => nothing)),
-            (:off, ("ESS_OBSREF_DISABLE" => "1", "ESS_STENCIL_DISABLE" => nothing)),
+            # `ESS_OBSREF_DISABLE=1` alone no longer forces the whole-equation
+            # decline: with the LANE-AFFINE signature the clamp transition opens
+            # a box cut of its own, so the forcing subscript is affine WITHIN
+            # each box and the equation stays on the affine path with no table
+            # at all. The oracle needs a genuinely divergent second path, so the
+            # `:off` arm restores the Δ-keyed signature too — which is exactly
+            # the build this switch was written against.
+            (:off, ("ESS_OBSREF_DISABLE" => "1", "ESS_STENCIL_DISABLE" => nothing,
+                    "ESS_LANE_AFFINE_KEY_DISABLE" => "1")),
             (:ref, ("ESS_OBSREF_DISABLE" => nothing, "ESS_STENCIL_DISABLE" => "1")))
         withenv(envs...) do
             ESM._reset_cascade_tally!()
@@ -107,6 +115,14 @@ function _pgt_oracle(model, ics, bufs; refresh!)
     @test get(b[:tbl][4], :affine, 0) >= 1
     @test get(b[:tbl][4], :percell_acc, 0) == 0
     @test get(b[:off][4], :percell_acc, 0) >= 1
+    # And with the lane-affine signature on, the table is not merely optional —
+    # a clamped forcing subscript needs NO per-box table, because the clamp
+    # transition is a box cut. (`_AK_TBL_LOG` counts every table materialised.)
+    withenv("ESS_AK_TBL_DEBUG" => "1") do
+        ESM._reset_ak_tbl_log!()
+        ESM._build_evaluator_impl(model; initial_conditions=ics, param_arrays=bufs)
+        @test sum(v[2] for v in values(ESM._AK_TBL_LOG); init=0) == 0
+    end
     du = Dict(tag => _pgt_eval(b[tag]) for tag in (:tbl, :off, :ref))
     @test du[:tbl] == du[:ref]
     @test du[:off] == du[:ref]


### PR DESCRIPTION
#273 made the node-lowering count grid-independent; it did not move build wall
time. This is why. #273 is now merged, so this PR's diff is its own three commits.

## The gap

`_AK_STATE_AFFINE` models `u[oln + Δ]` — a gather from an array laid out exactly
like the output. Every Cartesian stencil neighbour is that shape. A gather whose
array has a **different** shape is not:

* a lower-rank geometry column — `coslat_e[j]`, `dS_lat[j]`, `dphi_lat[j±n]` read
  from an `(i, j, k)` loop;
* a staggered face field — `Mx` on `(NLON+1, NLAT, NLEV)` against a state on
  `(NLON, NLAT, NLEV)`;
* a 2-D surface field — `PS[i,j]`, `pbl_wt[i,j]`.

Their slots are still perfectly affine in the loop indices, but with the
**array's own strides**, so `Δ = slot − oln` moves at every cell and the affine
tier reads a transition where there is none. `_AK_CONST_BOX` and
`_AK_FORCING_BOX` exist precisely because a const array or a forcing buffer lives
on its own grid; there is no state counterpart, so two O(grid) costs follow:

1. **The cut signature.** `_cell_ckey!` keyed state lanes by `Δ`. With `Δ` moving
   at every cell the edge-inward scan never stabilises — it walks the whole
   half-range of every axis instead of stopping after `_AFFINE_STABLE_GUARD`
   cells — and every axis is cut into segments up to the
   `_AFFINE_MAX_DELTA_SEGS` cap. The **box count grows with the grid**, and every
   per-box cost (branch key, corner verification, lane derivation, spine memo
   key) is paid once per box.
2. **The box lowering.** `_derive_lane_repl` then cannot prove the lane uniform
   over its box and materialises a **dense per-box slot table** — one
   `_eval_recipe` and one stored `Int` per box CELL, per lane. On a transport
   model, `ESS_AK_TBL_DEBUG=1` says every table entry is a state gather of
   exactly this shape.

## The fix

Two changes, each with a kill switch that restores the previous build byte for
byte.

**1. Lane-affine signature** (`ESS_LANE_AFFINE_KEY_DISABLE=1`). A subscript that
is *structurally* affine in the loop indices (`+ - neg *` over loop names and
integer literals) can never open a cut and is skipped outright — so the common
lane costs **less** than it did under the Δ key. Any other subscript contributes
its per-dim **backward difference** `v(loop) − v(loop − e_d)`, which is constant
wherever the subscript is affine and changes exactly at the cell where a clamp /
fold / wrap engages — exactly where the box processor's corner verification would
fail. Ghost bits are unchanged. The difference is reference-free by construction:
keying the *deviation from an affine model derived at a probe cell* silently
poisons the scan whenever that probe sits on the clamped side of the very
transition being looked for (it then keys a change at every cell, and past
`_AFFINE_MAX_DELTA_SEGS` the scan falls back to the base key and tables the lane
anyway — which is how `stencil_affine_pgather_tbl_test.jl` caught it at N=32).

**2. Lane-affine state box** (`ESS_STATE_BOX_DISABLE=1`). Before paying for a
per-box table, derive the lane's own affine map by finite differences and verify
it at every corner — the same derivation the const and live-forcing branches
already use — then lower it through the **existing** `_AccStateTblBox`
descriptor, addressed by an *identity* table over the variable's own contiguous
slot block. That block is the size of the **variable**, not of the grid, and one
object is shared by every lane, box and equation of the build
(`_STATE_SLOT_TBL_POOL`, installed and torn down exactly like
`_LANE_INTERN_POOL`). No new descriptor kind, so no runner, codegen, oop-merge or
Reactant-extension change.

**3. The guard that makes (2) sound** (review commit, see below).

## Effect on the build

Stated as properties, not as timings:

* the box count and the `_cell_ckey!` call count **stop growing with the grid**;
* **no** per-box slot table is materialised for a cross-shape state lane at all;
* the previous build was not even **monotone** in the grid — an axis was cut per
  index only while its length stayed under `_AFFINE_MAX_DELTA_SEGS`, so a small
  grid whose two horizontal axes both qualified cut more boxes than a larger one
  that did not — and the new one is;
* the interpreted RHS is unchanged.

The build is **not** yet O(1) in the grid. With box count, `_cell_ckey!` count,
spine-template count and node lowerings all flat, the residual is no longer a
per-cell algorithm: it is the cost of the same fixed work in a process whose live
heap grows with the grid (the per-lane descriptor data `grid_invariance_test.jl`
explicitly permits to grow linearly), a large fraction of which is GC. Making the
out-of-place plan's affine descriptor vectors lazy is the next lever, and is not
attempted here.

## Bit-identity

`sha256(du)` at the build's own base point is **identical** to the kill-switch
build for **both** ReSEACT split parts at every grid tested, with
`_BENCH_COMPILE_CALLS` unchanged at every grid.

`test/stencil_affine_cross_shape_test.jl` pins the property on a minimal model
(`D(u[i,j]) = a[j]·u[i,j]` — a 1-D column read from a 2-D loop): the cascade
tally and kernel count are grid-independent, descriptor tables do not grow with
the cell count, and the RHS equals the kill-switch build's. It fails with the
switches on.

`test/stencil_affine_pgather_tbl_test.jl`'s A2 differential oracle needed one
adjustment. `ESS_OBSREF_DISABLE=1` alone no longer forces the whole-equation
decline, because the clamp transition now opens a box cut of its own and the
forcing subscript is affine *within* each box. The `:off` arm therefore restores
the Δ-keyed signature too — the build that switch was written against — and the
file gains an assertion that with the lane-affine key on, a clamped forcing
subscript needs **no** per-box table at all.

## `fix(affine)`: clamp the lane-key backward probe

A subscript is a total function of the loop only when it is *arithmetic*: an
unstructured gather resolves its subscript through a const connectivity array
(`index(cells_on_cell, i, n)`), and evaluating that at `i = lo − 1` throws
`E_TREEWALK_CONSTARRAY_OOB`. Three tests caught it — both mesh reductions in
`tree_walk_arrayop_test.jl` and the slot-table kernel in
`access_kernel_foundation_test.jl` — none of them on a structured grid. At `lo`
the clamped difference degenerates to `0` for every lane, which costs nothing:
`lo` is a segment start unconditionally and the scan compares it only against
`lo + 1`.

## `fix(affine)`: corner agreement does not license the lane-affine state box

**Found in review; change (2) as first written returned silently wrong numbers.**

Change (2) verified its derived affine slot map at the 2^D box corners plus D
unit-step probes. That is a sample of `2^D + D` cells and cannot see the box
interior, and **esm-spec §4.3.3 states outright that "Non-affine index
expressions are legal"** — a state subscript may resolve through arbitrary
connectivity data. Reproducer:

```
w : 1-D state, extent N = 40           # the gathered array — DIFFERENT shape
u : 2-D state, (N, N)                  # the output loop
conn : const array, conn[i] = i for every i EXCEPT conn[20] = 21
D(w[i])   = 0
D(u[i,j]) = w[index(conn, i)]
```

The gather is cross-shape, so the `Δ` test fails and the new branch runs. The
finite difference gives stride 1 and the model matches at **every** corner
(i = 1 and i = 40 are both unswapped), so the lane lowers to `_AccStateTblBox`.
The cut scan does not rescue it: the backward-difference key changes only at
i = 20 and i = 21, `_AFFINE_STABLE_GUARD = 8` retires the edge-inward scan long
before it reaches the middle, and the swap is not a makearray region boundary so
it is not a `_region_cut_candidates` probe either. Result: `du[u[20,j]]` reads
`w[20]` where the per-cell reference (and `main`) read `w[21]` — 40 of 1600
output cells wrong, with no error, no diagnostic and no fallback. Reproduced at
(N, i₀) = (40,20), (64,32), (24,12). `ESS_STATE_BOX_DISABLE=1` alone makes it
correct; `ESS_LANE_AFFINE_KEY_DISABLE=1` alone leaves it wrong, so change (2) is
the sole cause.

The guard is the property that holds at every cell rather than at a sample:
every subscript must be **structurally affine** in the output loop indices —
the `_affine_idx_expr` predicate change (1) already computes. Since
`_derive_var_affine`'s slot map is affine in the subscript *values*, the composed
map is affine in the loop exactly when the subscripts are; the same argument
discharges the ghost predicate (a half-space in an affine function, so extremes
are at corners) and the `1 ≤ a ≤ len` table bound. Anything else keeps the exact
per-box table it had. Every motivating shape passes the guard, and the
grid-independence assertions still hold.

`stencil_affine_cross_shape_test.jl` gains the reproducer as a regression test;
with the guard reverted it fails 3 of its 7 assertions.

**Related:** the same construction on a **same-shape** gather is already wrong on
`main` via the older `_AccStateAffine(Δ)` corner check. That is filed as #282 and
is deliberately **not** fixed here — the `uniform &&` branch is the hot path for
every Cartesian stencil neighbour and guarding it would push unstructured gathers
onto the table path, an unmeasured performance change.

## Split out

The `diag(build)` per-phase wall/GC timers that attributed the term have been
removed from this branch: they are instrumentation, not the fix, and they carry
an undecided question about `@_bench` reading the clock unconditionally inside
the per-lane, per-box loop (two clock reads per lane per box, in a default build
that never reads the counters). They are preserved as a standalone commit for a
separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1oPxGtgFJMT46aMZg5xTH
