### PR TITLE
perf(oop): the sub-kernel descriptors were the ue readers, not the ghost gathers

### DIFF
--- a/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
+++ b/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
@@ -180,14 +180,58 @@ fold.
   forcing reads go through the buffers argument, never `ue` — and the
   discrete-cadence refresh stays visible with fill scatters skipped (probed).
 
+## ReSEACT at CONUS: 1.36x on the whole adjoint loop, chemistry exact
+
+Measured 2026-09-09 at 4x5 CONUS (13x7x72, 6 552 cells), two driver builds in
+ONE process, arms interleaved, every pair run in BOTH arm orders — reproducing
+to three digits, so the order is not what is being measured.
+`tools/diag/p13_ssa_ab.jl` + `tools/diag/p11_ue_traffic.py` in the consuming
+repo.
+
+| program | arms off | arms on | off/on | copies | real element writes |
+|---|---|---|---|---|---|
+| `ros_step` (chemistry) | 38.90 ms | 28.23 ms | **1.38** (bit-for-bit) | | |
+| `ros_vjp` | 81.11 ms | 56.71 ms | **1.43** (λ bit-for-bit) | | |
+| `rhs` (transport RHS) | 3.755 ms | 6.405 ms | 0.59 | 2 → 3 | 2.49 M → 2.69 M |
+| `rhs_vjp` | 80.5 ms | 72.2 ms | **1.12** | **98 → 82** | 59.55 M → 55.22 M |
+| `ssp_step` (4-stage) | 13.41 ms | 24.25 ms | 0.55 | 8 → 12 | 10.43 M → 16.97 M |
+| `ssp_vjp` | 306.6 ms | 254.9 ms | **1.20** | **394 → 331** | 231.8 M → 176.3 M |
+
+Weighted by the adjoint's step mix (45.3 chemistry + 3.2 transport steps per
+300 s window) the per-window cost is 6.46 s → 4.74 s, **1.36x**.
+
+WHY THE TRANSPORT FORWARD LOSES. A producer's `dynamic_update_slice` into `ue`
+ALIASES its operand in the FORWARD, so XLA:CPU writes only the update and the
+scatter is nearly free there; skipping it instead forces the producer's value to
+be materialized as its own buffer. On the PPM transport RHS (17 producers,
+blocks up to 3 456 elements) that trade is a loss. On chemistry it is a win in
+both directions, because there the redirect replaces fragmented gathers of the
+12 326-element buffer with gathers of much smaller producer values and 59 of 59
+scatters disappear.
+
+The copies the scatter chain causes are all in the REVERSE, where each `ue`
+version has ~70 live consumers and copy-insertion duplicates the whole buffer
+per version. That is where removing readers pays on both halves: `ssp_vjp`
+loses 63 of its 394 whole-buffer copies and 24% of its write traffic for 1.20x,
+against a ~1.8x ceiling if every copy vanished.
+
+It is also why `ess-oop-levelbase` (one read version per level) failed where
+this succeeds: it reduced VERSIONS, which the forward already got for free,
+instead of removing READERS. Its census went 99 → 102 copies; this one goes
+98 → 82 and 394 → 331.
+
 ## What is NOT verified
 
-The `ESM_TEST_REACTANT=1` traced census (`reactant_oop_ssa_test.jl`) asserts the
-DUS delta equals `n_skipped_scatters` on the toy fixtures; the extension's arms
-are exercised there only insofar as those fixtures engage them. The ReSEACT
-timing A/B and the whole-buffer copy census live in the consuming repo
-(`tools/diag/p13_ssa_ab.jl`, `tools/diag/p11_ue_traffic.py`) because they need
-the offline forcing environment.
+Bit-identity across the arms is asserted and holds on HOST (`==`) and, on the
+toy fixtures, in the traced census (`reactant_oop_ssa_test.jl`, which pins the
+DUS delta to `n_skipped_scatters`). At CONUS the two arms are NOT bit-identical:
+changing the operand graph changes XLA's fusion, hence FMA and vectorization
+order. chemistry `ros_step` is bit-for-bit and `ros_vjp`'s λ is bit-for-bit (its
+p-gradient differs in the 20th significant figure); transport `ssp_step`
+differs by 5.6e-15 pointwise relative. The pointwise metric on the VJPs is
+uninformative — it reads exactly 2.0 on components at ~1e-310 — so the probe
+also reports a scale-relative figure and the count of components over 1e-9 of
+scale.
 
 ## Generalization assessment (honest)
 

--- a/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
+++ b/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
@@ -25,8 +25,24 @@ With the flag on, a consumer descriptor references its producer's RESULT VALUE:
 * **tier 2 (slice)** — the gather decomposes into few consecutive-position runs,
   each inside one producer ⇒ one `slice` per run (+ one `concatenate` when
   more than one run);
+* **tier 2b (producer gather)** — the mapping lies inside ONE producer but
+  shatters into more runs than slices are worth ⇒ one `gather` of that
+  producer's value at producer-local positions. Exactly the single op the dense
+  `ue` gather was, over an index vector of the same length: the win is not op
+  count, it is that the read no longer touches the flat buffer;
 * **tier 3 (fallback)** — everything else keeps the dense gather from `ue`,
   byte-for-byte.
+
+Three descriptor surfaces feed those tiers: a kernel's own top-level
+descriptors, its TEMPLATE SUB-KERNEL (`_NK_SUBCALL`) descriptors — resolved by
+`_build_oop_desc_vectors` against the same parent lanes, so decomposable by the
+same map, but indexed by `S.acc` and therefore carried in a per-sub table — and
+GHOST-MASKED `_AK_STATE_TBL_BOX` descriptors, where a masked lane's value is
+discarded by the emitter's `ifelse` select and is therefore a WILDCARD the
+decomposition fills with whatever continues a neighbouring run. Each of the
+three has a bisect knob (`ESS_OOP_SSA_SUB`, `ESS_OOP_SSA_PGATHER`,
+`ESS_OOP_SSA_GHOST`, all default ON inside `ESS_OOP_SSA=1`), which is what lets
+one process A/B an arm and what each engagement test's negative control flips.
 
 A producer's scatter into `ue` is emitted only when static accounting finds a
 residual reader of its block; otherwise it is skipped and the value flows only
@@ -88,15 +104,51 @@ XLA's optimizer converges the two programs (18 ≡ 18 ops optimized) — at scal
 that convergence is precisely what fails (pairwise slice-CSE went quadratic on
 CONUS; the buffers exceed L3), so the emission-level census is the measure.
 
-## What blocks the rest (tier-3 fallbacks, in expected ReSEACT impact order)
+## Measured on ReSEACT — and the blocker order the spike guessed is WRONG
 
-1. **Ghost-masked `_AK_STATE_TBL_BOX` gathers** (boundary stencils through slot
-   tables with 0-entries). Extension is mechanical: redirect the safe-index
-   gather to producer slices and keep the select-against-mask.
-2. **Sub-kernel (`_NK_SUBCALL`) descriptor plans.** Their tables are resolved
-   against parent lanes but indexed per-sub, so the per-kernel redirect table
-   does not align; needs per-sub redirect tables built in
-   `_build_oop_acc_plan`-style. Mechanical, not conceptual.
+The spike listed its remaining tier-3 fallbacks "in expected ReSEACT impact
+order" and put ghost-masked table gathers first. `oop_ssa_stats` now carries a
+per-reason blocker tally (which read surface still reads each surviving
+producer's block), and on the ReSEACT transport RHS at 6x6x8 it says:
+
+| | spike | + this extension |
+|---|---|---|
+| top-level edges redirected | 51 / 100 | **97 / 100** |
+| top-level elements | 5 292 / 32 148 | **24 948 / 32 148** |
+| SUB-KERNEL descriptors redirected | 0 / 885 | **731 / 885** |
+| sub-kernel elements | 0 / 1 074 487 | **896 863 / 1 074 487** |
+| producer scatters skipped | 6 / 17 | **13 / 17** |
+| blocked producers, by reason | sub 9, frag 5, scalar 2, scan 1 | sub 2, scalar 2, scan 1 |
+| … blocked SOLELY by that reason | sub 4, frag 1 | scalar 2, sub 1 |
+
+Two things in that table refute the spike's ordering:
+
+* **there are ZERO ghost-masked descriptors in this build** (`n_ghost_edges = 0`
+  at both 6x6x8 and on split part 2), and none at all in any of the 1-D host
+  fixtures — so blocker #1, the one the note called the primary target, has no
+  coverage to give here. It is implemented anyway (it is cheap and it is
+  correct), and the unit tests cover it directly, but it is not what was
+  holding the scatters.
+* **the sub-kernel descriptors are the read surface that matters**: 885 of the
+  985 candidate descriptors and 1 074 487 of the 1 106 635 candidate READ
+  ELEMENTS — 33x the top-level edges' volume — and they held 9 of the 11
+  surviving producer scatters alive. Blocker #2, listed second and described as
+  "mechanical, not conceptual", was the whole game.
+
+E-lane CSR gathers (#3) and `_AK_STATE_FIXED` pins are likewise 0 here. What is
+left is blocker #4 (scalar-walker reads: 2 producers, and BOTH of them are
+blocked by nothing else) plus one sub-kernel descriptor group and one level scan
+fold.
+
+## What blocks the rest (tier-3 fallbacks, in the order the spike GUESSED)
+
+1. ~~**Ghost-masked `_AK_STATE_TBL_BOX` gathers**~~ — CLOSED (`_ssa_lane_owners`'
+   wildcard fill), and measured at ZERO coverage on ReSEACT: no build in this
+   corpus emits one. Kept because it is correct and free.
+2. ~~**Sub-kernel (`_NK_SUBCALL`) descriptor plans**~~ — CLOSED (per-sub tables
+   on `_OopSSAKernel.subs`, `_oop_ssa_subctx` at the `_NK_SUBCALL` arm). This
+   was the real blocker: 731/885 descriptors and 896 863 read elements
+   redirected, 7 more producer scatters skipped.
 3. **E-lane (in-reduce) CSR gathers.** Per-entry `(cell, neighbour)` reads
    repeat cells — median run length 1 — so slices+concat lose to the gather;
    would need segment-level ops instead. Left as gathers deliberately.
@@ -104,8 +156,10 @@ CONUS; the buffers exceed L3), so the emission-level census is the measure.
    `_NK_STATE_GATHER`, batch slot vectors). Redirectable through the same
    slot→(producer, position) map; not done in the spike. They also hold
    producer scatters alive wherever they read.
-5. **Fragmented gathers** (`nseg > max(8, L÷4)`): kept dense by the
-   worthwhileness threshold; they also keep their producers' scatters.
+5. ~~**Fragmented gathers**~~ (`nseg > min(64, max(8, L÷4))`) — CLOSED by tier
+   2b: past the slice threshold a single-producer mapping gathers the producer's
+   VALUE instead of the buffer. `frag` went 5 blocked producers → 0. A
+   fragmented MULTI-producer mapping has no one-op form and still falls back.
 6. **Per-cell fallback kernels** disable scatter-skipping globally (reads
    un-enumerable). Rare on affine builds.
 
@@ -125,6 +179,15 @@ CONUS; the buffers exceed L3), so the emission-level census is the measure.
 * Live forcing (`param_arrays`/`rhs_with_buffers`) rides through unchanged —
   forcing reads go through the buffers argument, never `ue` — and the
   discrete-cadence refresh stays visible with fill scatters skipped (probed).
+
+## What is NOT verified
+
+The `ESM_TEST_REACTANT=1` traced census (`reactant_oop_ssa_test.jl`) asserts the
+DUS delta equals `n_skipped_scatters` on the toy fixtures; the extension's arms
+are exercised there only insofar as those fixtures engage them. The ReSEACT
+timing A/B and the whole-buffer copy census live in the consuming repo
+(`tools/diag/p13_ssa_ab.jl`, `tools/diag/p11_ue_traffic.py`) because they need
+the offline forcing environment.
 
 ## Generalization assessment (honest)
 

--- a/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
+++ b/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
@@ -82,7 +82,10 @@ vectorizable kernels (ghost-masked ones excluded and counted as fallback).
 | merged class (g1,g2 → one kernel, N=6) | 3/3 | 24/24 | 1/1 | member reads = slices at offsets inside ONE producer value |
 | reaction–diffusion, no observeds (N=16) | 7/7 | 46/46 | 0/0 | prefix reads become slices of `u` |
 
-Whole host corpus green with the flag FORCED on: tree_walk_oop (164),
+Full suite (`Pkg.test()`, `ESM_TEST_REACTANT=1`) at 4x5-era main: flag OFF
+89 034 pass / 8 broken / 89 042; forced ON 89 029 pass / 5 fail / 8 broken, the
+5 being exactly `reactant_oop_intern_test.jl`'s interning-ENGAGEMENT assertions
+(see Interactions below). Whole host corpus green with the flag FORCED on: tree_walk_oop (164),
 oop_merge (75), array_obs_materialize (78), scan_prefix (333),
 oop_scalar_batch (42), observed_materialization (20), observed_slots (36),
 iip_generic — all bit-identical to `f!` — and green with the flag OFF
@@ -226,12 +229,13 @@ Bit-identity across the arms is asserted and holds on HOST (`==`) and, on the
 toy fixtures, in the traced census (`reactant_oop_ssa_test.jl`, which pins the
 DUS delta to `n_skipped_scatters`). At CONUS the two arms are NOT bit-identical:
 changing the operand graph changes XLA's fusion, hence FMA and vectorization
-order. chemistry `ros_step` is bit-for-bit and `ros_vjp`'s λ is bit-for-bit (its
-p-gradient differs in the 20th significant figure); transport `ssp_step`
-differs by 5.6e-15 pointwise relative. The pointwise metric on the VJPs is
-uninformative — it reads exactly 2.0 on components at ~1e-310 — so the probe
-also reports a scale-relative figure and the count of components over 1e-9 of
-scale.
+order. chemistry `ros_step` is bit-for-bit and `ros_vjp`'s λ is bit-for-bit; on
+transport the largest ABSOLUTE difference is 5.6e-15 on `ssp_step` (1.1e-18 of
+scale) and 3.5e-18 on `ssp_vjp`'s λ (3.2e-16 of scale), and NOT ONE of the
+85 176 state or λ components in any program differs by more than 1e-9 of that
+quantity's own scale. The POINTWISE relative metric is uninformative here — it
+reads exactly 2.0 on an opposite-signed component at ~1e-310 — which is why the
+probe reports absolute and scale-relative figures plus a component count.
 
 ## Generalization assessment (honest)
 

--- a/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
+++ b/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
@@ -183,7 +183,7 @@ fold.
   forcing reads go through the buffers argument, never `ue` — and the
   discrete-cadence refresh stays visible with fill scatters skipped (probed).
 
-## ReSEACT at CONUS: 1.36x on the whole adjoint loop, chemistry exact
+## ReSEACT at CONUS: 1.36x on the adjoint step+VJP mix, chemistry exact
 
 Measured 2026-09-09 at 4x5 CONUS (13x7x72, 6 552 cells), two driver builds in
 ONE process, arms interleaved, every pair run in BOTH arm orders — reproducing
@@ -201,7 +201,13 @@ repo.
 | `ssp_vjp` | 306.6 ms | 254.9 ms | **1.20** | **394 → 331** | 231.8 M → 176.3 M |
 
 Weighted by the adjoint's step mix (45.3 chemistry + 3.2 transport steps per
-300 s window) the per-window cost is 6.46 s → 4.74 s, **1.36x**.
+300 s window) the per-window step+VJP cost is 6.46 s → 4.74 s, **1.36x**.
+
+That mix prices ONE primal against one VJP. The adjoint evaluates the primal
+TWICE per accepted step — the forward step and the backward replay — so a primal
+regression is paid twice against one VJP win, and the whole loop (which also
+carries the refresh and host terms) is NOT this ratio. Do not read 1.36x as a
+loop figure.
 
 WHY THE TRANSPORT FORWARD LOSES. A producer's `dynamic_update_slice` into `ue`
 ALIASES its operand in the FORWARD, so XLA:CPU writes only the update and the

--- a/pkg/EarthSciAST.jl/src/tree_walk/oop.jl
+++ b/pkg/EarthSciAST.jl/src/tree_walk/oop.jl
@@ -2375,14 +2375,22 @@ const _OOP_NO_SUB = _OopSubRT(_AccKernel[], _OopAccPlan[], Vector{Any}[], Vector
 # reads part of it — and the scatter into `ue` is emitted only where something
 # genuinely still reads the flat buffer.
 #
-# THREE TIERS, decided per consumer DESCRIPTOR at build time:
+# FOUR TIERS, decided per consumer DESCRIPTOR at build time:
 #   1. direct: the gather is one producer's entire block ⇒ the producer's SSA
 #      value, no op at all;
 #   2. slice: the gather decomposes into few consecutive-position runs, each
 #      inside one producer ⇒ per-run slices (+ one concatenate when > 1);
-#   3. fallback: anything else — non-affine tables, ghost-masked gathers,
-#      E-lane (in-reduce) and sub-kernel reads, scalar-walker reads — keeps the
+#   2b. producer gather: too fragmented for slices but inside ONE producer ⇒
+#      one gather of that producer's VALUE at producer-local positions — the
+#      same single op, off the value rather than the flat buffer;
+#   3. fallback: anything else — multi-producer fragmented mappings, unowned
+#      slots, E-lane (in-reduce) reads, scalar-walker reads — keeps the
 #      existing dense gather from `ue`, byte-for-byte.
+#
+# THREE DESCRIPTOR SURFACES feed those tiers: a kernel's own descriptors, its
+# TEMPLATE SUB-KERNEL descriptors (same parent lanes, own `S.acc` table — see
+# `_OopSSAKernel.subs`), and GHOST-MASKED table gathers, whose masked lanes are
+# wildcards because the emitter's select discards them.
 #
 # SOUNDNESS RESTS ON THREE STATIC FACTS, all established by the existing build:
 #   * a fill level reads the state and STRICTLY LOWER levels only (the
@@ -2395,9 +2403,11 @@ const _OOP_NO_SUB = _OopSubRT(_AccKernel[], _OopAccPlan[], Vector{Any}[], Vector
 #     that would observe the wrong write;
 #   * a producer's scatter into `ue` is skipped ONLY when static accounting
 #     shows every read of its block was redirected — every non-redirected read
-#     surface (scalar `_Node` walks, E-lane/sub-kernel plans, `_AK_STATE_FIXED`
-#     pins, ghost gathers, level scan folds, declined descriptors) marks its
-#     slots as residual, and ANY per-cell (non-vectorizable) kernel disables
+#     surface (scalar `_Node` walks, E-lane plans, `_AK_STATE_FIXED` pins,
+#     level scan folds, declined descriptors — sub-kernel and ghost-masked
+#     plans only where THEY decline) marks its slots as residual, and reduces
+#     per producer into the blocker tally `oop_ssa_stats` reports; ANY per-cell
+#     (non-vectorizable) kernel disables
 #     skipping wholesale, because its reads cannot be enumerated.
 #
 # BIT-IDENTITY. A redirected read returns the exact array the scatter would
@@ -2418,39 +2428,90 @@ struct _OopSSASeg
     len::Int     # run length
 end
 
+# ONE consumer descriptor's redirect. Exactly one form is populated:
+#
+#   * `segs` non-empty — consecutive-position RUNS: the producer's whole value
+#     (tier 1, no op at all) or one slice per run plus a concatenate (tier 2);
+#   * `pid != 0` — ONE producer, arbitrary positions: a single gather of that
+#     producer's VALUE at `pos` (tier 2b). This is the same single op the dense
+#     `ue` gather was, over an index vector of the same length — the win is not
+#     op count, it is that the read no longer touches the flat buffer, so the
+#     producer's scatter into it can go. It is what a FRAGMENTED mapping (one
+#     that shatters into more runs than slices are worth) takes instead of the
+#     fallback.
+#
+# Both empty ⇒ the descriptor keeps the dense `ue` gather (tier 3).
+struct _OopSSARef
+    segs::Vector{_OopSSASeg}
+    pid::Int
+    pos::Vector{Int}
+end
+const _OOP_SSA_NOREF = _OopSSARef(_OopSSASeg[], 0, Int[])
+
 # Per-kernel build-time SSA role: its producer id (0 ⇒ untracked), whether its
 # scatter into `ue` may be skipped (valid only when the runtime result is a
-# lane vector of the planned length), and the per-descriptor redirect table
-# (aligned with `K.acc`; an empty entry keeps the gather path).
+# lane vector of the planned length), the per-descriptor redirect table
+# (aligned with `K.acc`; a `_OOP_SSA_NOREF` entry keeps the gather path), and
+# the same table for each TEMPLATE SUB-KERNEL, aligned with `plan.subs`.
+#
+# The sub tables are sound for the same reason the parent's are: a sub-kernel is
+# evaluated at the PARENT's lanes and `_build_oop_desc_vectors` resolves its
+# descriptors against that same lane enumeration, so its gather index vectors
+# are slot vectors into `ue` exactly like the parent's, decomposable by exactly
+# the same map. Only the TABLE differs (`S.acc`, not `K.acc`), which is why the
+# spike could not reuse the parent's.
 struct _OopSSAKernel
     pid::Int
     skip::Bool
-    desc::Vector{Vector{_OopSSASeg}}
+    desc::Vector{_OopSSARef}
+    subs::Vector{Vector{_OopSSARef}}
 end
-const _OOP_SSA_KERNEL_OFF = _OopSSAKernel(0, false, Vector{_OopSSASeg}[])
+const _OOP_SSA_NO_SUBDESC = Vector{_OopSSARef}[]
+const _OOP_SSA_KERNEL_OFF = _OopSSAKernel(0, false, _OopSSARef[], _OOP_SSA_NO_SUBDESC)
 const _OOP_SSA_EMPTY_KS = _OopSSAKernel[]
 const _OOP_SSA_NO_VALS = Any[]
 
-# The walk-time context: the CURRENT kernel's redirect table plus this call's
-# producer values. Downgraded to the OFF singleton on entering a `_NK_SUBCALL`
-# or `_NK_REDUCE` body, whose descriptor plans index a different lane space
-# than the table was computed against.
+# The walk-time context: the CURRENT descriptor table, this call's producer
+# values, and the parent kernel's per-sub tables (carried through unchanged, so
+# a NESTED `_NK_SUBCALL` — which resolves against the same flat `plan.subs`
+# list — keeps working). Downgraded to the OFF singleton on entering a
+# `_NK_REDUCE` body, whose E-lane plan indexes per ENTRY rather than per lane.
 struct _OopSSACtx
-    desc::Vector{Vector{_OopSSASeg}}
+    desc::Vector{_OopSSARef}
     vals::Vector{Any}
+    subs::Vector{Vector{_OopSSARef}}
 end
-const _OOP_SSA_CTX_OFF = _OopSSACtx(Vector{_OopSSASeg}[], _OOP_SSA_NO_VALS)
+const _OOP_SSA_CTX_OFF = _OopSSACtx(_OopSSARef[], _OOP_SSA_NO_VALS, _OOP_SSA_NO_SUBDESC)
 
 @inline _oop_ssa_k(ks::Vector{_OopSSAKernel}, j::Int) =
     isempty(ks) ? _OOP_SSA_KERNEL_OFF : @inbounds ks[j]
 
+@inline _oop_ssa_ctx(ssak::_OopSSAKernel, vals::Vector{Any}) =
+    (isempty(ssak.desc) && isempty(ssak.subs)) ? _OOP_SSA_CTX_OFF :
+    _OopSSACtx(ssak.desc, vals, ssak.subs)
+
+# The context for sub-kernel `j` of the kernel this context belongs to.
+@inline function _oop_ssa_subctx(ssa::_OopSSACtx, j::Int)
+    sv = ssa.subs
+    (isempty(sv) || j > length(sv)) && return _OOP_SSA_CTX_OFF
+    d = @inbounds sv[j]
+    isempty(d) && return _OOP_SSA_CTX_OFF
+    return _OopSSACtx(d, ssa.vals, sv)
+end
+
 # Resolve one redirected descriptor to a producer-value reference, or `nothing`
-# to take the gather fallback (redirect table empty, or a referenced producer
-# recorded no lane vector this call).
-@inline function _oop_ssa_ref(ssa::_OopSSACtx, i::Int)
+# to take the gather fallback (no redirect, or a referenced producer recorded no
+# lane vector this call).
+@inline function _oop_ssa_ref(ssa::_OopSSACtx, i::Int, memo)
     d = ssa.desc
     isempty(d) && return nothing
-    segs = @inbounds d[i]
+    r = @inbounds d[i]
+    if r.pid != 0
+        v = @inbounds ssa.vals[r.pid]
+        v isa AbstractArray || return nothing
+        return _oop_gather(v, r.pos, memo)               # tier 2b
+    end
+    segs = r.segs
     isempty(segs) && return nothing
     return _oop_ssa_resolve(ssa.vals, segs)
 end
@@ -2496,17 +2557,20 @@ function _oop_eval_acck(nd::_Node, u, p, t, K::_AccKernel, plan::_OopAccPlan,
             # (`_AK_CONST_EDGE` falls through to the frozen-consts arm below.)
             # An SSA-redirected descriptor (ess-oop-ssa) references its producer's
             # value instead of gathering the flat buffer; `nothing` ⇒ gather.
-            v = _oop_ssa_ref(ssa, nd.idx)
+            v = _oop_ssa_ref(ssa, nd.idx, fb.memo)
             v === nothing || return v
             return _oop_gather(u, plan.gathers[nd.idx], fb.memo)
         elseif ak === _AK_STATE_TBL_BOX
             m = plan.ghost[nd.idx]
-            if isempty(m)
-                # Ghost-free table gathers are ordinary reads and may redirect;
-                # a ghost-bearing one keeps the gather+select path (its safe-index
-                # lanes read a slot the redirect analysis never modeled).
-                v = _oop_ssa_ref(ssa, nd.idx)
-                v === nothing || return v
+            # A redirected descriptor (ess-oop-ssa) references its producer's
+            # value instead of gathering the flat buffer. A GHOST-BEARING one
+            # redirects too (`_ssa_lane_owners`): its concrete lanes carry the
+            # producer positions the gather would have read, its masked lanes
+            # carry placeholders, and the select below overwrites exactly those
+            # with 0.0 — so the result is the gather's, element for element.
+            v = _oop_ssa_ref(ssa, nd.idx, fb.memo)
+            if v !== nothing
+                return isempty(m) ? v : ifelse.(m, zero(T), v)
             end
             g = _oop_gather(u, plan.gathers[nd.idx], fb.memo)
             # ghost lanes (table slot 0) select 0.0 — the in-place runners'
@@ -2551,11 +2615,16 @@ function _oop_eval_acck(nd::_Node, u, p, t, K::_AccKernel, plan::_OopAccPlan,
         Sp = @inbounds sub.plans[j]
         iv = @inbounds sub.invvals[j]
         cv = @inbounds sub.cellvals[j]
+        # The sub's OWN redirect table (ess-oop-ssa): its descriptors were
+        # resolved against these same parent lanes, so they decompose by the
+        # same slot→(producer, position) map — but they index `S.acc`, which is
+        # why the table cannot be the parent's.
+        ssaS = _oop_ssa_subctx(ssa, j)
         rs = S.cse.recipes
         @inbounds for i in eachindex(rs)
-            cv[i] = _oop_eval_acck(rs[i], u, p, t, S, Sp, iv, cv, sub, fb, T)
+            cv[i] = _oop_eval_acck(rs[i], u, p, t, S, Sp, iv, cv, sub, fb, T, ssaS)
         end
-        return _oop_eval_acck(S.spine, u, p, t, S, Sp, iv, cv, sub, fb, T)
+        return _oop_eval_acck(S.spine, u, p, t, S, Sp, iv, cv, sub, fb, T, ssaS)
     elseif k === _NK_REDUCE
         # Variable-valence sum reduction, CSR-segmented (gordian reduce-vectorize):
         # evaluate the body ONCE over the flat E-lane buffer (its only state access
@@ -2671,15 +2740,16 @@ function _oop_run_acc_vec(du, u, p, t, K::_AccKernel, plan::_OopAccPlan,
                           ::Type{T}, fb::_OopForcing=_OOP_NO_FORCING,
                           ssak::_OopSSAKernel=_OOP_SSA_KERNEL_OFF,
                           vals::Vector{Any}=_OOP_SSA_NO_VALS) where {T}
-    ssa = isempty(ssak.desc) ? _OOP_SSA_CTX_OFF : _OopSSACtx(ssak.desc, vals)
+    ssa = _oop_ssa_ctx(ssak, vals)
     sub = _oop_build_subrt(plan)
     for j in eachindex(sub.subs)
         S = @inbounds sub.subs[j]
         Sp = @inbounds sub.plans[j]
         iv = @inbounds sub.invvals[j]; cv = @inbounds sub.cellvals[j]
+        ssaS = _oop_ssa_subctx(ssa, j)
         ir = S.cse.inv_recipes
         @inbounds for i in eachindex(ir)
-            iv[i] = _oop_eval_acck(ir[i], u, p, t, S, Sp, iv, cv, sub, fb, T)
+            iv[i] = _oop_eval_acck(ir[i], u, p, t, S, Sp, iv, cv, sub, fb, T, ssaS)
         end
     end
     cse = K.cse
@@ -2834,10 +2904,45 @@ end
 
 _oop_ssa_enabled() = get(ENV, "ESS_OOP_SSA", "") == "1"
 
+# Bisect knobs for the three redirect arms added after the spike, all riding
+# inside `ESS_OOP_SSA=1` and all default ON. Setting one to 0 declines exactly
+# that arm while KEEPING the per-blocker attribution below, so one process can
+# A/B an arm without a second checkout — which is how the arms were measured
+# (setup wall on this filesystem is not a usable metric) — and so the test file
+# has a negative control for each.
+#
+#   ESS_OOP_SSA_GHOST=0     ghost-masked `_AK_STATE_TBL_BOX` descriptors
+#                           (`_ssa_lane_owners`' wildcard fill)
+#   ESS_OOP_SSA_SUB=0       template sub-kernel (`_NK_SUBCALL`) descriptor tables
+#   ESS_OOP_SSA_PGATHER=0   tier 2b, the single-producer value gather
+_oop_ssa_ghost_enabled()   = get(ENV, "ESS_OOP_SSA_GHOST", "1") != "0"
+_oop_ssa_sub_enabled()     = get(ENV, "ESS_OOP_SSA_SUB", "1") != "0"
+_oop_ssa_pgather_enabled() = get(ENV, "ESS_OOP_SSA_PGATHER", "1") != "0"
+
+# WHY a residual `ue` read exists, one bit per read surface, carried per slot in
+# the analysis' `resid` map and reduced per producer into the blocker tally
+# `oop_ssa_stats` reports. The tally is the campaign's steering instrument: a
+# producer's scatter survives because SOME surface still reads its block, and
+# only the per-reason breakdown says which extension would free it.
+const _SSA_R_SCALAR = 0x01   # scalar-walker read (`_NK_STATE`/`_NK_STATE_GATHER`)
+const _SSA_R_SCAN   = 0x02   # a fill level's scan fold reads its own slots back
+const _SSA_R_FIXED  = 0x04   # `_AK_STATE_FIXED` descriptor pin
+const _SSA_R_GHOST  = 0x08   # ghost-masked table gather kept dense
+const _SSA_R_DENSE  = 0x10   # descriptor whose gather did not decompose
+const _SSA_R_FRAG   = 0x20   # decomposed, but too fragmented to be worthwhile
+const _SSA_R_SUB    = 0x40   # sub-kernel (`_NK_SUBCALL`) descriptor plan gather
+const _SSA_R_ELANE  = 0x80   # E-lane (in-reduce) CSR plan gather
+const _SSA_R_NAMES = (:scalar, :scan, :fixed, :ghost, :dense, :frag, :sub, :elane)
+const _SSA_R_BITS = (_SSA_R_SCALAR, _SSA_R_SCAN, _SSA_R_FIXED, _SSA_R_GHOST,
+                     _SSA_R_DENSE, _SSA_R_FRAG, _SSA_R_SUB, _SSA_R_ELANE)
+
 # Redirect coverage + accounting for one build, kept on the closure for
 # reflection (`oop_ssa_stats`). "Edges" are the redirect CANDIDATES: top-level
-# cell-lane state-gather descriptors of vectorizable kernels (ghost-masked ones
-# excluded); an edge is "fast" when it was redirected to producer values.
+# cell-lane state-gather descriptors of vectorizable kernels; an edge is "fast"
+# when it was redirected to producer values. GHOST-MASKED descriptors are
+# counted in their OWN pair of columns (`n_gedges`/`n_gfast`), not in
+# `n_edges`/`n_fast`, so the plain-edge coverage number stays comparable across
+# the feature's revisions.
 struct _OopSSAStats
     n_edges::Int
     n_fast::Int
@@ -2847,7 +2952,18 @@ struct _OopSSAStats
     n_skip::Int           # producers whose `ue` scatter is statically skippable
     elems_skip::Int       # Σ out_slots lengths over skippable producers
     dynamic::Bool         # a per-cell kernel exists ⇒ no scatter may be skipped
+    n_gedges::Int         # ghost-masked candidate descriptors
+    n_gfast::Int          # … of which redirected to producer values + select
+    elems_gedges::Int
+    elems_gfast::Int
+    n_sedges::Int         # TEMPLATE SUB-KERNEL candidate descriptors
+    n_sfast::Int          # … of which redirected
+    elems_sedges::Int
+    elems_sfast::Int
+    blk::NTuple{8,Int}      # producers whose residual set includes reason k
+    blk_only::NTuple{8,Int} # … producers blocked SOLELY by reason k
 end
+const _SSA_BLK0 = ntuple(_ -> 0, 8)
 
 struct _OopSSAPlan
     enabled::Bool
@@ -2857,20 +2973,22 @@ struct _OopSSAPlan
     stats::_OopSSAStats
 end
 const _OOP_SSA_OFF = _OopSSAPlan(false, 0, Vector{_OopSSAKernel}[], _OopSSAKernel[],
-                                 _OopSSAStats(0, 0, 0, 0, 0, 0, 0, false))
+                                 _OopSSAStats(0, 0, 0, 0, 0, 0, 0, false,
+                                              0, 0, 0, 0, 0, 0, 0, 0,
+                                              _SSA_BLK0, _SSA_BLK0))
 
 # Residual `ue` reads of the scalar walkers: `_NK_STATE` pins one slot,
 # `_NK_STATE_GATHER` may read any slot in its table (its subscripts are
 # runtime loop counters). Everything else that reads the state does so through
 # an access-kernel plan, which the caller accounts separately.
-function _ssa_mark_node_reads!(resid::BitVector, n::_Node)
+function _ssa_mark_node_reads!(resid::Vector{UInt8}, n::_Node)
     k = n.kind
     if k === _NK_STATE
-        1 <= n.idx <= length(resid) && (resid[n.idx] = true)
+        1 <= n.idx <= length(resid) && (resid[n.idx] |= _SSA_R_SCALAR)
     elseif k === _NK_STATE_GATHER
         sg = n.payload::_StateGather
         for s in sg.slot_flat
-            1 <= s <= length(resid) && (resid[s] = true)
+            1 <= s <= length(resid) && (resid[s] |= _SSA_R_SCALAR)
         end
     end
     for c in n.children
@@ -2879,50 +2997,115 @@ function _ssa_mark_node_reads!(resid::BitVector, n::_Node)
     return nothing
 end
 
-# Decompose one gather-index vector into consecutive-position runs over the
-# slot-ownership maps, or `nothing` when any element is unowned or its producer
-# does not strictly precede the consumer (`cons_level`).
-function _ssa_decompose(g::Vector{Int}, own_pid::Vector{Int32}, own_pos::Vector{Int32},
-                        prod_level::Vector{Int}, cons_level::Int)
-    segs = _OopSSASeg[]
-    i = 1
+# Resolve one gather-index vector to per-lane (producer, position) ownership, or
+# `nothing` when any lane is unowned or its producer does not strictly precede
+# the consumer (`cons_level`).
+#
+# `m` is the descriptor's GHOST mask (empty ⇒ none). A ghost-bearing
+# `_AK_STATE_TBL_BOX` is a BOUNDARY STENCIL: the in-place runners read
+# `s == 0 ? 0.0 : u[s]`, and the vectorized emitter reproduces that as one
+# gather at a SAFE index (slot 1 substituted for every ghost) followed by
+# `ifelse.(mask, 0, ·)`. Run decomposition over the substituted vector is
+# hopeless — the 1s shatter every run — but a masked lane's value is DISCARDED
+# by that select, so it is a WILDCARD here: fill it with whatever (producer,
+# position) CONTINUES a neighbouring run, forward from a resolved left neighbour
+# first, then backward from a resolved right one, and only fall back to a
+# placeholder when neither exists. A one-sided stencil at the grid edge then
+# collapses to a SINGLE slice of its producer, with the select the op it was.
+#
+# `prod_len[pid]` is the producer's value length (entry 1 = `n_states`, the raw
+# state), bounding the positions a filler may invent.
+function _ssa_lane_owners(g::Vector{Int}, m::Vector{Bool},
+                          own_pid::Vector{Int32}, own_pos::Vector{Int32},
+                          prod_level::Vector{Int}, prod_len::Vector{Int},
+                          cons_level::Int)
     L = length(g)
     n = length(own_pid)
-    while i <= L
-        s = g[i]
-        (1 <= s <= n) || return nothing
-        pid = Int(@inbounds own_pid[s])
+    masked = !isempty(m)
+    masked && length(m) != L && return nothing
+    pid_l = zeros(Int, L)               # 0 ⇒ unresolved (a masked lane, so far)
+    pos_l = zeros(Int, L)
+    nconc = 0
+    @inbounds for l in 1:L
+        masked && m[l] && continue
+        sl = g[l]
+        (1 <= sl <= n) || return nothing
+        pid = Int(own_pid[sl])
         pid == 0 && return nothing
-        @inbounds prod_level[pid] < cons_level || return nothing
-        lo = Int(@inbounds own_pos[s])
+        prod_level[pid] < cons_level || return nothing
+        pid_l[l] = pid
+        pos_l[l] = Int(own_pos[sl])
+        nconc += 1
+    end
+    # An ALL-ghost descriptor is a constant zero vector; that is a different
+    # (and much rarer) rewrite, so decline it here rather than model it.
+    nconc == 0 && return nothing
+    if masked && nconc < L
+        @inbounds for l in 2:L                        # extend forward
+            pid_l[l] == 0 || continue
+            pl = pid_l[l - 1]
+            (pl != 0 && pos_l[l - 1] + 1 <= prod_len[pl]) || continue
+            pid_l[l] = pl
+            pos_l[l] = pos_l[l - 1] + 1
+        end
+        @inbounds for l in (L - 1):-1:1               # then backward
+            pid_l[l] == 0 || continue
+            pr = pid_l[l + 1]
+            (pr != 0 && pos_l[l + 1] - 1 >= 1) || continue
+            pid_l[l] = pr
+            pos_l[l] = pos_l[l + 1] - 1
+        end
+        @inbounds for l in 1:L                        # placeholder: state slot 1
+            pid_l[l] == 0 || continue
+            prod_len[1] >= 1 || return nothing
+            pid_l[l] = 1
+            pos_l[l] = 1
+        end
+    end
+    return pid_l, pos_l
+end
+
+# A RUN decomposition must BEAT the gather it replaces: accept when the run
+# count is small against the lane count (each run is one slice; > 1 also costs a
+# concatenate). The cap must be ABSOLUTE as well as relative: lattice run counts
+# grow ~O(sqrt NC) with the grid, and a purely relative bound (L>>2 = 1,638 at
+# CONUS) admitted edges of hundreds of slices each -- the emitted module
+# overflowed XLA:CPU's contiguous JIT section arena ("Unable to allocate section
+# memory") at 13x7x72 while RSS sat at 6.7 GB. 64 leaves the measured 6x6x8
+# behaviour (L>>2 = 72) essentially unchanged. A mapping that fails this test is
+# NOT back to the flat buffer whenever it lies inside ONE producer: tier 2b then
+# gathers that producer's value, one op, same index volume (see `_OopSSARef`).
+@inline _ssa_worthwhile(L::Int, nseg::Int) = nseg <= min(64, max(8, L >> 2))
+
+# Pick the cheapest reference form for a resolved descriptor, or
+# `_OOP_SSA_NOREF` when none beats the dense `ue` gather.
+function _ssa_pack_ref(pid_l::Vector{Int}, pos_l::Vector{Int}, pgather_ok::Bool)
+    L = length(pid_l)
+    segs = _OopSSASeg[]
+    l = 1
+    @inbounds while l <= L
+        pid = pid_l[l]
+        lo = pos_l[l]
         len = 1
-        while i + len <= L
-            s2 = g[i + len]
-            (1 <= s2 <= n) || return nothing
-            (Int(@inbounds own_pid[s2]) == pid &&
-             Int(@inbounds own_pos[s2]) == lo + len) || break
+        while l + len <= L && pid_l[l + len] == pid && pos_l[l + len] == lo + len
             len += 1
         end
         push!(segs, _OopSSASeg(pid, lo, len))
-        i += len
+        l += len
     end
-    return segs
+    _ssa_worthwhile(L, length(segs)) && return _OopSSARef(segs, 0, Int[])
+    pgather_ok || return _OOP_SSA_NOREF
+    p1 = @inbounds pid_l[1]
+    all(==(p1), pid_l) && return _OopSSARef(_OopSSASeg[], p1, copy(pos_l))
+    return _OOP_SSA_NOREF
 end
-
-# A redirect must BEAT the gather it replaces: accept when the run count is
-# small against the lane count (each run is one slice; > 1 also costs a
-# concatenate). A fragmented mapping keeps the dense gather. The cap must be
-# ABSOLUTE as well as relative: lattice run counts grow ~O(sqrt NC) with the
-# grid, and a purely relative bound (L>>2 = 1,638 at CONUS) admitted edges of
-# hundreds of slices each -- the emitted module overflowed XLA:CPU's
-# contiguous JIT section arena ("Unable to allocate section memory") at
-# 13x7x72 while RSS sat at 6.7 GB. 64 leaves the measured 6x6x8 behaviour
-# (L>>2 = 72) essentially unchanged.
-@inline _ssa_worthwhile(L::Int, nseg::Int) = nseg <= min(64, max(8, L >> 2))
 
 function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
                              rhs_list, cse_prelude, n_states::Int, n_total::Int)
     _oop_ssa_enabled() || return _OOP_SSA_OFF
+    ghost_ok = _oop_ssa_ghost_enabled()
+    sub_ok = _oop_ssa_sub_enabled()
+    pgather_ok = _oop_ssa_pgather_enabled()
     nlev = length(mat_levels)
 
     # ---- Slot ownership, in execution order (LAST writer owns) ----
@@ -2933,6 +3116,7 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
     end
     prod_level = Int[0]
     prod_slots = Vector{Int}[Int[]]         # pid 1 never scatters; empty slot list
+    prod_len = Int[n_states]                # pid 1's VALUE is `u` itself
     matpids = Vector{Vector{Int}}(undef, nlev)
     dynamic = any(pl -> !pl.vectorizable, acc_plans)
     for li in 1:nlev
@@ -2946,6 +3130,7 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
             if plan.vectorizable
                 push!(prod_level, li)
                 push!(prod_slots, plan.out_slots)
+                push!(prod_len, length(plan.out_slots))
                 pid = length(prod_level)
                 pids[j] = pid
                 out = plan.out_slots
@@ -2970,10 +3155,10 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
     end
 
     # ---- Residual `ue` reads (everything that will NOT be redirected) ----
-    resid = falses(n_total)
-    markv!(v) = (for s in v
-                     1 <= s <= n_total && (resid[s] = true)
-                 end)
+    resid = zeros(UInt8, n_total)
+    markv!(v, why::UInt8) = (for s in v
+                                 1 <= s <= n_total && (resid[s] |= why)
+                             end)
     for nd in cse_prelude
         _ssa_mark_node_reads!(resid, nd)
     end
@@ -2986,54 +3171,100 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
             _ssa_mark_node_reads!(resid, nd)
         end
         for S in scans
-            markv!((S::_ScanFold).slots)      # the fold reads its own slots back
+            # the fold reads its own slots back
+            markv!((S::_ScanFold).slots, _SSA_R_SCAN)
         end
     end
     # (The state-RHS `scan_folds` fold `du`, not `ue` — no residue here.)
 
     n_edges = 0; n_fast = 0; elems_edges = 0; elems_fast = 0
+    n_gedges = 0; n_gfast = 0; elems_gedges = 0; elems_gfast = 0
+    n_sedges = 0; n_sfast = 0; elems_sedges = 0; elems_sfast = 0
 
-    # Per consumer kernel: decide redirects for the top-level cell-lane
-    # descriptors, then mark every read that stays on the gather path.
-    function consumer(K::_AccKernel, plan::_OopAccPlan, cons_level::Int)
-        plan.vectorizable || return _OOP_SSA_KERNEL_OFF
-        segsv = Vector{_OopSSASeg}[_OopSSASeg[] for _ in 1:length(K.acc)]
+    # ONE descriptor table — a kernel's own, or a sub-kernel's, both resolved
+    # against the SAME lane enumeration. Decides each descriptor's redirect and
+    # marks every read that stays on the gather path, with the reason that
+    # declined it. Returns the per-descriptor refs and whether any redirected.
+    function desc_table(acc::Vector{_AccDesc}, pl::_OopAccPlan, cons_level::Int,
+                        is_sub::Bool)
+        # A sub whose spine does not vectorize forces the parent non-vectorizable
+        # (`_build_oop_acc_plan`), so this cannot fire for a reached sub — but a
+        # fallback plan carries no per-descriptor vectors at all, so refuse it
+        # rather than index them.
+        pl.vectorizable || return (_OopSSARef[], false)
+        refs = _OopSSARef[_OOP_SSA_NOREF for _ in 1:length(acc)]
         any_fast = false
-        for i in eachindex(K.acc)
-            a = K.acc[i]
+        for i in eachindex(acc)
+            a = acc[i]
             if a.kind === _AK_STATE_FIXED
-                1 <= a.idx <= n_total && (resid[a.idx] = true)
+                1 <= a.idx <= n_total && (resid[a.idx] |= _SSA_R_FIXED)
             end
-            g = plan.gathers[i]
+            g = pl.gathers[i]
             isempty(g) && continue
-            if isempty(plan.ghost[i])
+            gh = pl.ghost[i]
+            ghosted = !isempty(gh)
+            if is_sub
+                n_sedges += 1
+                elems_sedges += length(g)
+            elseif ghosted
+                # Boundary stencil through a slot table with 0 entries: the
+                # redirect covers the concrete lanes and the emitter keeps the
+                # select against the (host, constant) ghost mask.
+                n_gedges += 1
+                elems_gedges += length(g)
+            else
                 n_edges += 1
                 elems_edges += length(g)
-                segs = _ssa_decompose(g, own_pid, own_pos, prod_level, cons_level)
-                if segs !== nothing && _ssa_worthwhile(length(g), length(segs))
-                    segsv[i] = segs
-                    any_fast = true
-                    n_fast += 1
-                    elems_fast += length(g)
-                    continue
-                end
             end
-            markv!(g)                          # ghost-masked or unresolved: gather
+            own = ((ghosted && !ghost_ok) || (is_sub && !sub_ok)) ? nothing :
+                  _ssa_lane_owners(g, gh, own_pid, own_pos, prod_level, prod_len,
+                                   cons_level)
+            ref = own === nothing ? _OOP_SSA_NOREF :
+                  _ssa_pack_ref(own[1], own[2], pgather_ok)
+            if ref === _OOP_SSA_NOREF
+                markv!(g, ghosted ? _SSA_R_GHOST :
+                          is_sub ? _SSA_R_SUB :
+                          own === nothing ? _SSA_R_DENSE : _SSA_R_FRAG)
+                continue
+            end
+            refs[i] = ref
+            any_fast = true
+            if is_sub
+                n_sfast += 1
+                elems_sfast += length(g)
+            elseif ghosted
+                n_gfast += 1
+                elems_gfast += length(g)
+            else
+                n_fast += 1
+                elems_fast += length(g)
+            end
         end
-        for (S, sp) in zip(plan.subs, plan.sub_plans)
-            for i in eachindex(S.acc)
-                S.acc[i].kind === _AK_STATE_FIXED &&
-                    1 <= S.acc[i].idx <= n_total && (resid[S.acc[i].idx] = true)
-                markv!(sp.gathers[i])
+        return refs, any_fast
+    end
+
+    function consumer(K::_AccKernel, plan::_OopAccPlan, cons_level::Int)
+        plan.vectorizable || return _OOP_SSA_KERNEL_OFF
+        refs, top_fast = desc_table(K.acc, plan, cons_level, false)
+        subrefs = _OOP_SSA_NO_SUBDESC
+        sub_fast = false
+        if !isempty(plan.subs)
+            sv = Vector{Vector{_OopSSARef}}(undef, length(plan.subs))
+            for j in eachindex(plan.subs)
+                sr, sf = desc_table(plan.subs[j].acc, plan.sub_plans[j],
+                                    cons_level, true)
+                sv[j] = sf ? sr : _OopSSARef[]
+                sub_fast |= sf
             end
+            sub_fast && (subrefs = sv)
         end
         for ep in plan.red_plan
             for g in ep.gathers
-                markv!(g)
+                markv!(g, _SSA_R_ELANE)
             end
         end
-        any_fast || return _OopSSAKernel(0, false, Vector{_OopSSASeg}[])
-        return _OopSSAKernel(0, false, segsv)
+        (top_fast || sub_fast) || return _OOP_SSA_KERNEL_OFF
+        return _OopSSAKernel(0, false, top_fast ? refs : _OopSSARef[], subrefs)
     end
 
     mat = Vector{Vector{_OopSSAKernel}}(undef, nlev)
@@ -3047,24 +3278,38 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
 
     # ---- Producer roles: attach pid + the scatter-skip verdict ----
     n_skip = 0; elems_skip = 0
+    blk = zeros(Int, 8); blk_only = zeros(Int, 8)
     for li in 1:nlev
         pids = matpids[li]
         ks = mat[li]
         for j in eachindex(pids)
             pid = pids[j]
             pid == 0 && continue
-            skip = !dynamic && !any(@inbounds(resid[s]) for s in prod_slots[pid])
+            why = UInt8(0)
+            @inbounds for sl in prod_slots[pid]
+                why |= resid[sl]
+            end
+            skip = !dynamic && why == 0
             if skip
                 n_skip += 1
                 elems_skip += length(prod_slots[pid])
+            else
+                for k in 1:8
+                    (why & _SSA_R_BITS[k]) == 0 && continue
+                    blk[k] += 1
+                    why == _SSA_R_BITS[k] && (blk_only[k] += 1)
+                end
             end
             k0 = ks[j]
-            ks[j] = _OopSSAKernel(pid, skip, k0.desc)
+            ks[j] = _OopSSAKernel(pid, skip, k0.desc, k0.subs)
         end
     end
 
     stats = _OopSSAStats(n_edges, n_fast, elems_edges, elems_fast,
-                         length(prod_level) - 1, n_skip, elems_skip, dynamic)
+                         length(prod_level) - 1, n_skip, elems_skip, dynamic,
+                         n_gedges, n_gfast, elems_gedges, elems_gfast,
+                         n_sedges, n_sfast, elems_sedges, elems_sfast,
+                         NTuple{8,Int}(blk), NTuple{8,Int}(blk_only))
     return _OopSSAPlan(true, length(prod_level), mat, fin, stats)
 end
 
@@ -3082,8 +3327,14 @@ function oop_ssa_stats(f::_OopRHS)
     s = p.stats
     return (; enabled = p.enabled, n_edges = s.n_edges, n_fast = s.n_fast,
             elems_edges = s.elems_edges, elems_fast = s.elems_fast,
+            n_ghost_edges = s.n_gedges, n_ghost_fast = s.n_gfast,
+            elems_ghost_edges = s.elems_gedges, elems_ghost_fast = s.elems_gfast,
+            n_sub_edges = s.n_sedges, n_sub_fast = s.n_sfast,
+            elems_sub_edges = s.elems_sedges, elems_sub_fast = s.elems_sfast,
             n_producers = s.n_prod, n_skipped_scatters = s.n_skip,
-            elems_skipped = s.elems_skip, dynamic = s.dynamic)
+            elems_skipped = s.elems_skip, dynamic = s.dynamic,
+            blockers = NamedTuple{_SSA_R_NAMES}(s.blk),
+            blockers_only = NamedTuple{_SSA_R_NAMES}(s.blk_only))
 end
 
 function _make_rhs_oop(rhs_list::AbstractVector{Tuple{Int,_Node}},

--- a/pkg/EarthSciAST.jl/test/tree_walk_oop_ssa_test.jl
+++ b/pkg/EarthSciAST.jl/test/tree_walk_oop_ssa_test.jl
@@ -213,3 +213,242 @@ _s_ip(f!, u, p, t) = (du = zero(u); f!(du, u, p, t); du)
         @test Jon == Joff
     end
 end
+
+# ---------------------------------------------------------------------------
+# The three arms added after the spike (`SSA_SPIKE.md` "What blocks the rest"):
+# ghost-masked table gathers (#1), template sub-kernel descriptor tables (#2),
+# and tier 2b — the single-producer VALUE gather that fragmented mappings (#5)
+# take instead of the flat-buffer fallback. Each has a bisect knob
+# (`ESS_OOP_SSA_GHOST` / `_SUB` / `_PGATHER`, all default on), so every
+# engagement assertion below is paired with a NEGATIVE CONTROL: the same build
+# with that one arm declined must show the coverage gone.
+# ---------------------------------------------------------------------------
+
+# One producer occupying slots 5:8 at level 1, the state at slots 1:4 (level 0).
+const _SX_PID = Int32[1, 1, 1, 1, 2, 2, 2, 2]
+const _SX_POS = Int32[1, 2, 3, 4, 1, 2, 3, 4]
+const _SX_LVL = Int[0, 1]
+const _SX_LEN = Int[4, 4]
+_sx_owners(g, m = Bool[]; lvl = 2, pid = _SX_PID, pos = _SX_POS) =
+    ESMs._ssa_lane_owners(g, m, pid, pos, _SX_LVL, _SX_LEN, lvl)
+
+@testset "SSA reference forms (lane owners + tier choice)" begin
+
+    @testset "run decomposition and the level/ownership refusals" begin
+        o = _sx_owners([5, 6, 7, 8])
+        @test o !== nothing
+        r = ESMs._ssa_pack_ref(o[1], o[2], true)
+        @test r.pid == 0 && r.segs == [ESMs._OopSSASeg(2, 1, 4)]
+        # a producer that does NOT strictly precede the consumer is refused
+        @test _sx_owners([5, 6, 7, 8]; lvl = 1) === nothing
+        # so is a slot nothing owns (a later writer disowned it)
+        dis = copy(_SX_PID); dis[6] = 0
+        @test _sx_owners([5, 6, 7, 8]; pid = dis) === nothing
+        # out-of-range slots are refused rather than read
+        @test _sx_owners([5, 6, 7, 99]) === nothing
+    end
+
+    @testset "ghost mask: a wildcard lane takes whatever continues the run" begin
+        # A MIDDLE ghost (its safe-index gather read slot 1) is filled from its
+        # left neighbour and the whole descriptor collapses to ONE slice.
+        o = _sx_owners([5, 1, 7, 8], Bool[false, true, false, false])
+        @test o !== nothing
+        @test o[1] == [2, 2, 2, 2] && o[2] == [1, 2, 3, 4]
+        @test ESMs._ssa_pack_ref(o[1], o[2], true).segs == [ESMs._OopSSASeg(2, 1, 4)]
+        # A LEADING ghost cannot back-extend past position 1, so it takes the
+        # placeholder segment (the state's slot 1) and the rest is one slice.
+        o = _sx_owners([1, 5, 6, 7], Bool[true, false, false, false])
+        @test o !== nothing
+        @test o[1] == [1, 2, 2, 2] && o[2] == [1, 1, 2, 3]
+        @test ESMs._ssa_pack_ref(o[1], o[2], true).segs ==
+              [ESMs._OopSSASeg(1, 1, 1), ESMs._OopSSASeg(2, 1, 3)]
+        # A leading ghost that CAN back-extend does, and the run stays single.
+        o = _sx_owners([1, 6, 7, 8], Bool[true, false, false, false])
+        @test o[1] == [2, 2, 2, 2] && o[2] == [1, 2, 3, 4]
+        # Every invented position stays inside its producer's value, whichever
+        # lanes the mask covers.
+        raw = [5, 6, 7, 8]
+        for bits in 1:14                      # every mask but none-set / all-set
+            msk = Bool[(bits >> (l - 1)) & 1 == 1 for l in 1:4]
+            o = _sx_owners(Int[msk[l] ? 1 : raw[l] for l in 1:4], msk)
+            @test o !== nothing
+            for l in 1:4
+                @test 1 <= o[2][l] <= _SX_LEN[o[1][l]]
+            end
+        end
+        # An ALL-ghost descriptor is declined (it is a constant zero vector).
+        @test _sx_owners([1, 1, 1, 1], Bool[true, true, true, true]) === nothing
+    end
+
+    @testset "tier 2b: a fragmented SINGLE-producer mapping gathers the value" begin
+        pid = fill(Int32(2), 40)
+        pos = Int32.(1:40)
+        lvl = Int[0, 1]
+        len = Int[40, 40]
+        g = collect(40:-1:1)                      # reversed ⇒ 40 runs of length 1
+        o = ESMs._ssa_lane_owners(g, Bool[], pid, pos, lvl, len, 2)
+        @test o !== nothing
+        r = ESMs._ssa_pack_ref(o[1], o[2], true)
+        @test r.pid == 2 && r.pos == g && isempty(r.segs)
+        # NEGATIVE CONTROL: with tier 2b declined the mapping is too fragmented
+        # for slices and falls back to the flat buffer.
+        @test ESMs._ssa_pack_ref(o[1], o[2], false) === ESMs._OOP_SSA_NOREF
+        # A fragmented MULTI-producer mapping has no one-op form either way.
+        pid2 = Int32[i <= 20 ? 2 : 3 for i in 1:40]
+        pos2 = Int32[i <= 20 ? i : i - 20 for i in 1:40]
+        o2 = ESMs._ssa_lane_owners(g, Bool[], pid2, pos2, Int[0, 1, 1], Int[40, 20, 20], 2)
+        @test o2 !== nothing
+        @test ESMs._ssa_pack_ref(o2[1], o2[2], true) === ESMs._OOP_SSA_NOREF
+    end
+end
+
+# A REVERSED read of a materialized observed: `g[N+1-i]` is not `out .+ delta`,
+# so the build lowers it to a per-box slot table whose lanes descend — L runs of
+# length 1, past the slice worthwhileness bound. Tier 2b turns it into one
+# gather of `g`'s value; without tier 2b it is the dense `ue` gather, and `g`'s
+# scatter has to stay.
+function _s_rev(N)
+    _s_doc("SSAREV",
+        Dict{String,Any}("u" => _s_state(shape = Any["n"]),
+                         "g" => _s_state(shape = Any["n"]),
+                         "k" => _s_param(0.25)),
+        Any[Dict{String,Any}("lhs" => "g",
+                "rhs" => _s_ao(_s_o("+", _s_o("*", 2.0, _s_ix("u", "i")), 1.0))),
+            Dict{String,Any}("lhs" => _s_ao(_s_Dt(_s_ix("u", "i"))),
+                "rhs" => _s_ao(_s_o("-", _s_o("*", "k",
+                                    _s_ix("g", _s_o("-", Float64(N + 1), "i"))),
+                                    _s_ix("u", "i"))))],
+        N)
+end
+
+_s_build_env(doc, env...) = withenv("ESS_OOP_SSA" => "1", env...) do
+    ESMs.build_evaluator(doc; form = :oop)
+end
+
+@testset "tier 2b end to end (reversed observed read)" begin
+    N = 24
+    doc = _s_rev(N)
+    (fon, u0, p, _, _) = _s_build_env(doc)
+    (fno, _, _, _, _) = _s_build_env(doc, "ESS_OOP_SSA_PGATHER" => "0")
+    foff, = withenv("ESS_OOP_SSA" => nothing) do
+        ESMs.build_evaluator(doc; form = :oop)
+    end
+    fip, = ESMs.build_evaluator(doc)
+    for probe in (u0, _s_seed(length(u0))), t in (0.0, 0.41)
+        a = fon(probe, p, t)
+        @test a == foff(probe, p, t)
+        @test a == fno(probe, p, t)
+        @test a == _s_ip(fip, probe, p, t)
+    end
+    son = ESMs.oop_ssa_stats(fon)
+    sno = ESMs.oop_ssa_stats(fno)
+    # ENGAGEMENT + NEGATIVE CONTROL: the reversed edge redirects only with the
+    # arm on, and it is the last reader keeping `g`'s scatter alive.
+    @test son.n_fast > sno.n_fast
+    @test son.n_skipped_scatters > sno.n_skipped_scatters
+    @test son.n_producers == 1 && son.n_skipped_scatters == 1
+    Jon = ForwardDiff.jacobian(uu -> fon(uu, p, 0.2), _s_seed(N))
+    Joff = ForwardDiff.jacobian(uu -> foff(uu, p, 0.2), _s_seed(N))
+    @test Jon == Joff
+end
+
+# ---------------------------------------------------------------------------
+# Template SUB-KERNEL descriptor tables (`SSA_SPIKE.md` blocker #2). A sub is
+# evaluated at the PARENT's lanes and `_build_oop_desc_vectors` resolves its
+# descriptors against that same enumeration, so its gathers are ordinary slot
+# vectors into `ue` — but they index `S.acc`, not `K.acc`, which is why the
+# spike's per-kernel table could not carry them and every one of them held its
+# producers' scatters alive. Measured on the ReSEACT transport RHS at 6x6x8,
+# these are 885 of the 985 candidate descriptors and 1.07 M of the 1.11 M read
+# elements, so they are the read surface that matters.
+#
+# The fixture is the duo-rule shape from codegen_subcall_fn_test.jl — a
+# makearray whose region value applies an aggregate-bodied template whose expr
+# holds more applies as arithmetic OPERANDS — because that is what mints
+# `_NK_SUBCALL`s at all.
+function _s_sub_fixture(dir, N)
+    ix(f, i, j) = Dict("op" => "index", "args" => Any[f, i, j])
+    ap(a, b) = Dict("op" => "apply_expression_template", "args" => Any[],
+                    "name" => "leaf", "bindings" => Dict("a" => a, "b" => b))
+    leaf_terms = Any[]
+    for k in 1:12
+        push!(leaf_terms, Dict("op" => "*", "args" => Any[0.5 + 0.01k,
+            Dict("op" => "+", "args" => Any[
+                Dict("op" => "*", "args" => Any["a", "a"]),
+                Dict("op" => "*", "args" => Any["b", 0.3 + 0.02k])])]))
+    end
+    leaf = Dict("params" => Any["a", "b"],
+                "body" => Dict("op" => "+", "args" => leaf_terms))
+    inner_expr = Dict("op" => "+", "args" => Any[
+        Dict("op" => "*", "args" => Any[0.25, ap(ix("f", "i", "j"), ix("f", "i", "j"))]),
+        ap(ix("f", "i", "j"), ix("f", "j", "i")),
+        Dict("op" => "*", "args" => Any[ap(ix("f", "i", "j"), ix("f", "i", "j")), 0.125])])
+    inner = Dict("params" => Any["f"],
+                 "body" => Dict("op" => "aggregate", "output_idx" => Any["i", "j"],
+                                "args" => Any["f"],
+                                "ranges" => Dict("i" => Dict("from" => "x"),
+                                                 "j" => Dict("from" => "y")),
+                                "expr" => inner_expr))
+    rhs = Dict("op" => "makearray", "args" => Any[],
+               "regions" => Any[Any[Any[1, "N"], Any[1, "N"]]],
+               "values" => Any[Dict("op" => "apply_expression_template",
+                                    "args" => Any[], "name" => "inner",
+                                    "bindings" => Dict("f" => "u"))])
+    doc = Dict("esm" => "1.0.0",
+        "metadata" => Dict("name" => "ssa_subcall_fixture",
+                           "description" => "generated by tree_walk_oop_ssa_test.jl: sub-kernel redirect"),
+        "metaparameters" => Dict("N" => Dict("type" => "integer", "default" => N)),
+        "index_sets" => Dict("x" => Dict("kind" => "interval", "size" => "N"),
+                             "y" => Dict("kind" => "interval", "size" => "N")),
+        "models" => Dict("M" => Dict(
+            "expression_templates" => Dict("leaf" => leaf, "inner" => inner),
+            "variables" => Dict("u" => Dict("type" => "unknown", "units" => "1",
+                                            "shape" => Any["x", "y"], "default" => 1.0)),
+            "equations" => Any[Dict(
+                "lhs" => Dict("op" => "D", "args" => Any["u"], "wrt" => "t"),
+                "rhs" => rhs)])))
+    path = joinpath(dir, "ssa_subcall_fixture.esm")
+    open(path, "w") do io
+        JSON3.write(io, doc)
+    end
+    return path
+end
+
+@testset "sub-kernel descriptor tables redirect (blocker #2)" begin
+    mktempdir() do dir
+        F = _s_sub_fixture(dir, 5)
+        build(env...) = withenv(env...) do
+            ESMs.build_evaluator(ESMs.flatten(ESMs.load_path(F)); form = :oop)
+        end
+        # The nested-boundary tier is what mints the `_NK_SUBCALL`s.
+        nested = "ESS_NESTED_TEMPLATE_BOUNDARY" => "1"
+        (fon, u0, p, _, _) = build(nested, "ESS_OOP_SSA" => "1")
+        (fno, _, _, _, _) = build(nested, "ESS_OOP_SSA" => "1",
+                                  "ESS_OOP_SSA_SUB" => "0")
+        (foff, _, _, _, _) = build(nested, "ESS_OOP_SSA" => nothing)
+        fip, ui, pi_, _, _ = withenv(nested) do
+            ESMs.build_evaluator(ESMs.flatten(ESMs.load_path(F)))
+        end
+
+        son = ESMs.oop_ssa_stats(fon)
+        sno = ESMs.oop_ssa_stats(fno)
+        # ENGAGEMENT: the sub tables are where this fixture's reads live at all,
+        # and every one of them redirects.
+        @test son.n_sub_edges > 0
+        @test son.n_sub_fast == son.n_sub_edges
+        # NEGATIVE CONTROL: with the arm declined not one of them redirects.
+        @test sno.n_sub_edges == son.n_sub_edges
+        @test sno.n_sub_fast == 0
+
+        # BIT-IDENTITY across all three builds and the in-place `f!`.
+        for probe in (u0, _s_seed(length(u0))), t in (0.0, 0.63)
+            a = fon(probe, p, t)
+            @test a == foff(probe, p, t)
+            @test a == fno(probe, p, t)
+            @test a == _s_ip(fip, probe, pi_, t)
+        end
+        u = _s_seed(length(u0))
+        @test ForwardDiff.jacobian(uu -> fon(uu, p, 0.3), u) ==
+              ForwardDiff.jacobian(uu -> foff(uu, p, 0.3), u)
+    end
+end


### PR DESCRIPTION
## What this is

The `ess-oop-ssa` spike (`src/tree_walk/SSA_SPIKE.md`) redirects a consumer
access-kernel descriptor's read from the flat extended buffer `ue` to its
PRODUCER'S VALUE, and skips a producer's scatter into `ue` when static
accounting shows nothing reads its block off the buffer any more. It shipped
with four of its own "What blocks the rest" items open. This closes three of
them — and, more usefully, **measures which one mattered. The list's order was
wrong.**

Independent of #273 (`perf/contraction-tier-order`) and #278
(`perf/cross-shape-state-gather`); based on `origin/main`, touching only the
`_OopSSA*` sections of `oop.jl`, that file's test, and the design note.

## The measurement that redirected the work

`oop_ssa_stats` now carries a per-reason **blocker tally**: for each producer
whose scatter survived, which read surface still reads its block. On the ReSEACT
transport RHS at 6x6x8 — the target of the whole exercise — it says:

* **ghost-masked `_AK_STATE_TBL_BOX` gathers, blocker #1 and the note's primary
  target, do not occur in this build.** `n_ghost_edges = 0` on both split parts,
  and none in any 1-D host fixture either. The arm is implemented and
  unit-tested anyway (it is cheap and it is correct), but it buys nothing here.
* **the template SUB-KERNEL descriptors (blocker #2) are the read surface**:
  885 of the 985 candidate descriptors and **1 074 487 of the 1 106 635
  candidate read elements — 33x the top-level edges' volume** — and they held
  9 of the 11 surviving producer scatters alive.
* E-lane CSR gathers (#3) and `_AK_STATE_FIXED` pins are 0 here too.

## What changed

Three redirect arms, each with a bisect knob (`ESS_OOP_SSA_SUB`,
`ESS_OOP_SSA_PGATHER`, `ESS_OOP_SSA_GHOST`, all default ON inside
`ESS_OOP_SSA=1`, so one process can A/B an arm and every engagement test has a
negative control):

1. **Per-sub descriptor tables** (`_OopSSAKernel.subs`, `_oop_ssa_subctx`).
   A sub-kernel is evaluated at the PARENT's lanes and
   `_build_oop_desc_vectors` resolves its descriptors against that same
   enumeration, so its gathers decompose by exactly the same
   slot→(producer, position) map; only the table differs (`S.acc`, not
   `K.acc`), which is why the spike's per-kernel table could not carry them.
2. **Tier 2b, the single-producer VALUE gather.** Past the slice-worthwhileness
   bound a mapping that lies inside ONE producer now gathers that producer's
   value at producer-local positions: the same single op the dense `ue` gather
   was, over an index vector of the same length. The win is not op count — it is
   that the read stops touching the flat buffer, which is what lets the scatter
   go.
3. **Ghost-masked table gathers.** A masked lane's value is discarded by the
   emitter's `ifelse.(mask, 0, ·)` select, so it is a WILDCARD for the
   decomposition: fill it with whatever continues a neighbouring run (forward,
   then backward, then a placeholder). A one-sided boundary stencil collapses to
   a single slice, and the select is the op it already was.

`_ssa_decompose` and its masked variant are unified into `_ssa_lane_owners`
(resolve lanes to owners) + `_ssa_pack_ref` (pick the cheapest form), so all
three surfaces and all four tiers go through one path.

## Coverage

Host fixtures (`oop_ssa_stats`, the note's four): unchanged at 100% — they were
already all tier 1/2, which is the point of the `none` row below.

ReSEACT, per arm, `tools/diag/p12_ssa_blockers.jl` at 6x6x8:

**transport (split part 1)**

| arms | edges | sub-kernel | scatters skipped | blocked by |
|---|---|---|---|---|
| none (the spike) | 51/100 | 0/885 | 6/17 (720 slots) | sub 9, frag 5, scalar 2, scan 1 |
| ghost only | 51/100 | 0/885 | 6/17 | unchanged |
| sub only | 51/100 | 5/885 | 7/17 | sub 8, frag 5, scalar 2, scan 1 |
| tier 2b only | **97/100** | 0/885 | 7/17 | sub 9, scalar 2, scan 1 |
| **all three** | **97/100** | **731/885** | **13/17 (4 874 of 8 042 slots)** | sub 2, scalar 2, scan 1 |

**chemistry (split part 2)**

| arms | edges | scatters skipped |
|---|---|---|
| none | 561/563 | 57/59 |
| **all three** | **563/563** | **59/59 — the chemistry RHS no longer scatters into `ue` at all** |

The two arms that pay are **synergistic**: the sub tables make the descriptors
visible, tier 2b gives them a form. 731 of the 885 need both, because a
sub-kernel gather is almost always too fragmented for slices (sub alone
redirects 5).

What is left on transport is blocker #4 (scalar-walker reads: 2 producers, and
`blockers_only` says BOTH are blocked by nothing else), one sub-kernel
descriptor group, and one level scan fold.

## Exactness

Unchanged, and it is the contract. A redirect returns exactly the array the
scatter would have copied — or a slice, or a gather, of it — and for a
ghost-bearing descriptor the select overwrites precisely the lanes whose
positions were invented, so no invented value can reach arithmetic (nor a
derivative: `ifelse` propagates only the selected branch).

* `:oop`(on) == `:oop`(off) == `:inplace` at Float64 `==`, and ForwardDiff
  jacobians `==`, on every fixture in `tree_walk_oop_ssa_test.jl`.
* With the flag OFF every structure is the empty singleton and the emitted
  program is byte-for-byte the pre-spike emitter.
* With all three knobs at 0 the coverage is bit-identical to the spike's — the
  `none` row above is the assertion.

## Tests

121 new assertions in `test/tree_walk_oop_ssa_test.jl`, all with negative
controls:

* white-box `_ssa_lane_owners`: the level and ownership refusals, out-of-range
  slots, the ghost wildcard fill (middle ghost → ONE slice; leading ghost that
  cannot back-extend → placeholder + slice; leading ghost that can → one slice),
  that every invented position stays inside its producer's value for all 14
  non-trivial 4-lane masks, and the all-ghost decline;
* white-box `_ssa_pack_ref`: the tier choice, that a fragmented single-producer
  mapping takes tier 2b at exactly the producer-local positions, that
  `ESS_OOP_SSA_PGATHER=0` sends it back to the buffer, and that a fragmented
  MULTI-producer mapping has no one-op form either way;
* end-to-end **tier 2b**: a reversed observed read (`g[N+1-i]`, L runs of
  length 1). Bit-identical to flag-off, to `ESS_OOP_SSA_PGATHER=0`, and to
  `:inplace`; ForwardDiff `==`; engagement (`n_fast` and
  `n_skipped_scatters` both strictly greater than the arm-off build, and the
  producer's scatter is the one that dies);
* end-to-end **sub-kernel tables**: the duo-rule shape from
  `codegen_subcall_fn_test.jl` (the shape that mints `_NK_SUBCALL`s at all) —
  26 sub descriptors, all redirected, `0` with `ESS_OOP_SSA_SUB=0`, values
  bit-identical across all three builds and `:inplace`.

Suite with the flag **OFF** (the default path): `tree_walk_oop` 164,
`tree_walk_oop_ssa` 45 + 121 new, `oop_merge` 20 + 55, `array_obs_materialize`
71 + 3, `observed_materialization` 4, `scan_prefix` 333, `oop_scalar_batch` 42,
`tree_walk_observed_slots` 8 + 12 + 36, `tree_walk_iip_generic` 69,
`codegen_subcall_fn` 50 — all green.

## Not verified here

The ReSEACT timing A/B and the whole-extended-buffer copy census need the
offline forcing environment; they live in the consuming repo
(`tools/diag/p13_ssa_ab.jl` — which includes the driver twice, once per arm,
because these are BUILD-time flags and cannot ride a trace-time `Ref` the way
`ess-oop-levelbase` did — and `tools/diag/p11_ue_traffic.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# ReSEACT at CONUS, measured (2026-09-09)

4x5 CONUS = 13x7x72 = 6 552 cells. Two driver builds in ONE process, arms
interleaved A/B/A/B on the same inputs with fresh device buffers per call, and
every pair run in **both arm orders** — which reproduced to three digits, so
"which arm compiled first" is not what is being measured.
`tools/diag/p13_ssa_ab.jl` + `tools/diag/p11_ue_traffic.py`.

## Timing

| program | arms off | arms on | off/on | exactness |
|---|---|---|---|---|
| `ros_step` (chemistry step) | 38.90 / 38.62 ms | 28.23 / 28.19 ms | **1.38 / 1.37 faster** | **bit-for-bit** |
| `ros_vjp` (chemistry VJP) | 81.11 / 81.50 ms | 56.71 / 56.83 ms | **1.43 / 1.43 faster** | λ **bit-for-bit**; p-grad max abs 2.5e-24 on a 7e-5 scale (3.5e-20 scale-relative), 0 of 162 components over 1e-9 |
| `rhs` (transport RHS) | 3.755 / 3.771 ms | 6.405 / 6.372 ms | 0.59 / 0.59 **slower** | see below |
| `rhs_vjp` | 80.5 / 80.0 ms | 72.2 / 72.4 ms | **1.12 / 1.11 faster** | |
| `ssp_step` (4-stage transport) | 13.41 / 13.20 ms | 24.25 / 24.13 ms | 0.55 / 0.55 **slower** | 5.55e-15 pointwise relative |
| `ssp_vjp` | 306.6 / 307.4 ms | 254.9 / 255.6 ms | **1.20 / 1.20 faster** | |

Weighted by the adjoint's own step mix at CONUS (45.3 chemistry + 3.2 transport
steps per 300 s window), the per-window cost goes **6.46 s → 4.74 s, 1.36x** —
and the chemistry half, which is 84% of it, is exact.

## Whole-buffer copies and write traffic

| program | copies off → on | MB | real element writes off → on |
|---|---|---|---|
| `rhs` | 2 → 3 | 4.0 → 5.9 | 2.49 M → 2.69 M |
| `rhs_vjp` | **98 → 82** | 194.0 → 162.3 | 59.55 M → 55.22 M |
| `ssp_step` | 8 → 12 | 15.8 → 23.8 | 10.43 M → 16.97 M |
| `ssp_vjp` | **394 → 331** | 779.9 → 655.2 | 231.8 M (1854 MB) → 176.3 M (1411 MB) |

The `off` column reproduces the campaign's published baseline on the nose
(`rhs_vjp` 98 vs the recorded 99, `ssp_vjp` 394 exactly), so the two arms really
are the spike and the spike-plus-extension. `ssp_vjp` loses 63 of its 394
whole-buffer copies and **24% of its write traffic**, and runs 1.20x — against
the ~1.8x ceiling if every copy vanished.

## Why the transport forward loses while everything else wins

A producer's `dynamic_update_slice` into `ue` **aliases its operand in the
forward**: XLA:CPU writes only the update, so the scatter is nearly free there,
and skipping it instead forces the producer's value to be materialized as its
own buffer. On the PPM transport RHS — 17 producers, output blocks up to 3 456
elements — that trade is a loss (`ssp_step` +63% element writes, 1.8x slower).
On the chemistry RHS it is a large win in both directions, because there the
redirect turns fragmented gathers of the 12 326-element buffer into gathers of
much smaller producer values and 59 of 59 scatters disappear.

The copies the scatter chain causes are all in the **reverse**, where each `ue`
version has ~70 live consumers and copy-insertion duplicates the whole buffer
per version. That is where removing readers pays on both halves.

This is also exactly why `ess-oop-levelbase` failed where this does not: it
reduced the number of `ue` VERSIONS — which the forward already got for free —
instead of removing READERS, which is what frees the reverse. Its census went
99 → 102 copies; this one goes 98 → 82 and 394 → 331.

## Exactness at CONUS

Host is exact (`==`) and asserted in the suite. Traced, chemistry is exact and
transport differs only by XLA re-fusing a changed operand graph (FMA and
vectorization order):

| program | max abs difference | ÷ scale | components over 1e-9 of scale |
|---|---|---|---|
| `ros_step` | **0** | 0 | 0 of 85 176 |
| `ros_vjp` λ | **0** | 0 | 0 of 85 176 |
| `ros_vjp` p-grad | 2.5e-24 | 3.5e-20 | 0 of 162 |
| `rhs` | 1.9e-17 | 1.6e-14 | 0 of 85 176 |
| `rhs_vjp` λ | 1.7e-21 | 1.5e-16 | 0 of 85 176 |
| `ssp_step` | 5.6e-15 | **1.1e-18** | 0 of 85 176 |
| `ssp_vjp` λ | 3.5e-18 | 3.2e-16 | 0 of 85 176 |

Not one of the 85 176 state or λ components in any program differs by more than
1e-9 of that quantity's own scale. The POINTWISE relative metric is what
initially read `2.0` on the VJPs and `5.55e-15` on `ssp_step`: it is
uninformative on components at ~1e-310 (rel 2.0 is the signature of an
opposite-signed denormal), which is why `P13_SCAL` reports absolute and
scale-relative figures. The only entries with any component over the 1e-9
threshold are the p-gradients of the SINGLE-STEP transport programs, whose whole
gradient vector is ~1e-19 in magnitude because θ barely enters one transport
step — the absolute differences there are 5e-29 and 8e-20.

## Suite

Full `Pkg.test()` with `ESM_TEST_REACTANT=1`, both arms:

* flag **OFF**: **89 034 pass, 8 broken, 89 042 total**, 70 min, exit 0 — the
  default path is untouched.
* forced **`ESS_OOP_SSA=1`**: **89 029 pass, 5 fail, 8 broken, 89 042 total**,
  64 min. All 5 failures are `reactant_oop_intern_test.jl` lines 155, 161, 167,
  168 and 191 — precisely the 5 interning-ENGAGEMENT assertions (`hits == 0`;
  `ops["1"] < ops["0"]` reading 210 < 210) that `SSA_SPIKE.md` already documents
  as the two features composing, with every VALUE assertion passing. Nothing
  else in 89 042 tests fails.

`reactant_oop_test.jl` 35/35 and `reactant_oop_intern_test.jl` 19/19 also pass
standalone with the flag off.

## Recommendation

On this evidence `ESS_OOP_SSA=1` (with these arms, which ride inside it) is
worth defaulting: the dominant loop is 1.36x cheaper and the chemistry half is
exact. Two caveats a maintainer should weigh:

1. flag-on is not bit-identical to flag-off in the traced TRANSPORT path
   (5.6e-15), so defaulting it changes numbers for existing traced users and
   should be a noted change, not a silent one;
2. the transport forward is 1.8x slower, so a caller that runs the transport
   primal without a reverse is worse off. If that matters, the arms already
   have per-arm knobs and the emitter could gate the scatter-skip on producer
   block size — but on the adjoint workload this PR targets, the mix is
   decisively favourable.
