### PR TITLE
perf(oop): the scalar read surfaces DO hold the last two transport scatters -- and freeing them costs 4.3% (default OFF; stacks on #283)

### DIFF
--- a/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
+++ b/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
@@ -180,14 +180,58 @@ fold.
   forcing reads go through the buffers argument, never `ue` — and the
   discrete-cadence refresh stays visible with fill scatters skipped (probed).
 
+## ReSEACT at CONUS: 1.36x on the whole adjoint loop, chemistry exact
+
+Measured 2026-09-09 at 4x5 CONUS (13x7x72, 6 552 cells), two driver builds in
+ONE process, arms interleaved, every pair run in BOTH arm orders — reproducing
+to three digits, so the order is not what is being measured.
+`tools/diag/p13_ssa_ab.jl` + `tools/diag/p11_ue_traffic.py` in the consuming
+repo.
+
+| program | arms off | arms on | off/on | copies | real element writes |
+|---|---|---|---|---|---|
+| `ros_step` (chemistry) | 38.90 ms | 28.23 ms | **1.38** (bit-for-bit) | | |
+| `ros_vjp` | 81.11 ms | 56.71 ms | **1.43** (λ bit-for-bit) | | |
+| `rhs` (transport RHS) | 3.755 ms | 6.405 ms | 0.59 | 2 → 3 | 2.49 M → 2.69 M |
+| `rhs_vjp` | 80.5 ms | 72.2 ms | **1.12** | **98 → 82** | 59.55 M → 55.22 M |
+| `ssp_step` (4-stage) | 13.41 ms | 24.25 ms | 0.55 | 8 → 12 | 10.43 M → 16.97 M |
+| `ssp_vjp` | 306.6 ms | 254.9 ms | **1.20** | **394 → 331** | 231.8 M → 176.3 M |
+
+Weighted by the adjoint's step mix (45.3 chemistry + 3.2 transport steps per
+300 s window) the per-window cost is 6.46 s → 4.74 s, **1.36x**.
+
+WHY THE TRANSPORT FORWARD LOSES. A producer's `dynamic_update_slice` into `ue`
+ALIASES its operand in the FORWARD, so XLA:CPU writes only the update and the
+scatter is nearly free there; skipping it instead forces the producer's value to
+be materialized as its own buffer. On the PPM transport RHS (17 producers,
+blocks up to 3 456 elements) that trade is a loss. On chemistry it is a win in
+both directions, because there the redirect replaces fragmented gathers of the
+12 326-element buffer with gathers of much smaller producer values and 59 of 59
+scatters disappear.
+
+The copies the scatter chain causes are all in the REVERSE, where each `ue`
+version has ~70 live consumers and copy-insertion duplicates the whole buffer
+per version. That is where removing readers pays on both halves: `ssp_vjp`
+loses 63 of its 394 whole-buffer copies and 24% of its write traffic for 1.20x,
+against a ~1.8x ceiling if every copy vanished.
+
+It is also why `ess-oop-levelbase` (one read version per level) failed where
+this succeeds: it reduced VERSIONS, which the forward already got for free,
+instead of removing READERS. Its census went 99 → 102 copies; this one goes
+98 → 82 and 394 → 331.
+
 ## What is NOT verified
 
-The `ESM_TEST_REACTANT=1` traced census (`reactant_oop_ssa_test.jl`) asserts the
-DUS delta equals `n_skipped_scatters` on the toy fixtures; the extension's arms
-are exercised there only insofar as those fixtures engage them. The ReSEACT
-timing A/B and the whole-buffer copy census live in the consuming repo
-(`tools/diag/p13_ssa_ab.jl`, `tools/diag/p11_ue_traffic.py`) because they need
-the offline forcing environment.
+Bit-identity across the arms is asserted and holds on HOST (`==`) and, on the
+toy fixtures, in the traced census (`reactant_oop_ssa_test.jl`, which pins the
+DUS delta to `n_skipped_scatters`). At CONUS the two arms are NOT bit-identical:
+changing the operand graph changes XLA's fusion, hence FMA and vectorization
+order. chemistry `ros_step` is bit-for-bit and `ros_vjp`'s λ is bit-for-bit (its
+p-gradient differs in the 20th significant figure); transport `ssp_step`
+differs by 5.6e-15 pointwise relative. The pointwise metric on the VJPs is
+uninformative — it reads exactly 2.0 on components at ~1e-310 — so the probe
+also reports a scale-relative figure and the count of components over 1e-9 of
+scale.
 
 ## Generalization assessment (honest)
 

--- a/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
+++ b/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
@@ -25,8 +25,24 @@ With the flag on, a consumer descriptor references its producer's RESULT VALUE:
 * **tier 2 (slice)** — the gather decomposes into few consecutive-position runs,
   each inside one producer ⇒ one `slice` per run (+ one `concatenate` when
   more than one run);
+* **tier 2b (producer gather)** — the mapping lies inside ONE producer but
+  shatters into more runs than slices are worth ⇒ one `gather` of that
+  producer's value at producer-local positions. Exactly the single op the dense
+  `ue` gather was, over an index vector of the same length: the win is not op
+  count, it is that the read no longer touches the flat buffer;
 * **tier 3 (fallback)** — everything else keeps the dense gather from `ue`,
   byte-for-byte.
+
+Three descriptor surfaces feed those tiers: a kernel's own top-level
+descriptors, its TEMPLATE SUB-KERNEL (`_NK_SUBCALL`) descriptors — resolved by
+`_build_oop_desc_vectors` against the same parent lanes, so decomposable by the
+same map, but indexed by `S.acc` and therefore carried in a per-sub table — and
+GHOST-MASKED `_AK_STATE_TBL_BOX` descriptors, where a masked lane's value is
+discarded by the emitter's `ifelse` select and is therefore a WILDCARD the
+decomposition fills with whatever continues a neighbouring run. Each of the
+three has a bisect knob (`ESS_OOP_SSA_SUB`, `ESS_OOP_SSA_PGATHER`,
+`ESS_OOP_SSA_GHOST`, all default ON inside `ESS_OOP_SSA=1`), which is what lets
+one process A/B an arm and what each engagement test's negative control flips.
 
 A producer's scatter into `ue` is emitted only when static accounting finds a
 residual reader of its block; otherwise it is skipped and the value flows only
@@ -88,15 +104,51 @@ XLA's optimizer converges the two programs (18 ≡ 18 ops optimized) — at scal
 that convergence is precisely what fails (pairwise slice-CSE went quadratic on
 CONUS; the buffers exceed L3), so the emission-level census is the measure.
 
-## What blocks the rest (tier-3 fallbacks, in expected ReSEACT impact order)
+## Measured on ReSEACT — and the blocker order the spike guessed is WRONG
 
-1. **Ghost-masked `_AK_STATE_TBL_BOX` gathers** (boundary stencils through slot
-   tables with 0-entries). Extension is mechanical: redirect the safe-index
-   gather to producer slices and keep the select-against-mask.
-2. **Sub-kernel (`_NK_SUBCALL`) descriptor plans.** Their tables are resolved
-   against parent lanes but indexed per-sub, so the per-kernel redirect table
-   does not align; needs per-sub redirect tables built in
-   `_build_oop_acc_plan`-style. Mechanical, not conceptual.
+The spike listed its remaining tier-3 fallbacks "in expected ReSEACT impact
+order" and put ghost-masked table gathers first. `oop_ssa_stats` now carries a
+per-reason blocker tally (which read surface still reads each surviving
+producer's block), and on the ReSEACT transport RHS at 6x6x8 it says:
+
+| | spike | + this extension |
+|---|---|---|
+| top-level edges redirected | 51 / 100 | **97 / 100** |
+| top-level elements | 5 292 / 32 148 | **24 948 / 32 148** |
+| SUB-KERNEL descriptors redirected | 0 / 885 | **731 / 885** |
+| sub-kernel elements | 0 / 1 074 487 | **896 863 / 1 074 487** |
+| producer scatters skipped | 6 / 17 | **13 / 17** |
+| blocked producers, by reason | sub 9, frag 5, scalar 2, scan 1 | sub 2, scalar 2, scan 1 |
+| … blocked SOLELY by that reason | sub 4, frag 1 | scalar 2, sub 1 |
+
+Two things in that table refute the spike's ordering:
+
+* **there are ZERO ghost-masked descriptors in this build** (`n_ghost_edges = 0`
+  at both 6x6x8 and on split part 2), and none at all in any of the 1-D host
+  fixtures — so blocker #1, the one the note called the primary target, has no
+  coverage to give here. It is implemented anyway (it is cheap and it is
+  correct), and the unit tests cover it directly, but it is not what was
+  holding the scatters.
+* **the sub-kernel descriptors are the read surface that matters**: 885 of the
+  985 candidate descriptors and 1 074 487 of the 1 106 635 candidate READ
+  ELEMENTS — 33x the top-level edges' volume — and they held 9 of the 11
+  surviving producer scatters alive. Blocker #2, listed second and described as
+  "mechanical, not conceptual", was the whole game.
+
+E-lane CSR gathers (#3) and `_AK_STATE_FIXED` pins are likewise 0 here. What is
+left is blocker #4 (scalar-walker reads: 2 producers, and BOTH of them are
+blocked by nothing else) plus one sub-kernel descriptor group and one level scan
+fold.
+
+## What blocks the rest (tier-3 fallbacks, in the order the spike GUESSED)
+
+1. ~~**Ghost-masked `_AK_STATE_TBL_BOX` gathers**~~ — CLOSED (`_ssa_lane_owners`'
+   wildcard fill), and measured at ZERO coverage on ReSEACT: no build in this
+   corpus emits one. Kept because it is correct and free.
+2. ~~**Sub-kernel (`_NK_SUBCALL`) descriptor plans**~~ — CLOSED (per-sub tables
+   on `_OopSSAKernel.subs`, `_oop_ssa_subctx` at the `_NK_SUBCALL` arm). This
+   was the real blocker: 731/885 descriptors and 896 863 read elements
+   redirected, 7 more producer scatters skipped.
 3. **E-lane (in-reduce) CSR gathers.** Per-entry `(cell, neighbour)` reads
    repeat cells — median run length 1 — so slices+concat lose to the gather;
    would need segment-level ops instead. Left as gathers deliberately.
@@ -104,8 +156,10 @@ CONUS; the buffers exceed L3), so the emission-level census is the measure.
    `_NK_STATE_GATHER`, batch slot vectors). Redirectable through the same
    slot→(producer, position) map; not done in the spike. They also hold
    producer scatters alive wherever they read.
-5. **Fragmented gathers** (`nseg > max(8, L÷4)`): kept dense by the
-   worthwhileness threshold; they also keep their producers' scatters.
+5. ~~**Fragmented gathers**~~ (`nseg > min(64, max(8, L÷4))`) — CLOSED by tier
+   2b: past the slice threshold a single-producer mapping gathers the producer's
+   VALUE instead of the buffer. `frag` went 5 blocked producers → 0. A
+   fragmented MULTI-producer mapping has no one-op form and still falls back.
 6. **Per-cell fallback kernels** disable scatter-skipping globally (reads
    un-enumerable). Rare on affine builds.
 
@@ -125,6 +179,15 @@ CONUS; the buffers exceed L3), so the emission-level census is the measure.
 * Live forcing (`param_arrays`/`rhs_with_buffers`) rides through unchanged —
   forcing reads go through the buffers argument, never `ue` — and the
   discrete-cadence refresh stays visible with fill scatters skipped (probed).
+
+## What is NOT verified
+
+The `ESM_TEST_REACTANT=1` traced census (`reactant_oop_ssa_test.jl`) asserts the
+DUS delta equals `n_skipped_scatters` on the toy fixtures; the extension's arms
+are exercised there only insofar as those fixtures engage them. The ReSEACT
+timing A/B and the whole-buffer copy census live in the consuming repo
+(`tools/diag/p13_ssa_ab.jl`, `tools/diag/p11_ue_traffic.py`) because they need
+the offline forcing environment.
 
 ## Generalization assessment (honest)
 

--- a/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
+++ b/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
@@ -33,6 +33,17 @@ With the flag on, a consumer descriptor references its producer's RESULT VALUE:
 * **tier 3 (fallback)** — everything else keeps the dense gather from `ue`,
   byte-for-byte.
 
+The same slot→(producer, position) map also serves the **scalar read
+surfaces** — the scalar `_Node` walker (`_oop_eval`: a `_NK_STATE` pin, a
+`_NK_STATE_GATHER` slot table) and its lane-batched twin (`_oop_eval_batch`) —
+which have no descriptor to key a per-kernel table on. There it is published
+per surface as a consumer LEVEL (`_OopSSAOwn` + `_OopSSASCtx`): a scalar read
+of slot `s` redirects iff `s` has an owner and that owner's level is strictly
+below the surface's. The scalar walker decides per SLOT (it can fall back per
+read); the batched walker returns a whole lane vector through one gather, so it
+decides per NODE and requires one common producer across every lane (ghost
+lanes are wildcards — the select discards them).
+
 Three descriptor surfaces feed those tiers: a kernel's own top-level
 descriptors, its TEMPLATE SUB-KERNEL (`_NK_SUBCALL`) descriptors — resolved by
 `_build_oop_desc_vectors` against the same parent lanes, so decomposable by the
@@ -56,11 +67,15 @@ through references. Final `du` scatters (the real output) are untouched.
   scalar fills, per-cell fallback kernels, or level scan folds are disowned
   (or re-owned by the later writer), and the level check refuses any redirect
   that could observe the wrong write.
-* Every non-redirected read surface marks residual slots: scalar-walker trees
-  (`_NK_STATE`, `_NK_STATE_GATHER`), E-lane (in-reduce) and sub-kernel plans,
-  `_AK_STATE_FIXED` pins, ghost-masked table gathers, declined descriptors,
-  level scan folds. Any per-cell (non-vectorizable) kernel disables ALL
-  scatter skipping — its reads cannot be enumerated.
+* Every non-redirected read surface marks residual slots: E-lane (in-reduce)
+  and sub-kernel plans, `_AK_STATE_FIXED` pins, ghost-masked table gathers,
+  declined descriptors, level scan folds, and the scalar reads the surface map
+  refuses. Any per-cell (non-vectorizable) kernel disables ALL scatter
+  skipping — its reads cannot be enumerated.
+* The scalar arm's build-time marking (`_ssa_mark_node_reads!` /
+  `_ssa_mark_batch_reads!`) and its walk-time seams share ONE predicate
+  (`_ssa_owner_pid`), so a slot is marked residual exactly when the walker will
+  read it off `ue` — the two cannot drift.
 * Runtime guard: a producer whose spine hoists to a lane-invariant SCALAR
   records no value; redirects to it fall back to the gather and its scatter
   still runs, so the build-time `skip` verdict never outruns reality.
@@ -155,10 +170,32 @@ fold.
 3. **E-lane (in-reduce) CSR gathers.** Per-entry `(cell, neighbour)` reads
    repeat cells — median run length 1 — so slices+concat lose to the gather;
    would need segment-level ops instead. Left as gathers deliberately.
-4. **Scalar-walker and lane-batched scalar reads** (`_NK_STATE`,
-   `_NK_STATE_GATHER`, batch slot vectors). Redirectable through the same
-   slot→(producer, position) map; not done in the spike. They also hold
-   producer scatters alive wherever they read.
+4. **Scalar-walker and lane-batched scalar reads** — **built, MEASURED, and
+   shipped OFF** (`ESS_OOP_SSA_SCALAR=1` opts in). Both walkers redirect
+   through the same slot→(producer, position) map, published per surface as a
+   consumer level, so item 4's premise was right: the surface IS redirectable
+   through the existing map. On the ReSEACT transport RHS at 6x6x8 it was the
+   SOLE blocker on 2 of the 4 surviving producers (two level-3/4 per-column
+   fills reading a lower level's kernel output through a `_NK_STATE_GATHER`,
+   404 352 read elements), and closing it takes scatters-skipped **13/17 →
+   15/17** (4 874 → 5 450 slots) with the `scalar` blocker row at zero.
+
+   It does not pay. At CONUS 4x5: `rhs` flat (ratio 1.010), **`rhs_vjp` 4.3%
+   SLOWER** (71.41 → 74.59 ms). Copy census: whole-buffer copies 82 → 80 —
+   the two scatters it really did free — against total copy instructions
+   **290 → 432** and real element writes 55.22 → 56.11 M. The scalar surfaces'
+   reads were already CHEAP relative to the buffer versions they kept alive (a
+   handful of gathers per level, not O(cells) of them), so freeing two scatters
+   buys little while the redirect's own materialization — a producer-value
+   gather per lane group, off a value XLA must keep live across the level
+   boundary — adds copies. That is the scatter-skip gate's mechanism again: a
+   PARTIAL skip pays twice, once for the buffer that still gets assembled and
+   once for the value kept alive beside it. Coverage is not the objective
+   function; the copy census is.
+
+   What survives as load-bearing is the INSTRUMENTATION: the `scalar` blocker
+   row and the scalar edge columns of `oop_ssa_stats`. What is left on that RHS
+   is one sub-kernel descriptor group and one level scan fold.
 5. ~~**Fragmented gathers**~~ (`nseg > min(64, max(8, L÷4))`) — CLOSED by tier
    2b: past the slice threshold a single-producer mapping gathers the producer's
    VALUE instead of the buffer. `frag` went 5 blocked producers → 0. A

--- a/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
+++ b/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
@@ -82,7 +82,10 @@ vectorizable kernels (ghost-masked ones excluded and counted as fallback).
 | merged class (g1,g2 → one kernel, N=6) | 3/3 | 24/24 | 1/1 | member reads = slices at offsets inside ONE producer value |
 | reaction–diffusion, no observeds (N=16) | 7/7 | 46/46 | 0/0 | prefix reads become slices of `u` |
 
-Whole host corpus green with the flag FORCED on: tree_walk_oop (164),
+Full suite (`Pkg.test()`, `ESM_TEST_REACTANT=1`) at 4x5-era main: flag OFF
+89 034 pass / 8 broken / 89 042; forced ON 89 029 pass / 5 fail / 8 broken, the
+5 being exactly `reactant_oop_intern_test.jl`'s interning-ENGAGEMENT assertions
+(see Interactions below). Whole host corpus green with the flag FORCED on: tree_walk_oop (164),
 oop_merge (75), array_obs_materialize (78), scan_prefix (333),
 oop_scalar_batch (42), observed_materialization (20), observed_slots (36),
 iip_generic — all bit-identical to `f!` — and green with the flag OFF
@@ -226,12 +229,13 @@ Bit-identity across the arms is asserted and holds on HOST (`==`) and, on the
 toy fixtures, in the traced census (`reactant_oop_ssa_test.jl`, which pins the
 DUS delta to `n_skipped_scatters`). At CONUS the two arms are NOT bit-identical:
 changing the operand graph changes XLA's fusion, hence FMA and vectorization
-order. chemistry `ros_step` is bit-for-bit and `ros_vjp`'s λ is bit-for-bit (its
-p-gradient differs in the 20th significant figure); transport `ssp_step`
-differs by 5.6e-15 pointwise relative. The pointwise metric on the VJPs is
-uninformative — it reads exactly 2.0 on components at ~1e-310 — so the probe
-also reports a scale-relative figure and the count of components over 1e-9 of
-scale.
+order. chemistry `ros_step` is bit-for-bit and `ros_vjp`'s λ is bit-for-bit; on
+transport the largest ABSOLUTE difference is 5.6e-15 on `ssp_step` (1.1e-18 of
+scale) and 3.5e-18 on `ssp_vjp`'s λ (3.2e-16 of scale), and NOT ONE of the
+85 176 state or λ components in any program differs by more than 1e-9 of that
+quantity's own scale. The POINTWISE relative metric is uninformative here — it
+reads exactly 2.0 on an opposite-signed component at ~1e-310 — which is why the
+probe reports absolute and scale-relative figures plus a component count.
 
 ## Generalization assessment (honest)
 

--- a/pkg/EarthSciAST.jl/src/tree_walk/oop.jl
+++ b/pkg/EarthSciAST.jl/src/tree_walk/oop.jl
@@ -2375,14 +2375,22 @@ const _OOP_NO_SUB = _OopSubRT(_AccKernel[], _OopAccPlan[], Vector{Any}[], Vector
 # reads part of it — and the scatter into `ue` is emitted only where something
 # genuinely still reads the flat buffer.
 #
-# THREE TIERS, decided per consumer DESCRIPTOR at build time:
+# FOUR TIERS, decided per consumer DESCRIPTOR at build time:
 #   1. direct: the gather is one producer's entire block ⇒ the producer's SSA
 #      value, no op at all;
 #   2. slice: the gather decomposes into few consecutive-position runs, each
 #      inside one producer ⇒ per-run slices (+ one concatenate when > 1);
-#   3. fallback: anything else — non-affine tables, ghost-masked gathers,
-#      E-lane (in-reduce) and sub-kernel reads, scalar-walker reads — keeps the
+#   2b. producer gather: too fragmented for slices but inside ONE producer ⇒
+#      one gather of that producer's VALUE at producer-local positions — the
+#      same single op, off the value rather than the flat buffer;
+#   3. fallback: anything else — multi-producer fragmented mappings, unowned
+#      slots, E-lane (in-reduce) reads, scalar-walker reads — keeps the
 #      existing dense gather from `ue`, byte-for-byte.
+#
+# THREE DESCRIPTOR SURFACES feed those tiers: a kernel's own descriptors, its
+# TEMPLATE SUB-KERNEL descriptors (same parent lanes, own `S.acc` table — see
+# `_OopSSAKernel.subs`), and GHOST-MASKED table gathers, whose masked lanes are
+# wildcards because the emitter's select discards them.
 #
 # SOUNDNESS RESTS ON THREE STATIC FACTS, all established by the existing build:
 #   * a fill level reads the state and STRICTLY LOWER levels only (the
@@ -2395,9 +2403,11 @@ const _OOP_NO_SUB = _OopSubRT(_AccKernel[], _OopAccPlan[], Vector{Any}[], Vector
 #     that would observe the wrong write;
 #   * a producer's scatter into `ue` is skipped ONLY when static accounting
 #     shows every read of its block was redirected — every non-redirected read
-#     surface (scalar `_Node` walks, E-lane/sub-kernel plans, `_AK_STATE_FIXED`
-#     pins, ghost gathers, level scan folds, declined descriptors) marks its
-#     slots as residual, and ANY per-cell (non-vectorizable) kernel disables
+#     surface (scalar `_Node` walks, E-lane plans, `_AK_STATE_FIXED` pins,
+#     level scan folds, declined descriptors — sub-kernel and ghost-masked
+#     plans only where THEY decline) marks its slots as residual, and reduces
+#     per producer into the blocker tally `oop_ssa_stats` reports; ANY per-cell
+#     (non-vectorizable) kernel disables
 #     skipping wholesale, because its reads cannot be enumerated.
 #
 # BIT-IDENTITY. A redirected read returns the exact array the scatter would
@@ -2418,39 +2428,90 @@ struct _OopSSASeg
     len::Int     # run length
 end
 
+# ONE consumer descriptor's redirect. Exactly one form is populated:
+#
+#   * `segs` non-empty — consecutive-position RUNS: the producer's whole value
+#     (tier 1, no op at all) or one slice per run plus a concatenate (tier 2);
+#   * `pid != 0` — ONE producer, arbitrary positions: a single gather of that
+#     producer's VALUE at `pos` (tier 2b). This is the same single op the dense
+#     `ue` gather was, over an index vector of the same length — the win is not
+#     op count, it is that the read no longer touches the flat buffer, so the
+#     producer's scatter into it can go. It is what a FRAGMENTED mapping (one
+#     that shatters into more runs than slices are worth) takes instead of the
+#     fallback.
+#
+# Both empty ⇒ the descriptor keeps the dense `ue` gather (tier 3).
+struct _OopSSARef
+    segs::Vector{_OopSSASeg}
+    pid::Int
+    pos::Vector{Int}
+end
+const _OOP_SSA_NOREF = _OopSSARef(_OopSSASeg[], 0, Int[])
+
 # Per-kernel build-time SSA role: its producer id (0 ⇒ untracked), whether its
 # scatter into `ue` may be skipped (valid only when the runtime result is a
-# lane vector of the planned length), and the per-descriptor redirect table
-# (aligned with `K.acc`; an empty entry keeps the gather path).
+# lane vector of the planned length), the per-descriptor redirect table
+# (aligned with `K.acc`; a `_OOP_SSA_NOREF` entry keeps the gather path), and
+# the same table for each TEMPLATE SUB-KERNEL, aligned with `plan.subs`.
+#
+# The sub tables are sound for the same reason the parent's are: a sub-kernel is
+# evaluated at the PARENT's lanes and `_build_oop_desc_vectors` resolves its
+# descriptors against that same lane enumeration, so its gather index vectors
+# are slot vectors into `ue` exactly like the parent's, decomposable by exactly
+# the same map. Only the TABLE differs (`S.acc`, not `K.acc`), which is why the
+# spike could not reuse the parent's.
 struct _OopSSAKernel
     pid::Int
     skip::Bool
-    desc::Vector{Vector{_OopSSASeg}}
+    desc::Vector{_OopSSARef}
+    subs::Vector{Vector{_OopSSARef}}
 end
-const _OOP_SSA_KERNEL_OFF = _OopSSAKernel(0, false, Vector{_OopSSASeg}[])
+const _OOP_SSA_NO_SUBDESC = Vector{_OopSSARef}[]
+const _OOP_SSA_KERNEL_OFF = _OopSSAKernel(0, false, _OopSSARef[], _OOP_SSA_NO_SUBDESC)
 const _OOP_SSA_EMPTY_KS = _OopSSAKernel[]
 const _OOP_SSA_NO_VALS = Any[]
 
-# The walk-time context: the CURRENT kernel's redirect table plus this call's
-# producer values. Downgraded to the OFF singleton on entering a `_NK_SUBCALL`
-# or `_NK_REDUCE` body, whose descriptor plans index a different lane space
-# than the table was computed against.
+# The walk-time context: the CURRENT descriptor table, this call's producer
+# values, and the parent kernel's per-sub tables (carried through unchanged, so
+# a NESTED `_NK_SUBCALL` — which resolves against the same flat `plan.subs`
+# list — keeps working). Downgraded to the OFF singleton on entering a
+# `_NK_REDUCE` body, whose E-lane plan indexes per ENTRY rather than per lane.
 struct _OopSSACtx
-    desc::Vector{Vector{_OopSSASeg}}
+    desc::Vector{_OopSSARef}
     vals::Vector{Any}
+    subs::Vector{Vector{_OopSSARef}}
 end
-const _OOP_SSA_CTX_OFF = _OopSSACtx(Vector{_OopSSASeg}[], _OOP_SSA_NO_VALS)
+const _OOP_SSA_CTX_OFF = _OopSSACtx(_OopSSARef[], _OOP_SSA_NO_VALS, _OOP_SSA_NO_SUBDESC)
 
 @inline _oop_ssa_k(ks::Vector{_OopSSAKernel}, j::Int) =
     isempty(ks) ? _OOP_SSA_KERNEL_OFF : @inbounds ks[j]
 
+@inline _oop_ssa_ctx(ssak::_OopSSAKernel, vals::Vector{Any}) =
+    (isempty(ssak.desc) && isempty(ssak.subs)) ? _OOP_SSA_CTX_OFF :
+    _OopSSACtx(ssak.desc, vals, ssak.subs)
+
+# The context for sub-kernel `j` of the kernel this context belongs to.
+@inline function _oop_ssa_subctx(ssa::_OopSSACtx, j::Int)
+    sv = ssa.subs
+    (isempty(sv) || j > length(sv)) && return _OOP_SSA_CTX_OFF
+    d = @inbounds sv[j]
+    isempty(d) && return _OOP_SSA_CTX_OFF
+    return _OopSSACtx(d, ssa.vals, sv)
+end
+
 # Resolve one redirected descriptor to a producer-value reference, or `nothing`
-# to take the gather fallback (redirect table empty, or a referenced producer
-# recorded no lane vector this call).
-@inline function _oop_ssa_ref(ssa::_OopSSACtx, i::Int)
+# to take the gather fallback (no redirect, or a referenced producer recorded no
+# lane vector this call).
+@inline function _oop_ssa_ref(ssa::_OopSSACtx, i::Int, memo)
     d = ssa.desc
     isempty(d) && return nothing
-    segs = @inbounds d[i]
+    r = @inbounds d[i]
+    if r.pid != 0
+        v = @inbounds ssa.vals[r.pid]
+        v isa AbstractArray || return nothing
+        return _oop_gather(v, r.pos, memo)               # tier 2b
+    end
+    segs = r.segs
     isempty(segs) && return nothing
     return _oop_ssa_resolve(ssa.vals, segs)
 end
@@ -2496,17 +2557,20 @@ function _oop_eval_acck(nd::_Node, u, p, t, K::_AccKernel, plan::_OopAccPlan,
             # (`_AK_CONST_EDGE` falls through to the frozen-consts arm below.)
             # An SSA-redirected descriptor (ess-oop-ssa) references its producer's
             # value instead of gathering the flat buffer; `nothing` ⇒ gather.
-            v = _oop_ssa_ref(ssa, nd.idx)
+            v = _oop_ssa_ref(ssa, nd.idx, fb.memo)
             v === nothing || return v
             return _oop_gather(u, plan.gathers[nd.idx], fb.memo)
         elseif ak === _AK_STATE_TBL_BOX
             m = plan.ghost[nd.idx]
-            if isempty(m)
-                # Ghost-free table gathers are ordinary reads and may redirect;
-                # a ghost-bearing one keeps the gather+select path (its safe-index
-                # lanes read a slot the redirect analysis never modeled).
-                v = _oop_ssa_ref(ssa, nd.idx)
-                v === nothing || return v
+            # A redirected descriptor (ess-oop-ssa) references its producer's
+            # value instead of gathering the flat buffer. A GHOST-BEARING one
+            # redirects too (`_ssa_lane_owners`): its concrete lanes carry the
+            # producer positions the gather would have read, its masked lanes
+            # carry placeholders, and the select below overwrites exactly those
+            # with 0.0 — so the result is the gather's, element for element.
+            v = _oop_ssa_ref(ssa, nd.idx, fb.memo)
+            if v !== nothing
+                return isempty(m) ? v : ifelse.(m, zero(T), v)
             end
             g = _oop_gather(u, plan.gathers[nd.idx], fb.memo)
             # ghost lanes (table slot 0) select 0.0 — the in-place runners'
@@ -2551,11 +2615,16 @@ function _oop_eval_acck(nd::_Node, u, p, t, K::_AccKernel, plan::_OopAccPlan,
         Sp = @inbounds sub.plans[j]
         iv = @inbounds sub.invvals[j]
         cv = @inbounds sub.cellvals[j]
+        # The sub's OWN redirect table (ess-oop-ssa): its descriptors were
+        # resolved against these same parent lanes, so they decompose by the
+        # same slot→(producer, position) map — but they index `S.acc`, which is
+        # why the table cannot be the parent's.
+        ssaS = _oop_ssa_subctx(ssa, j)
         rs = S.cse.recipes
         @inbounds for i in eachindex(rs)
-            cv[i] = _oop_eval_acck(rs[i], u, p, t, S, Sp, iv, cv, sub, fb, T)
+            cv[i] = _oop_eval_acck(rs[i], u, p, t, S, Sp, iv, cv, sub, fb, T, ssaS)
         end
-        return _oop_eval_acck(S.spine, u, p, t, S, Sp, iv, cv, sub, fb, T)
+        return _oop_eval_acck(S.spine, u, p, t, S, Sp, iv, cv, sub, fb, T, ssaS)
     elseif k === _NK_REDUCE
         # Variable-valence sum reduction, CSR-segmented (gordian reduce-vectorize):
         # evaluate the body ONCE over the flat E-lane buffer (its only state access
@@ -2671,15 +2740,16 @@ function _oop_run_acc_vec(du, u, p, t, K::_AccKernel, plan::_OopAccPlan,
                           ::Type{T}, fb::_OopForcing=_OOP_NO_FORCING,
                           ssak::_OopSSAKernel=_OOP_SSA_KERNEL_OFF,
                           vals::Vector{Any}=_OOP_SSA_NO_VALS) where {T}
-    ssa = isempty(ssak.desc) ? _OOP_SSA_CTX_OFF : _OopSSACtx(ssak.desc, vals)
+    ssa = _oop_ssa_ctx(ssak, vals)
     sub = _oop_build_subrt(plan)
     for j in eachindex(sub.subs)
         S = @inbounds sub.subs[j]
         Sp = @inbounds sub.plans[j]
         iv = @inbounds sub.invvals[j]; cv = @inbounds sub.cellvals[j]
+        ssaS = _oop_ssa_subctx(ssa, j)
         ir = S.cse.inv_recipes
         @inbounds for i in eachindex(ir)
-            iv[i] = _oop_eval_acck(ir[i], u, p, t, S, Sp, iv, cv, sub, fb, T)
+            iv[i] = _oop_eval_acck(ir[i], u, p, t, S, Sp, iv, cv, sub, fb, T, ssaS)
         end
     end
     cse = K.cse
@@ -2834,10 +2904,45 @@ end
 
 _oop_ssa_enabled() = get(ENV, "ESS_OOP_SSA", "") == "1"
 
+# Bisect knobs for the three redirect arms added after the spike, all riding
+# inside `ESS_OOP_SSA=1` and all default ON. Setting one to 0 declines exactly
+# that arm while KEEPING the per-blocker attribution below, so one process can
+# A/B an arm without a second checkout — which is how the arms were measured
+# (setup wall on this filesystem is not a usable metric) — and so the test file
+# has a negative control for each.
+#
+#   ESS_OOP_SSA_GHOST=0     ghost-masked `_AK_STATE_TBL_BOX` descriptors
+#                           (`_ssa_lane_owners`' wildcard fill)
+#   ESS_OOP_SSA_SUB=0       template sub-kernel (`_NK_SUBCALL`) descriptor tables
+#   ESS_OOP_SSA_PGATHER=0   tier 2b, the single-producer value gather
+_oop_ssa_ghost_enabled()   = get(ENV, "ESS_OOP_SSA_GHOST", "1") != "0"
+_oop_ssa_sub_enabled()     = get(ENV, "ESS_OOP_SSA_SUB", "1") != "0"
+_oop_ssa_pgather_enabled() = get(ENV, "ESS_OOP_SSA_PGATHER", "1") != "0"
+
+# WHY a residual `ue` read exists, one bit per read surface, carried per slot in
+# the analysis' `resid` map and reduced per producer into the blocker tally
+# `oop_ssa_stats` reports. The tally is the campaign's steering instrument: a
+# producer's scatter survives because SOME surface still reads its block, and
+# only the per-reason breakdown says which extension would free it.
+const _SSA_R_SCALAR = 0x01   # scalar-walker read (`_NK_STATE`/`_NK_STATE_GATHER`)
+const _SSA_R_SCAN   = 0x02   # a fill level's scan fold reads its own slots back
+const _SSA_R_FIXED  = 0x04   # `_AK_STATE_FIXED` descriptor pin
+const _SSA_R_GHOST  = 0x08   # ghost-masked table gather kept dense
+const _SSA_R_DENSE  = 0x10   # descriptor whose gather did not decompose
+const _SSA_R_FRAG   = 0x20   # decomposed, but too fragmented to be worthwhile
+const _SSA_R_SUB    = 0x40   # sub-kernel (`_NK_SUBCALL`) descriptor plan gather
+const _SSA_R_ELANE  = 0x80   # E-lane (in-reduce) CSR plan gather
+const _SSA_R_NAMES = (:scalar, :scan, :fixed, :ghost, :dense, :frag, :sub, :elane)
+const _SSA_R_BITS = (_SSA_R_SCALAR, _SSA_R_SCAN, _SSA_R_FIXED, _SSA_R_GHOST,
+                     _SSA_R_DENSE, _SSA_R_FRAG, _SSA_R_SUB, _SSA_R_ELANE)
+
 # Redirect coverage + accounting for one build, kept on the closure for
 # reflection (`oop_ssa_stats`). "Edges" are the redirect CANDIDATES: top-level
-# cell-lane state-gather descriptors of vectorizable kernels (ghost-masked ones
-# excluded); an edge is "fast" when it was redirected to producer values.
+# cell-lane state-gather descriptors of vectorizable kernels; an edge is "fast"
+# when it was redirected to producer values. GHOST-MASKED descriptors are
+# counted in their OWN pair of columns (`n_gedges`/`n_gfast`), not in
+# `n_edges`/`n_fast`, so the plain-edge coverage number stays comparable across
+# the feature's revisions.
 struct _OopSSAStats
     n_edges::Int
     n_fast::Int
@@ -2847,7 +2952,18 @@ struct _OopSSAStats
     n_skip::Int           # producers whose `ue` scatter is statically skippable
     elems_skip::Int       # Σ out_slots lengths over skippable producers
     dynamic::Bool         # a per-cell kernel exists ⇒ no scatter may be skipped
+    n_gedges::Int         # ghost-masked candidate descriptors
+    n_gfast::Int          # … of which redirected to producer values + select
+    elems_gedges::Int
+    elems_gfast::Int
+    n_sedges::Int         # TEMPLATE SUB-KERNEL candidate descriptors
+    n_sfast::Int          # … of which redirected
+    elems_sedges::Int
+    elems_sfast::Int
+    blk::NTuple{8,Int}      # producers whose residual set includes reason k
+    blk_only::NTuple{8,Int} # … producers blocked SOLELY by reason k
 end
+const _SSA_BLK0 = ntuple(_ -> 0, 8)
 
 struct _OopSSAPlan
     enabled::Bool
@@ -2857,20 +2973,22 @@ struct _OopSSAPlan
     stats::_OopSSAStats
 end
 const _OOP_SSA_OFF = _OopSSAPlan(false, 0, Vector{_OopSSAKernel}[], _OopSSAKernel[],
-                                 _OopSSAStats(0, 0, 0, 0, 0, 0, 0, false))
+                                 _OopSSAStats(0, 0, 0, 0, 0, 0, 0, false,
+                                              0, 0, 0, 0, 0, 0, 0, 0,
+                                              _SSA_BLK0, _SSA_BLK0))
 
 # Residual `ue` reads of the scalar walkers: `_NK_STATE` pins one slot,
 # `_NK_STATE_GATHER` may read any slot in its table (its subscripts are
 # runtime loop counters). Everything else that reads the state does so through
 # an access-kernel plan, which the caller accounts separately.
-function _ssa_mark_node_reads!(resid::BitVector, n::_Node)
+function _ssa_mark_node_reads!(resid::Vector{UInt8}, n::_Node)
     k = n.kind
     if k === _NK_STATE
-        1 <= n.idx <= length(resid) && (resid[n.idx] = true)
+        1 <= n.idx <= length(resid) && (resid[n.idx] |= _SSA_R_SCALAR)
     elseif k === _NK_STATE_GATHER
         sg = n.payload::_StateGather
         for s in sg.slot_flat
-            1 <= s <= length(resid) && (resid[s] = true)
+            1 <= s <= length(resid) && (resid[s] |= _SSA_R_SCALAR)
         end
     end
     for c in n.children
@@ -2879,50 +2997,115 @@ function _ssa_mark_node_reads!(resid::BitVector, n::_Node)
     return nothing
 end
 
-# Decompose one gather-index vector into consecutive-position runs over the
-# slot-ownership maps, or `nothing` when any element is unowned or its producer
-# does not strictly precede the consumer (`cons_level`).
-function _ssa_decompose(g::Vector{Int}, own_pid::Vector{Int32}, own_pos::Vector{Int32},
-                        prod_level::Vector{Int}, cons_level::Int)
-    segs = _OopSSASeg[]
-    i = 1
+# Resolve one gather-index vector to per-lane (producer, position) ownership, or
+# `nothing` when any lane is unowned or its producer does not strictly precede
+# the consumer (`cons_level`).
+#
+# `m` is the descriptor's GHOST mask (empty ⇒ none). A ghost-bearing
+# `_AK_STATE_TBL_BOX` is a BOUNDARY STENCIL: the in-place runners read
+# `s == 0 ? 0.0 : u[s]`, and the vectorized emitter reproduces that as one
+# gather at a SAFE index (slot 1 substituted for every ghost) followed by
+# `ifelse.(mask, 0, ·)`. Run decomposition over the substituted vector is
+# hopeless — the 1s shatter every run — but a masked lane's value is DISCARDED
+# by that select, so it is a WILDCARD here: fill it with whatever (producer,
+# position) CONTINUES a neighbouring run, forward from a resolved left neighbour
+# first, then backward from a resolved right one, and only fall back to a
+# placeholder when neither exists. A one-sided stencil at the grid edge then
+# collapses to a SINGLE slice of its producer, with the select the op it was.
+#
+# `prod_len[pid]` is the producer's value length (entry 1 = `n_states`, the raw
+# state), bounding the positions a filler may invent.
+function _ssa_lane_owners(g::Vector{Int}, m::Vector{Bool},
+                          own_pid::Vector{Int32}, own_pos::Vector{Int32},
+                          prod_level::Vector{Int}, prod_len::Vector{Int},
+                          cons_level::Int)
     L = length(g)
     n = length(own_pid)
-    while i <= L
-        s = g[i]
-        (1 <= s <= n) || return nothing
-        pid = Int(@inbounds own_pid[s])
+    masked = !isempty(m)
+    masked && length(m) != L && return nothing
+    pid_l = zeros(Int, L)               # 0 ⇒ unresolved (a masked lane, so far)
+    pos_l = zeros(Int, L)
+    nconc = 0
+    @inbounds for l in 1:L
+        masked && m[l] && continue
+        sl = g[l]
+        (1 <= sl <= n) || return nothing
+        pid = Int(own_pid[sl])
         pid == 0 && return nothing
-        @inbounds prod_level[pid] < cons_level || return nothing
-        lo = Int(@inbounds own_pos[s])
+        prod_level[pid] < cons_level || return nothing
+        pid_l[l] = pid
+        pos_l[l] = Int(own_pos[sl])
+        nconc += 1
+    end
+    # An ALL-ghost descriptor is a constant zero vector; that is a different
+    # (and much rarer) rewrite, so decline it here rather than model it.
+    nconc == 0 && return nothing
+    if masked && nconc < L
+        @inbounds for l in 2:L                        # extend forward
+            pid_l[l] == 0 || continue
+            pl = pid_l[l - 1]
+            (pl != 0 && pos_l[l - 1] + 1 <= prod_len[pl]) || continue
+            pid_l[l] = pl
+            pos_l[l] = pos_l[l - 1] + 1
+        end
+        @inbounds for l in (L - 1):-1:1               # then backward
+            pid_l[l] == 0 || continue
+            pr = pid_l[l + 1]
+            (pr != 0 && pos_l[l + 1] - 1 >= 1) || continue
+            pid_l[l] = pr
+            pos_l[l] = pos_l[l + 1] - 1
+        end
+        @inbounds for l in 1:L                        # placeholder: state slot 1
+            pid_l[l] == 0 || continue
+            prod_len[1] >= 1 || return nothing
+            pid_l[l] = 1
+            pos_l[l] = 1
+        end
+    end
+    return pid_l, pos_l
+end
+
+# A RUN decomposition must BEAT the gather it replaces: accept when the run
+# count is small against the lane count (each run is one slice; > 1 also costs a
+# concatenate). The cap must be ABSOLUTE as well as relative: lattice run counts
+# grow ~O(sqrt NC) with the grid, and a purely relative bound (L>>2 = 1,638 at
+# CONUS) admitted edges of hundreds of slices each -- the emitted module
+# overflowed XLA:CPU's contiguous JIT section arena ("Unable to allocate section
+# memory") at 13x7x72 while RSS sat at 6.7 GB. 64 leaves the measured 6x6x8
+# behaviour (L>>2 = 72) essentially unchanged. A mapping that fails this test is
+# NOT back to the flat buffer whenever it lies inside ONE producer: tier 2b then
+# gathers that producer's value, one op, same index volume (see `_OopSSARef`).
+@inline _ssa_worthwhile(L::Int, nseg::Int) = nseg <= min(64, max(8, L >> 2))
+
+# Pick the cheapest reference form for a resolved descriptor, or
+# `_OOP_SSA_NOREF` when none beats the dense `ue` gather.
+function _ssa_pack_ref(pid_l::Vector{Int}, pos_l::Vector{Int}, pgather_ok::Bool)
+    L = length(pid_l)
+    segs = _OopSSASeg[]
+    l = 1
+    @inbounds while l <= L
+        pid = pid_l[l]
+        lo = pos_l[l]
         len = 1
-        while i + len <= L
-            s2 = g[i + len]
-            (1 <= s2 <= n) || return nothing
-            (Int(@inbounds own_pid[s2]) == pid &&
-             Int(@inbounds own_pos[s2]) == lo + len) || break
+        while l + len <= L && pid_l[l + len] == pid && pos_l[l + len] == lo + len
             len += 1
         end
         push!(segs, _OopSSASeg(pid, lo, len))
-        i += len
+        l += len
     end
-    return segs
+    _ssa_worthwhile(L, length(segs)) && return _OopSSARef(segs, 0, Int[])
+    pgather_ok || return _OOP_SSA_NOREF
+    p1 = @inbounds pid_l[1]
+    all(==(p1), pid_l) && return _OopSSARef(_OopSSASeg[], p1, copy(pos_l))
+    return _OOP_SSA_NOREF
 end
-
-# A redirect must BEAT the gather it replaces: accept when the run count is
-# small against the lane count (each run is one slice; > 1 also costs a
-# concatenate). A fragmented mapping keeps the dense gather. The cap must be
-# ABSOLUTE as well as relative: lattice run counts grow ~O(sqrt NC) with the
-# grid, and a purely relative bound (L>>2 = 1,638 at CONUS) admitted edges of
-# hundreds of slices each -- the emitted module overflowed XLA:CPU's
-# contiguous JIT section arena ("Unable to allocate section memory") at
-# 13x7x72 while RSS sat at 6.7 GB. 64 leaves the measured 6x6x8 behaviour
-# (L>>2 = 72) essentially unchanged.
-@inline _ssa_worthwhile(L::Int, nseg::Int) = nseg <= min(64, max(8, L >> 2))
 
 function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
                              rhs_list, cse_prelude, n_states::Int, n_total::Int)
     _oop_ssa_enabled() || return _OOP_SSA_OFF
+    ghost_ok = _oop_ssa_ghost_enabled()
+    sub_ok = _oop_ssa_sub_enabled()
+    pgather_ok = _oop_ssa_pgather_enabled()
     nlev = length(mat_levels)
 
     # ---- Slot ownership, in execution order (LAST writer owns) ----
@@ -2933,6 +3116,7 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
     end
     prod_level = Int[0]
     prod_slots = Vector{Int}[Int[]]         # pid 1 never scatters; empty slot list
+    prod_len = Int[n_states]                # pid 1's VALUE is `u` itself
     matpids = Vector{Vector{Int}}(undef, nlev)
     dynamic = any(pl -> !pl.vectorizable, acc_plans)
     for li in 1:nlev
@@ -2946,6 +3130,7 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
             if plan.vectorizable
                 push!(prod_level, li)
                 push!(prod_slots, plan.out_slots)
+                push!(prod_len, length(plan.out_slots))
                 pid = length(prod_level)
                 pids[j] = pid
                 out = plan.out_slots
@@ -2970,10 +3155,10 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
     end
 
     # ---- Residual `ue` reads (everything that will NOT be redirected) ----
-    resid = falses(n_total)
-    markv!(v) = (for s in v
-                     1 <= s <= n_total && (resid[s] = true)
-                 end)
+    resid = zeros(UInt8, n_total)
+    markv!(v, why::UInt8) = (for s in v
+                                 1 <= s <= n_total && (resid[s] |= why)
+                             end)
     for nd in cse_prelude
         _ssa_mark_node_reads!(resid, nd)
     end
@@ -2986,54 +3171,100 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
             _ssa_mark_node_reads!(resid, nd)
         end
         for S in scans
-            markv!((S::_ScanFold).slots)      # the fold reads its own slots back
+            # the fold reads its own slots back
+            markv!((S::_ScanFold).slots, _SSA_R_SCAN)
         end
     end
     # (The state-RHS `scan_folds` fold `du`, not `ue` — no residue here.)
 
     n_edges = 0; n_fast = 0; elems_edges = 0; elems_fast = 0
+    n_gedges = 0; n_gfast = 0; elems_gedges = 0; elems_gfast = 0
+    n_sedges = 0; n_sfast = 0; elems_sedges = 0; elems_sfast = 0
 
-    # Per consumer kernel: decide redirects for the top-level cell-lane
-    # descriptors, then mark every read that stays on the gather path.
-    function consumer(K::_AccKernel, plan::_OopAccPlan, cons_level::Int)
-        plan.vectorizable || return _OOP_SSA_KERNEL_OFF
-        segsv = Vector{_OopSSASeg}[_OopSSASeg[] for _ in 1:length(K.acc)]
+    # ONE descriptor table — a kernel's own, or a sub-kernel's, both resolved
+    # against the SAME lane enumeration. Decides each descriptor's redirect and
+    # marks every read that stays on the gather path, with the reason that
+    # declined it. Returns the per-descriptor refs and whether any redirected.
+    function desc_table(acc::Vector{_AccDesc}, pl::_OopAccPlan, cons_level::Int,
+                        is_sub::Bool)
+        # A sub whose spine does not vectorize forces the parent non-vectorizable
+        # (`_build_oop_acc_plan`), so this cannot fire for a reached sub — but a
+        # fallback plan carries no per-descriptor vectors at all, so refuse it
+        # rather than index them.
+        pl.vectorizable || return (_OopSSARef[], false)
+        refs = _OopSSARef[_OOP_SSA_NOREF for _ in 1:length(acc)]
         any_fast = false
-        for i in eachindex(K.acc)
-            a = K.acc[i]
+        for i in eachindex(acc)
+            a = acc[i]
             if a.kind === _AK_STATE_FIXED
-                1 <= a.idx <= n_total && (resid[a.idx] = true)
+                1 <= a.idx <= n_total && (resid[a.idx] |= _SSA_R_FIXED)
             end
-            g = plan.gathers[i]
+            g = pl.gathers[i]
             isempty(g) && continue
-            if isempty(plan.ghost[i])
+            gh = pl.ghost[i]
+            ghosted = !isempty(gh)
+            if is_sub
+                n_sedges += 1
+                elems_sedges += length(g)
+            elseif ghosted
+                # Boundary stencil through a slot table with 0 entries: the
+                # redirect covers the concrete lanes and the emitter keeps the
+                # select against the (host, constant) ghost mask.
+                n_gedges += 1
+                elems_gedges += length(g)
+            else
                 n_edges += 1
                 elems_edges += length(g)
-                segs = _ssa_decompose(g, own_pid, own_pos, prod_level, cons_level)
-                if segs !== nothing && _ssa_worthwhile(length(g), length(segs))
-                    segsv[i] = segs
-                    any_fast = true
-                    n_fast += 1
-                    elems_fast += length(g)
-                    continue
-                end
             end
-            markv!(g)                          # ghost-masked or unresolved: gather
+            own = ((ghosted && !ghost_ok) || (is_sub && !sub_ok)) ? nothing :
+                  _ssa_lane_owners(g, gh, own_pid, own_pos, prod_level, prod_len,
+                                   cons_level)
+            ref = own === nothing ? _OOP_SSA_NOREF :
+                  _ssa_pack_ref(own[1], own[2], pgather_ok)
+            if ref === _OOP_SSA_NOREF
+                markv!(g, ghosted ? _SSA_R_GHOST :
+                          is_sub ? _SSA_R_SUB :
+                          own === nothing ? _SSA_R_DENSE : _SSA_R_FRAG)
+                continue
+            end
+            refs[i] = ref
+            any_fast = true
+            if is_sub
+                n_sfast += 1
+                elems_sfast += length(g)
+            elseif ghosted
+                n_gfast += 1
+                elems_gfast += length(g)
+            else
+                n_fast += 1
+                elems_fast += length(g)
+            end
         end
-        for (S, sp) in zip(plan.subs, plan.sub_plans)
-            for i in eachindex(S.acc)
-                S.acc[i].kind === _AK_STATE_FIXED &&
-                    1 <= S.acc[i].idx <= n_total && (resid[S.acc[i].idx] = true)
-                markv!(sp.gathers[i])
+        return refs, any_fast
+    end
+
+    function consumer(K::_AccKernel, plan::_OopAccPlan, cons_level::Int)
+        plan.vectorizable || return _OOP_SSA_KERNEL_OFF
+        refs, top_fast = desc_table(K.acc, plan, cons_level, false)
+        subrefs = _OOP_SSA_NO_SUBDESC
+        sub_fast = false
+        if !isempty(plan.subs)
+            sv = Vector{Vector{_OopSSARef}}(undef, length(plan.subs))
+            for j in eachindex(plan.subs)
+                sr, sf = desc_table(plan.subs[j].acc, plan.sub_plans[j],
+                                    cons_level, true)
+                sv[j] = sf ? sr : _OopSSARef[]
+                sub_fast |= sf
             end
+            sub_fast && (subrefs = sv)
         end
         for ep in plan.red_plan
             for g in ep.gathers
-                markv!(g)
+                markv!(g, _SSA_R_ELANE)
             end
         end
-        any_fast || return _OopSSAKernel(0, false, Vector{_OopSSASeg}[])
-        return _OopSSAKernel(0, false, segsv)
+        (top_fast || sub_fast) || return _OOP_SSA_KERNEL_OFF
+        return _OopSSAKernel(0, false, top_fast ? refs : _OopSSARef[], subrefs)
     end
 
     mat = Vector{Vector{_OopSSAKernel}}(undef, nlev)
@@ -3047,24 +3278,38 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
 
     # ---- Producer roles: attach pid + the scatter-skip verdict ----
     n_skip = 0; elems_skip = 0
+    blk = zeros(Int, 8); blk_only = zeros(Int, 8)
     for li in 1:nlev
         pids = matpids[li]
         ks = mat[li]
         for j in eachindex(pids)
             pid = pids[j]
             pid == 0 && continue
-            skip = !dynamic && !any(@inbounds(resid[s]) for s in prod_slots[pid])
+            why = UInt8(0)
+            @inbounds for sl in prod_slots[pid]
+                why |= resid[sl]
+            end
+            skip = !dynamic && why == 0
             if skip
                 n_skip += 1
                 elems_skip += length(prod_slots[pid])
+            else
+                for k in 1:8
+                    (why & _SSA_R_BITS[k]) == 0 && continue
+                    blk[k] += 1
+                    why == _SSA_R_BITS[k] && (blk_only[k] += 1)
+                end
             end
             k0 = ks[j]
-            ks[j] = _OopSSAKernel(pid, skip, k0.desc)
+            ks[j] = _OopSSAKernel(pid, skip, k0.desc, k0.subs)
         end
     end
 
     stats = _OopSSAStats(n_edges, n_fast, elems_edges, elems_fast,
-                         length(prod_level) - 1, n_skip, elems_skip, dynamic)
+                         length(prod_level) - 1, n_skip, elems_skip, dynamic,
+                         n_gedges, n_gfast, elems_gedges, elems_gfast,
+                         n_sedges, n_sfast, elems_sedges, elems_sfast,
+                         NTuple{8,Int}(blk), NTuple{8,Int}(blk_only))
     return _OopSSAPlan(true, length(prod_level), mat, fin, stats)
 end
 
@@ -3082,8 +3327,14 @@ function oop_ssa_stats(f::_OopRHS)
     s = p.stats
     return (; enabled = p.enabled, n_edges = s.n_edges, n_fast = s.n_fast,
             elems_edges = s.elems_edges, elems_fast = s.elems_fast,
+            n_ghost_edges = s.n_gedges, n_ghost_fast = s.n_gfast,
+            elems_ghost_edges = s.elems_gedges, elems_ghost_fast = s.elems_gfast,
+            n_sub_edges = s.n_sedges, n_sub_fast = s.n_sfast,
+            elems_sub_edges = s.elems_sedges, elems_sub_fast = s.elems_sfast,
             n_producers = s.n_prod, n_skipped_scatters = s.n_skip,
-            elems_skipped = s.elems_skip, dynamic = s.dynamic)
+            elems_skipped = s.elems_skip, dynamic = s.dynamic,
+            blockers = NamedTuple{_SSA_R_NAMES}(s.blk),
+            blockers_only = NamedTuple{_SSA_R_NAMES}(s.blk_only))
 end
 
 function _make_rhs_oop(rhs_list::AbstractVector{Tuple{Int,_Node}},

--- a/pkg/EarthSciAST.jl/src/tree_walk/oop.jl
+++ b/pkg/EarthSciAST.jl/src/tree_walk/oop.jl
@@ -909,6 +909,131 @@ const _OOP_NO_FORCING = _OopForcing((;), Vector{Float64}[])
     return arr
 end
 
+# ---- SSA scalar read redirect: the surface map (ess-oop-ssa, blocker #4) ----
+#
+# Declared HERE, above the two scalar walkers, because their signatures name the
+# context type; the ANALYSIS that fills it in and the rationale for the whole
+# feature live in the `_OopSSA*` section further down.
+#
+# DEFAULT OFF (`ESS_OOP_SSA_SCALAR=1` opts in), even inside `ESS_OOP_SSA=1`:
+# the redirect is exact and its coverage is real, but it MEASURED SLOWER — 4.3%
+# on the CONUS 4x5 transport reverse, for two whole-buffer copies removed and
+# 142 copy instructions added. See the knob's note below for the mechanism.
+# Everything here is therefore dead code on the default path, and the
+# instrumentation (the `scalar` blocker row, the scalar edge columns) is what
+# survives as load-bearing.
+#
+# WHAT THIS IS FOR. The vectorized redirect (`_OopSSARef`) reroutes a consumer
+# access kernel's whole-lane DESCRIPTOR off the flat extended buffer `ue`. It
+# leaves the emitter's other two readers of `ue` untouched: the scalar `_Node`
+# walker (`_oop_eval` — a `_NK_STATE` pin, a `_NK_STATE_GATHER` slot table) and
+# its lane-batched twin (`_oop_eval_batch` — the same two kinds over a group's
+# lane axis). Those reads are what `SSA_SPIKE.md` §"What blocks the rest" item 4
+# names, and they hold their producers' scatters into `ue` alive wherever they
+# land: on the ReSEACT transport RHS they were the SOLE blocker on two of the
+# four surviving producers.
+#
+# WHY ONE SHARED MAP AND NOT A TABLE PER SURFACE. A scalar read names a SLOT,
+# not a descriptor position, so there is nothing to key a per-consumer table on
+# — and one slot-indexed table per read surface would be O(levels × n_total)
+# host data (12 MB at CONUS) for a decision that is the same function of the
+# slot everywhere. So ownership is stored ONCE (`pid`/`pos`, the very vectors
+# the plan build already computes for the descriptor arm, plus each producer's
+# level) and each surface carries only its own consumer LEVEL. The redirect
+# fires for slot `s` at level `ℓ` iff `s` has an owner and that owner's level is
+# strictly below `ℓ` — the same two soundness facts the descriptor arm rests on
+# (fills read strictly lower levels; slot ownership is LAST-writer, so a slot a
+# later kernel rewrites is owned by that later kernel or by nobody and the level
+# test then refuses it).
+#
+# BUILD/RUN AGREEMENT. `_ssa_mark_node_reads!` marks a slot residual exactly
+# when this map would NOT redirect it, so the scatter-skip verdict is never
+# weaker than what runs. The one runtime divergence is the feature's existing
+# guard: a producer whose spine hoisted to a lane-invariant scalar records no
+# value, every redirect to it falls back to the (still-written) gather, and
+# `_oop_run_acc_vec` then emits its scatter after all.
+struct _OopSSAOwn
+    pid::Vector{Int32}      # slot → owning producer id (0 ⇒ unowned)
+    pos::Vector{Int32}      # slot → position inside that producer's value
+    lvl::Vector{Int}        # producer id → its fill level (entry 1 = 0, `u`)
+end
+const _OOP_SSA_OWN_OFF = _OopSSAOwn(Int32[], Int32[], Int[])
+
+# One scalar read surface at walk time: the shared map, this surface's consumer
+# level (0 ⇒ redirect disabled, the flag-off singleton) and this call's producer
+# values.
+struct _OopSSASCtx
+    own::_OopSSAOwn
+    cons::Int
+    vals::Vector{Any}
+end
+const _OOP_SSA_SCTX_OFF = _OopSSASCtx(_OOP_SSA_OWN_OFF, 0, Any[])
+const _OOP_NO_MASK = Bool[]     # "this lane vector has no ghost mask"
+
+@inline _oop_ssa_sctx(own::_OopSSAOwn, cons::Int, vals::Vector{Any}) =
+    isempty(own.pid) ? _OOP_SSA_SCTX_OFF : _OopSSASCtx(own, cons, vals)
+
+# THE redirect predicate — the producer that owns slot `s` and strictly
+# precedes level `cons`, or 0. Shared verbatim by the walk-time read seams and
+# by the build-time residual marking (`_ssa_mark_node_reads!`), because a
+# disagreement between the two would let a scatter be skipped while something
+# still read the buffer.
+@inline function _ssa_owner_pid(own::_OopSSAOwn, s::Int, cons::Int)
+    cons == 0 && return 0
+    pv = own.pid
+    (1 <= s <= length(pv)) || return 0
+    pid = Int(@inbounds pv[s])
+    pid == 0 && return 0
+    return (@inbounds own.lvl[pid]) < cons ? pid : 0
+end
+
+# `(pid, pos)` for a slot this surface may redirect, `(0, 0)` otherwise. Pure
+# integer table lookups — no state is touched, so it is equally usable from the
+# host walkers and from a trace.
+@inline function _oop_ssa_owner(sc::_OopSSASCtx, s::Int)
+    pid = _ssa_owner_pid(sc.own, s, sc.cons)
+    pid == 0 && return (0, 0)
+    return (pid, Int(@inbounds sc.own.pos[s]))
+end
+
+# ONE redirected scalar read, or `nothing` to take the `ue` read (not
+# redirectable here, or the producer recorded no value this call).
+@inline function _oop_ssa_scalar(sc::_OopSSASCtx, s::Int, ::Type{T}, memo) where {T}
+    pid, pos = _oop_ssa_owner(sc, s)
+    pid == 0 && return nothing
+    v = @inbounds sc.vals[pid]
+    v isa AbstractArray || return nothing
+    return convert(T, _oop_read_state(v, pos, memo))
+end
+
+# A LANE VECTOR of slots (`_oop_eval_batch`'s state leaves), redirected only
+# when every lane resolves into the SAME producer — then it is one gather of
+# that producer's value at producer-local positions, the same single op the `ue`
+# gather was. Mixed-owner lane sets keep the `ue` gather (and are marked
+# residual at build time, so their producers still scatter). `mask` lanes are
+# WILDCARDS: the caller's select overwrites them with 0, so a ghost lane takes
+# position 1 rather than breaking the single-producer form. Returns the producer
+# id and fills `pos`, or 0.
+@inline function _oop_ssa_lane_pid!(pos::Vector{Int}, sc::_OopSSASCtx,
+                                    slots::Vector{Int}, mask::Vector{Bool})
+    sc.cons == 0 && return 0
+    L = length(slots)
+    L == 0 && return 0
+    masked = !isempty(mask)
+    p1 = 0
+    @inbounds for l in 1:L
+        if masked && mask[l]
+            pos[l] = 1                      # wildcard: the select discards it
+            continue
+        end
+        pid, q = _oop_ssa_owner(sc, slots[l])
+        pid == 0 && return 0
+        p1 == 0 ? (p1 = pid) : (pid == p1 || return 0)
+        pos[l] = q
+    end
+    return p1
+end
+
 # ---- Scalar walker (`_Node`) ------------------------------------------------
 #
 # The generic twin of `_eval_node`. Type-stable in `T`: every leaf converts into the
@@ -920,11 +1045,16 @@ end
 # subexpressions. `f!` reads the same slots out of a `Vector{Float64}` captured on
 # the node; here they come from a `Vector{T}` allocated per call, which is what makes
 # CSE survive differentiation at all.
-function _oop_eval(n::_Node, u, p, t, cache::AbstractVector{T}, fb::_OopForcing)::T where {T}
+function _oop_eval(n::_Node, u, p, t, cache::AbstractVector{T}, fb::_OopForcing,
+                   sc::_OopSSASCtx=_OOP_SSA_SCTX_OFF)::T where {T}
     k = n.kind
     if k === _NK_LITERAL
         return _oop_const(T, n.literal, fb.memo)
     elseif k === _NK_STATE
+        # An SSA-redirected slot (ess-oop-ssa blocker #4) reads its producer's
+        # value instead of the flat buffer; `nothing` ⇒ read `ue`.
+        r = _oop_ssa_scalar(sc, n.idx, T, fb.memo)
+        r === nothing || return r
         return convert(T, _oop_read_state(u, n.idx, fb.memo))
     elseif k === _NK_PARAM
         return _oop_const(T, _read_param(p, n.sym, n.idx), fb.memo)
@@ -941,18 +1071,20 @@ function _oop_eval(n::_Node, u, p, t, cache::AbstractVector{T}, fb::_OopForcing)
     elseif k === _NK_CACHED
         return @inbounds cache[n.idx]
     elseif k === _NK_CONTRACTION
-        return _oop_contraction(n, u, p, t, cache, fb)
+        return _oop_contraction(n, u, p, t, cache, fb, sc)
     elseif k === _NK_LOOPVAR
         # ess-runtime-contraction: enclosing loop counter, an integer constant of T.
         return convert(T, (n.payload::Base.RefValue{Int})[])
     elseif k === _NK_CONTRACTION_LOOP
-        return _oop_contraction_loop(n, u, p, t, cache, fb)
+        return _oop_contraction_loop(n, u, p, t, cache, fb, sc)
     elseif k === _NK_CONST_GATHER
+        # No state read (a frozen array at loop-counter subscripts), so no
+        # redirect surface — and its subscripts go through `_oop_index_int`.
         return _oop_const_gather(n, u, p, t, cache, fb)
     elseif k === _NK_STATE_GATHER
-        return _oop_state_gather(n, u, p, t, cache, fb)
+        return _oop_state_gather(n, u, p, t, cache, fb, sc)
     else
-        return _oop_eval_op(n, u, p, t, cache, fb)
+        return _oop_eval_op(n, u, p, t, cache, fb, sc)
     end
 end
 
@@ -1044,7 +1176,8 @@ end
 # OOP twin of `_eval_state_gather` (ess-runtime-contraction). Same slot computation
 # and ghost convention; reads the state through `_oop_read_state` so a tracing
 # backend sees the real input, and returns `T` on both arms.
-function _oop_state_gather(n::_Node, u, p, t, cache::AbstractVector{T}, fb::_OopForcing)::T where {T}
+function _oop_state_gather(n::_Node, u, p, t, cache::AbstractVector{T}, fb::_OopForcing,
+                           sc::_OopSSASCtx=_OOP_SSA_SCTX_OFF)::T where {T}
     sg = n.payload::_StateGather
     children = n.children
     off = 0
@@ -1056,13 +1189,19 @@ function _oop_state_gather(n::_Node, u, p, t, cache::AbstractVector{T}, fb::_Oop
         off += (sub - sg.lo[d]) * sg.strides[d]
     end
     slot = @inbounds sg.slot_flat[off + 1]
+    # The resolved slot is a host `Int`, so the redirect decision is the same
+    # table lookup a `_NK_STATE` pin makes — per SLOT, which is why the build
+    # marks residual per slot of `sg.slot_flat` rather than all-or-nothing.
+    r = _oop_ssa_scalar(sc, slot, T, fb.memo)
+    r === nothing || return r
     return convert(T, _oop_read_state(u, slot, fb.memo))
 end
 
 # OOP twin of `_eval_contraction_loop` (ess-runtime-contraction). Same static-range
 # iteration, same 0̄-seeded ⊕-fold, so a Float64 `:oop` run stays bit-identical to
 # `f!` — the property the in-place tests use `:oop` as an oracle for.
-function _oop_contraction_loop(n::_Node, u, p, t, cache::AbstractVector{T}, fb::_OopForcing)::T where {T}
+function _oop_contraction_loop(n::_Node, u, p, t, cache::AbstractVector{T}, fb::_OopForcing,
+                               sc::_OopSSASCtx=_OOP_SSA_SCTX_OFF)::T where {T}
     spec = n.payload::_ContractLoop
     ref = spec.ref
     body = @inbounds n.children[1]
@@ -1072,31 +1211,32 @@ function _oop_contraction_loop(n::_Node, u, p, t, cache::AbstractVector{T}, fb::
     if op === :+
         @inbounds for k in rng
             ref[] = k
-            s += _oop_eval(body, u, p, t, cache, fb)
+            s += _oop_eval(body, u, p, t, cache, fb, sc)
         end
     elseif op === :*
         @inbounds for k in rng
             ref[] = k
-            s *= _oop_eval(body, u, p, t, cache, fb)
+            s *= _oop_eval(body, u, p, t, cache, fb, sc)
         end
     elseif op === :max
         @inbounds for k in rng
             ref[] = k
-            s = max(s, _oop_eval(body, u, p, t, cache, fb))
+            s = max(s, _oop_eval(body, u, p, t, cache, fb, sc))
         end
     else  # :min
         @inbounds for k in rng
             ref[] = k
-            s = min(s, _oop_eval(body, u, p, t, cache, fb))
+            s = min(s, _oop_eval(body, u, p, t, cache, fb, sc))
         end
     end
     return s
 end
 
-function _oop_eval_op(n::_Node, u, p, t, cache::AbstractVector{T}, fb::_OopForcing)::T where {T}
-    n.op === :fn && return _oop_fn(n, u, p, t, cache, fb)
+function _oop_eval_op(n::_Node, u, p, t, cache::AbstractVector{T}, fb::_OopForcing,
+                      sc::_OopSSASCtx=_OOP_SSA_SCTX_OFF)::T where {T}
+    n.op === :fn && return _oop_fn(n, u, p, t, cache, fb, sc)
     if n.op === :^ || n.op === :pow
-        return _oop_pow(n.op, n.children, u, p, t, cache, fb)
+        return _oop_pow(n.op, n.children, u, p, t, cache, fb, sc)
     end
     # A GUARD MUST GUARD. `ifelse`/`and`/`or` are lazy on the in-place scalar walker
     # (`_eval_node_op`), and this emitter promises a Float64 `:oop` run is bit-
@@ -1110,23 +1250,23 @@ function _oop_eval_op(n::_Node, u, p, t, cache::AbstractVector{T}, fb::_OopForci
     ch = n.children
     if n.op === :ifelse
         _expect_arity_n(n.op, ch, 3)
-        return _oop_eval(ch[1], u, p, t, cache, fb) != 0 ?
-               _oop_eval(ch[2], u, p, t, cache, fb) :
-               _oop_eval(ch[3], u, p, t, cache, fb)
+        return _oop_eval(ch[1], u, p, t, cache, fb, sc) != 0 ?
+               _oop_eval(ch[2], u, p, t, cache, fb, sc) :
+               _oop_eval(ch[3], u, p, t, cache, fb, sc)
     elseif n.op === :and
         @inbounds for i in eachindex(ch)
-            _oop_eval(ch[i], u, p, t, cache, fb) == 0 && return zero(T)
+            _oop_eval(ch[i], u, p, t, cache, fb, sc) == 0 && return zero(T)
         end
         return one(T)
     elseif n.op === :or
         @inbounds for i in eachindex(ch)
-            _oop_eval(ch[i], u, p, t, cache, fb) != 0 && return one(T)
+            _oop_eval(ch[i], u, p, t, cache, fb, sc) != 0 && return one(T)
         end
         return zero(T)
     end
     c = Vector{T}(undef, length(ch))
     @inbounds for i in eachindex(ch)
-        c[i] = _oop_eval(ch[i], u, p, t, cache, fb)
+        c[i] = _oop_eval(ch[i], u, p, t, cache, fb, sc)
     end
     return _oop_op(n.op, c, T, fb.memo)
 end
@@ -1144,35 +1284,37 @@ end
 # Both branches return the value type (`T^Float64` and `T^T` alike), so this stays
 # type-stable, and at Float64 it is the same `^` call the in-place ladder makes.
 @inline function _oop_pow(op::Symbol, ch::Vector{_Node}, u, p, t,
-                          cache::AbstractVector{T}, fb::_OopForcing)::T where {T}
+                          cache::AbstractVector{T}, fb::_OopForcing,
+                          sc::_OopSSASCtx=_OOP_SSA_SCTX_OFF)::T where {T}
     _expect_arity_n(op, ch, 2)
-    base = _oop_eval(ch[1], u, p, t, cache, fb)
+    base = _oop_eval(ch[1], u, p, t, cache, fb, sc)
     e = ch[2]
     return e.kind === _NK_LITERAL ? _oop_powlit(base, e.literal, fb.memo) :
-           base^_oop_eval(e, u, p, t, cache, fb)
+           base^_oop_eval(e, u, p, t, cache, fb, sc)
 end
 
 # Semiring fold, seeded from the 0̄ identity baked on the node — same order as
 # `_eval_contraction`, so the sum is bit-identical at Float64.
-function _oop_contraction(n::_Node, u, p, t, cache::AbstractVector{T}, fb::_OopForcing)::T where {T}
+function _oop_contraction(n::_Node, u, p, t, cache::AbstractVector{T}, fb::_OopForcing,
+                          sc::_OopSSASCtx=_OOP_SSA_SCTX_OFF)::T where {T}
     op = n.op
     ch = n.children
     s = _oop_const(T, n.literal, fb.memo)
     if op === :+
         @inbounds for k in eachindex(ch)
-            s += _oop_eval(ch[k], u, p, t, cache, fb)
+            s += _oop_eval(ch[k], u, p, t, cache, fb, sc)
         end
     elseif op === :*
         @inbounds for k in eachindex(ch)
-            s *= _oop_eval(ch[k], u, p, t, cache, fb)
+            s *= _oop_eval(ch[k], u, p, t, cache, fb, sc)
         end
     elseif op === :max
         @inbounds for k in eachindex(ch)
-            s = max(s, _oop_eval(ch[k], u, p, t, cache, fb))
+            s = max(s, _oop_eval(ch[k], u, p, t, cache, fb, sc))
         end
     else  # :min
         @inbounds for k in eachindex(ch)
-            s = min(s, _oop_eval(ch[k], u, p, t, cache, fb))
+            s = min(s, _oop_eval(ch[k], u, p, t, cache, fb, sc))
         end
     end
     return s
@@ -1189,24 +1331,25 @@ end
 # differentiation variable for a Rosenbrock ∂f/∂t term), and a traced walk
 # keeps the decomposition inside the program (`evaluate_closed_function_ad`),
 # exactly as before typed cores existed.
-function _oop_fn(n::_Node, u, p, t, cache::AbstractVector{T}, fb::_OopForcing)::T where {T}
+function _oop_fn(n::_Node, u, p, t, cache::AbstractVector{T}, fb::_OopForcing,
+                 sc::_OopSSASCtx=_OOP_SSA_SCTX_OFF)::T where {T}
     pl = n.payload
     c = n.children
     if pl isa Tuple{String,_InterpLinearSpec}
-        return _oop_interp_linear(pl[2], _oop_eval(c[1], u, p, t, cache, fb), T)
+        return _oop_interp_linear(pl[2], _oop_eval(c[1], u, p, t, cache, fb, sc), T)
     elseif pl isa Tuple{String,_InterpBilinearSpec}
-        return _oop_interp_bilinear(pl[2], _oop_eval(c[1], u, p, t, cache, fb),
-                                    _oop_eval(c[2], u, p, t, cache, fb), T)
+        return _oop_interp_bilinear(pl[2], _oop_eval(c[1], u, p, t, cache, fb, sc),
+                                    _oop_eval(c[2], u, p, t, cache, fb, sc), T)
     elseif pl isa Tuple{String,_InterpSearchsortedSpec}
-        return _oop_interp_searchsorted(pl[2], _oop_eval(c[1], u, p, t, cache, fb), T)
+        return _oop_interp_searchsorted(pl[2], _oop_eval(c[1], u, p, t, cache, fb, sc), T)
     elseif pl isa Tuple{String,_FnTypedCoreSpec}
         if T === Float64      # compile-time fold, as in `_eval_closed_fn`
-            return _fn_typed_core_call(pl[2].id, _oop_eval(c[1], u, p, t, cache, fb))
+            return _fn_typed_core_call(pl[2].id, _oop_eval(c[1], u, p, t, cache, fb, sc))
         end
-        args = Any[_oop_eval(ci, u, p, t, cache, fb) for ci in c]
+        args = Any[_oop_eval(ci, u, p, t, cache, fb, sc) for ci in c]
         return convert(T, _eval_closed_fn(pl[1], args, T))
     elseif pl isa Tuple{String,Nothing}
-        args = Any[_oop_eval(ci, u, p, t, cache, fb) for ci in c]
+        args = Any[_oop_eval(ci, u, p, t, cache, fb, sc) for ci in c]
         return convert(T, _eval_closed_fn(pl[1], args, T))
     end
     throw(TreeWalkError("E_TREEWALK_UNKNOWN_CLOSED_FUNCTION",
@@ -1587,13 +1730,30 @@ end
 # what `_oop_eval` computes on that lane's original node (see the bit-identity
 # note at the section header).
 function _oop_eval_batch(b::_OopBatchNode, u, p, t, cache::AbstractVector{T},
-                         fb::_OopForcing) where {T}
+                         fb::_OopForcing, sc::_OopSSASCtx=_OOP_SSA_SCTX_OFF) where {T}
     k = b.kind
     if k === _NK_LITERAL
         return isempty(b.lanes_f) ? _oop_const(T, b.literal, fb.memo) : b.lanes_f
     elseif k === _NK_STATE
-        return isempty(b.slots) ? convert(T, _oop_read_state(u, b.idx, fb.memo)) :
-               _oop_gather(u, b.slots, fb.memo)
+        if isempty(b.slots)
+            r = _oop_ssa_scalar(sc, b.idx, T, fb.memo)
+            r === nothing || return r
+            return convert(T, _oop_read_state(u, b.idx, fb.memo))
+        end
+        # SSA redirect (ess-oop-ssa blocker #4): one gather of the producer's
+        # VALUE when every lane of this group's slot vector lands in the same
+        # producer — the same single op, off the value instead of `ue`. The
+        # slot vector is build-time data, so this resolution is the same one
+        # `_ssa_mark_batch_reads!` made when it decided not to mark it residual.
+        if sc.cons != 0
+            pos = Vector{Int}(undef, length(b.slots))
+            pid = _oop_ssa_lane_pid!(pos, sc, b.slots, _OOP_NO_MASK)
+            if pid != 0
+                v = @inbounds sc.vals[pid]
+                v isa AbstractArray && return _oop_gather(v, pos, fb.memo)
+            end
+        end
+        return _oop_gather(u, b.slots, fb.memo)
     elseif k === _NK_PARAM
         return _oop_const(T, _read_param(p, b.sym, b.idx), fb.memo)
     elseif k === _NK_TIME
@@ -1667,6 +1827,21 @@ function _oop_eval_batch(b::_OopBatchNode, u, p, t, cache::AbstractVector{T},
             slots[l] = g ? 1 : sg.slot_flat[off + 1]
             anyghost |= g
         end
+        # SSA redirect (ess-oop-ssa blocker #4): the slots are host integers by
+        # now, so the same single-producer test the `_NK_STATE` lane vector
+        # takes applies — and a GHOST lane is a wildcard (the select below
+        # overwrites it with 0), so it does not break the single-producer form.
+        if sc.cons != 0
+            pos = Vector{Int}(undef, L)
+            pid = _oop_ssa_lane_pid!(pos, sc, slots, anyghost ? mask : _OOP_NO_MASK)
+            if pid != 0
+                v = @inbounds sc.vals[pid]
+                if v isa AbstractArray
+                    pg = _oop_gather(v, pos, fb.memo)
+                    return anyghost ? ifelse.(mask, zero(T), pg) : pg
+                end
+            end
+        end
         gth = _oop_gather(u, slots, fb.memo)
         return anyghost ? ifelse.(mask, zero(T), gth) : gth
     elseif k === _NK_CONTRACTION_LOOP
@@ -1681,22 +1856,22 @@ function _oop_eval_batch(b::_OopBatchNode, u, p, t, cache::AbstractVector{T},
         if op === :+
             for kk in b.lo:b.step:b.hi
                 @inbounds for r in refs; r[] = kk; end
-                s = s .+ _oop_eval_batch(body, u, p, t, cache, fb)
+                s = s .+ _oop_eval_batch(body, u, p, t, cache, fb, sc)
             end
         elseif op === :*
             for kk in b.lo:b.step:b.hi
                 @inbounds for r in refs; r[] = kk; end
-                s = s .* _oop_eval_batch(body, u, p, t, cache, fb)
+                s = s .* _oop_eval_batch(body, u, p, t, cache, fb, sc)
             end
         elseif op === :max
             for kk in b.lo:b.step:b.hi
                 @inbounds for r in refs; r[] = kk; end
-                s = max.(s, _oop_eval_batch(body, u, p, t, cache, fb))
+                s = max.(s, _oop_eval_batch(body, u, p, t, cache, fb, sc))
             end
         else  # :min
             for kk in b.lo:b.step:b.hi
                 @inbounds for r in refs; r[] = kk; end
-                s = min.(s, _oop_eval_batch(body, u, p, t, cache, fb))
+                s = min.(s, _oop_eval_batch(body, u, p, t, cache, fb, sc))
             end
         end
         return s
@@ -1707,19 +1882,19 @@ function _oop_eval_batch(b::_OopBatchNode, u, p, t, cache::AbstractVector{T},
         res::Any = _oop_const(T, b.literal, fb.memo)
         if b.op === :+
             for i in eachindex(ch)
-                res = res .+ _oop_eval_batch(ch[i], u, p, t, cache, fb)
+                res = res .+ _oop_eval_batch(ch[i], u, p, t, cache, fb, sc)
             end
         elseif b.op === :*
             for i in eachindex(ch)
-                res = res .* _oop_eval_batch(ch[i], u, p, t, cache, fb)
+                res = res .* _oop_eval_batch(ch[i], u, p, t, cache, fb, sc)
             end
         elseif b.op === :max
             for i in eachindex(ch)
-                res = max.(res, _oop_eval_batch(ch[i], u, p, t, cache, fb))
+                res = max.(res, _oop_eval_batch(ch[i], u, p, t, cache, fb, sc))
             end
         else  # :min
             for i in eachindex(ch)
-                res = min.(res, _oop_eval_batch(ch[i], u, p, t, cache, fb))
+                res = min.(res, _oop_eval_batch(ch[i], u, p, t, cache, fb, sc))
             end
         end
         return res
@@ -1727,20 +1902,20 @@ function _oop_eval_batch(b::_OopBatchNode, u, p, t, cache::AbstractVector{T},
         op = b.op
         ch = b.children
         if op === :fn
-            cv = Any[_oop_eval_batch(c, u, p, t, cache, fb) for c in ch]
+            cv = Any[_oop_eval_batch(c, u, p, t, cache, fb, sc) for c in ch]
             return _oop_batch_fn(b.payload, cv, T)
         elseif (op === :^ || op === :pow) && length(ch) == 2
             # A literal exponent stays a literal (see `_oop_pow`); the signature
             # pinned it, so a literal exponent is always the SHARED-literal form.
-            base = _oop_eval_batch(ch[1], u, p, t, cache, fb)
+            base = _oop_eval_batch(ch[1], u, p, t, cache, fb, sc)
             e = @inbounds ch[2]
             (e.kind === _NK_LITERAL && isempty(e.lanes_f)) &&
                 return _oop_powlit(base, e.literal, fb.memo)
-            return base .^ _oop_eval_batch(e, u, p, t, cache, fb)
+            return base .^ _oop_eval_batch(e, u, p, t, cache, fb, sc)
         end
         c = Vector{Any}(undef, length(ch))
         for i in eachindex(ch)
-            c[i] = _oop_eval_batch(ch[i], u, p, t, cache, fb)
+            c[i] = _oop_eval_batch(ch[i], u, p, t, cache, fb, sc)
         end
         return _oop_op(op, c, T, fb.memo)
     end
@@ -1751,16 +1926,18 @@ end
 # the surface are disjoint and the entries never read each other (section
 # header), so the values are the per-entry scalar walk's, bit for bit.
 function _oop_run_scalar_batches(du, sb::_OopScalarBatches, ue, p, t,
-                                 cache::AbstractVector{T}, fb::_OopForcing) where {T}
+                                 cache::AbstractVector{T}, fb::_OopForcing,
+                                 sc::_OopSSASCtx=_OOP_SSA_SCTX_OFF) where {T}
     rl = sb.rest
     @inbounds for i in eachindex(rl)
         slot, node = rl[i]
-        du = _oop_store(du, slot, _oop_eval(node, ue, p, t, cache, fb))
+        du = _oop_store(du, slot, _oop_eval(node, ue, p, t, cache, fb, sc))
     end
     gs = sb.groups
     for i in eachindex(gs)
         g = gs[i]
-        du = _oop_scatter(du, g.slots, _oop_eval_batch(g.root, ue, p, t, cache, fb))
+        du = _oop_scatter(du, g.slots,
+                          _oop_eval_batch(g.root, ue, p, t, cache, fb, sc))
     end
     return du
 end
@@ -2873,9 +3050,14 @@ forcing_buffer_index(f::_OopRHS) = f.buffer_index
 @inline function _oop_fill_level(ue, lvl, sb::_OopScalarBatches, p, t, ::Type{T},
                                  fb, empty_cache,
                                  ssaks::Vector{_OopSSAKernel}=_OOP_SSA_EMPTY_KS,
-                                 vals::Vector{Any}=_OOP_SSA_NO_VALS) where {T}
+                                 vals::Vector{Any}=_OOP_SSA_NO_VALS,
+                                 own::_OopSSAOwn=_OOP_SSA_OWN_OFF,
+                                 li::Int=0) where {T}
     scalars, kernels, plans, scans = lvl
-    ue = _oop_run_scalar_batches(ue, sb, ue, p, t, empty_cache, fb)
+    # This level's scalars run BEFORE its kernels, so their SSA consumer level
+    # is `li` and a redirect to a producer of this very level is refused.
+    ue = _oop_run_scalar_batches(ue, sb, ue, p, t, empty_cache, fb,
+                                 _oop_ssa_sctx(own, li, vals))
     for j in eachindex(kernels)
         plan = plans[j]
         ue = plan.vectorizable ?
@@ -2892,32 +3074,57 @@ end
 # costs an allocation per level per call. `ssat` rides along the same way (one
 # `Vector{_OopSSAKernel}` per level, empty ⇒ SSA off for that level).
 @inline _oop_fill_levels(ue, ::Tuple{}, sbs::Tuple, p, t, ::Type{T}, fb, ec,
-                         ssat::Tuple, vals::Vector{Any}) where {T} = ue
+                         ssat::Tuple, vals::Vector{Any}, own::_OopSSAOwn,
+                         li::Int) where {T} = ue
 @inline function _oop_fill_levels(ue, levels::Tuple, sbs::Tuple, p, t, ::Type{T},
-                                  fb, ec, ssat::Tuple, vals::Vector{Any}) where {T}
-    ue = _oop_fill_level(ue, levels[1], sbs[1], p, t, T, fb, ec, ssat[1], vals)
+                                  fb, ec, ssat::Tuple, vals::Vector{Any},
+                                  own::_OopSSAOwn=_OOP_SSA_OWN_OFF,
+                                  li::Int=1) where {T}
+    ue = _oop_fill_level(ue, levels[1], sbs[1], p, t, T, fb, ec, ssat[1], vals,
+                         own, li)
     return _oop_fill_levels(ue, Base.tail(levels), Base.tail(sbs), p, t, T, fb, ec,
-                            Base.tail(ssat), vals)
+                            Base.tail(ssat), vals, own, li + 1)
 end
 
 # ---- SSA build-time analysis (ess-oop-ssa) ----------------------------------
 
 _oop_ssa_enabled() = get(ENV, "ESS_OOP_SSA", "") == "1"
 
-# Bisect knobs for the three redirect arms added after the spike, all riding
-# inside `ESS_OOP_SSA=1` and all default ON. Setting one to 0 declines exactly
-# that arm while KEEPING the per-blocker attribution below, so one process can
-# A/B an arm without a second checkout — which is how the arms were measured
-# (setup wall on this filesystem is not a usable metric) — and so the test file
-# has a negative control for each.
+# Bisect knobs for the redirect arms added after the spike, all riding inside
+# `ESS_OOP_SSA=1`. Setting one to its off value declines exactly that arm while
+# KEEPING the per-blocker attribution below, so one process can A/B an arm
+# without a second checkout — which is how the arms were measured (setup wall
+# on this filesystem is not a usable metric) — and so the test file has a
+# negative control for each.
+#
+# THREE ARE DEFAULT ON because they paid. `_SCALAR` is default OFF because it
+# did NOT, and that is a measurement, not caution:
 #
 #   ESS_OOP_SSA_GHOST=0     ghost-masked `_AK_STATE_TBL_BOX` descriptors
 #                           (`_ssa_lane_owners`' wildcard fill)
 #   ESS_OOP_SSA_SUB=0       template sub-kernel (`_NK_SUBCALL`) descriptor tables
 #   ESS_OOP_SSA_PGATHER=0   tier 2b, the single-producer value gather
+#   ESS_OOP_SSA_SCALAR=1    OPT-IN: scalar-walker and lane-batched scalar reads
+#                           (`_NK_STATE` / `_NK_STATE_GATHER`, the surface map)
+#
+# WHY `_SCALAR` SHIPS OFF. It is correct and its coverage is real — on the
+# ReSEACT transport RHS at 6x6x8 it takes scatters-skipped 13/17 → 15/17 and
+# clears the `scalar` blocker row, moving 404 352 read elements off `ue` — but
+# at CONUS 4x5 it costs **4.3% on the transport step's reverse** (`rhs_vjp`
+# 71.41 → 74.59 ms; the forward `rhs` is flat at 1.010). The copy census says
+# why: whole-buffer copies 82 → 80 (the two scatters it really did free) against
+# total copy instructions 290 → 432 and real element writes 55.22 → 56.11 M.
+# The scalar surfaces' reads were ALREADY cheap relative to the buffer versions
+# they kept alive — a handful of gathers per level, not O(cells) of them — so
+# freeing two scatters buys little while the redirect's own materialization
+# (a producer-value gather per lane group, off a value XLA must now keep live
+# across the level boundary) adds copies. Same mechanism the scatter-skip gate
+# established: a PARTIAL skip pays twice, once for the buffer that still gets
+# assembled and once for the value kept alive beside it.
 _oop_ssa_ghost_enabled()   = get(ENV, "ESS_OOP_SSA_GHOST", "1") != "0"
 _oop_ssa_sub_enabled()     = get(ENV, "ESS_OOP_SSA_SUB", "1") != "0"
 _oop_ssa_pgather_enabled() = get(ENV, "ESS_OOP_SSA_PGATHER", "1") != "0"
+_oop_ssa_scalar_enabled()  = get(ENV, "ESS_OOP_SSA_SCALAR", "0") == "1"
 
 # WHY a residual `ue` read exists, one bit per read surface, carried per slot in
 # the analysis' `resid` map and reduced per producer into the blocker tally
@@ -2960,6 +3167,10 @@ struct _OopSSAStats
     n_sfast::Int          # … of which redirected
     elems_sedges::Int
     elems_sfast::Int
+    n_cedges::Int         # SCALAR read sites (scalar walker + lane-batched)
+    n_cfast::Int          # … of which fully redirected off `ue`
+    elems_cedges::Int     # Σ candidate slots over those sites
+    elems_cfast::Int      # … of which redirected
     blk::NTuple{8,Int}      # producers whose residual set includes reason k
     blk_only::NTuple{8,Int} # … producers blocked SOLELY by reason k
 end
@@ -2970,29 +3181,145 @@ struct _OopSSAPlan
     nprod::Int                          # producer count INCLUDING pid 1 (the state)
     mat::Vector{Vector{_OopSSAKernel}}  # per fill level, aligned with its kernels
     fin::Vector{_OopSSAKernel}          # aligned with the state-RHS acc_kernels
+    own::_OopSSAOwn                     # the scalar surfaces' shared slot map
     stats::_OopSSAStats
 end
 const _OOP_SSA_OFF = _OopSSAPlan(false, 0, Vector{_OopSSAKernel}[], _OopSSAKernel[],
+                                 _OOP_SSA_OWN_OFF,
                                  _OopSSAStats(0, 0, 0, 0, 0, 0, 0, false,
                                               0, 0, 0, 0, 0, 0, 0, 0,
+                                              0, 0, 0, 0,
                                               _SSA_BLK0, _SSA_BLK0))
 
-# Residual `ue` reads of the scalar walkers: `_NK_STATE` pins one slot,
-# `_NK_STATE_GATHER` may read any slot in its table (its subscripts are
-# runtime loop counters). Everything else that reads the state does so through
-# an access-kernel plan, which the caller accounts separately.
-function _ssa_mark_node_reads!(resid::Vector{UInt8}, n::_Node)
+# ---- scalar read surfaces: redirect verdict + residual marking -------------
+#
+# `_NK_STATE` pins one slot; `_NK_STATE_GATHER` resolves ONE slot per read out
+# of a static table (its subscripts are runtime loop counters, so the table —
+# not the slot — is what the build can see). Everything else that reads the
+# state does so through an access-kernel plan, accounted by `desc_table`.
+#
+# A slot is marked residual (`_SSA_R_SCALAR`) exactly when the surface map
+# would NOT redirect it at this surface's level; with the arm declined the map
+# is empty, `_ssa_owner_pid` returns 0 for every slot, and this is the pre-arm
+# behaviour verbatim. `cnt` accumulates (sites, sites redirected, candidate
+# slots, slots redirected) for `oop_ssa_stats`.
+#
+# GRANULARITY differs between the two walkers, because their fallbacks do:
+# `_oop_eval` reads ONE slot and can fall back per read, so the verdict is per
+# SLOT; `_oop_eval_batch` returns a whole lane vector through one gather, so its
+# verdict is per NODE and requires one common producer across every lane.
+function _ssa_mark_node_reads!(resid::Vector{UInt8}, n::_Node, own::_OopSSAOwn,
+                               cons::Int, cnt::Vector{Int})
     k = n.kind
     if k === _NK_STATE
-        1 <= n.idx <= length(resid) && (resid[n.idx] |= _SSA_R_SCALAR)
+        cnt[1] += 1; cnt[3] += 1
+        if _ssa_owner_pid(own, n.idx, cons) != 0
+            cnt[2] += 1; cnt[4] += 1
+        else
+            1 <= n.idx <= length(resid) && (resid[n.idx] |= _SSA_R_SCALAR)
+        end
     elseif k === _NK_STATE_GATHER
         sg = n.payload::_StateGather
+        nok = 0
         for s in sg.slot_flat
-            1 <= s <= length(resid) && (resid[s] |= _SSA_R_SCALAR)
+            if _ssa_owner_pid(own, s, cons) != 0
+                nok += 1
+            else
+                1 <= s <= length(resid) && (resid[s] |= _SSA_R_SCALAR)
+            end
         end
+        L = length(sg.slot_flat)
+        cnt[1] += 1; cnt[3] += L
+        nok == L && (cnt[2] += 1)
+        cnt[4] += nok
     end
     for c in n.children
-        _ssa_mark_node_reads!(resid, c)
+        _ssa_mark_node_reads!(resid, c, own, cons, cnt)
+    end
+    return nothing
+end
+
+# The ONE common producer of a lane-batched slot vector, or 0 — the build-time
+# twin of `_oop_ssa_lane_pid!`. A lane whose slot has no redirectable owner, or
+# a second producer, refuses the whole node (the walker then gathers `ue`).
+function _ssa_lane_common_pid(slots, own::_OopSSAOwn, cons::Int)
+    pid = 0
+    for s in slots
+        q = _ssa_owner_pid(own, s, cons)
+        q == 0 && return 0
+        pid == 0 ? (pid = q) : (q == pid || return 0)
+    end
+    return pid
+end
+
+_ssa_sg_slots(nd::_Node) = (nd.payload::_StateGather).slot_flat
+
+function _ssa_mark_batch_reads!(resid::Vector{UInt8}, b::_OopBatchNode,
+                                own::_OopSSAOwn, cons::Int, cnt::Vector{Int})
+    k = b.kind
+    if k === _NK_STATE && isempty(b.slots)
+        # A lane-INVARIANT pin: one slot, so the scalar rule applies.
+        cnt[1] += 1; cnt[3] += 1
+        if _ssa_owner_pid(own, b.idx, cons) != 0
+            cnt[2] += 1; cnt[4] += 1
+        else
+            1 <= b.idx <= length(resid) && (resid[b.idx] |= _SSA_R_SCALAR)
+        end
+    elseif k === _NK_STATE
+        L = length(b.slots)
+        cnt[1] += 1; cnt[3] += L
+        if _ssa_lane_common_pid(b.slots, own, cons) != 0
+            cnt[2] += 1; cnt[4] += L
+        else
+            for s in b.slots
+                1 <= s <= length(resid) && (resid[s] |= _SSA_R_SCALAR)
+            end
+        end
+    elseif k === _NK_STATE_GATHER
+        # Per-lane tables: the walker picks one slot per lane at run time, so
+        # the redirect must hold for EVERY slot of EVERY lane's table under one
+        # common producer. (A GHOST lane substitutes a safe slot at run time and
+        # is then discarded by the select, so it is a wildcard — see
+        # `_oop_ssa_lane_pid!` — and does not enter this test.)
+        pid = 0; tot = 0; okall = true
+        for nd in b.nodes
+            sf = _ssa_sg_slots(nd)
+            tot += length(sf)
+            q = _ssa_lane_common_pid(sf, own, cons)
+            if q == 0 || (pid != 0 && q != pid)
+                okall = false
+            elseif pid == 0
+                pid = q
+            end
+        end
+        cnt[1] += 1; cnt[3] += tot
+        if okall && pid != 0
+            cnt[2] += 1; cnt[4] += tot
+        else
+            for nd in b.nodes, s in _ssa_sg_slots(nd)
+                1 <= s <= length(resid) && (resid[s] |= _SSA_R_SCALAR)
+            end
+        end
+    end
+    # `_NK_CONST_GATHER` reads FROZEN array data, and every gather subscript is
+    # loop-counter integer arithmetic (`_oop_index_int` refuses anything else),
+    # so neither carries a state read into `resid`.
+    for c in b.children
+        _ssa_mark_batch_reads!(resid, c, own, cons, cnt)
+    end
+    return nothing
+end
+
+# One whole batch surface (`rhs_list`, or one fill level's scalars): the
+# leftover singles walk as `_Node`s, each group as its lowered lane tree —
+# together exactly the entries `_oop_batch_scalars` was given.
+function _ssa_mark_surface_reads!(resid::Vector{UInt8}, sb::_OopScalarBatches,
+                                  own::_OopSSAOwn, cons::Int, cnt::Vector{Int})
+    for (_, nd) in sb.rest
+        _ssa_mark_node_reads!(resid, nd, own, cons, cnt)
+    end
+    for g in sb.groups
+        _ssa_mark_batch_reads!(resid, g.root, own, cons, cnt)
     end
     return nothing
 end
@@ -3101,11 +3428,14 @@ function _ssa_pack_ref(pid_l::Vector{Int}, pos_l::Vector{Int}, pgather_ok::Bool)
 end
 
 function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
-                             rhs_list, cse_prelude, n_states::Int, n_total::Int)
+                             rhs_batches::_OopScalarBatches,
+                             mat_batches::Tuple, cse_prelude,
+                             n_states::Int, n_total::Int)
     _oop_ssa_enabled() || return _OOP_SSA_OFF
     ghost_ok = _oop_ssa_ghost_enabled()
     sub_ok = _oop_ssa_sub_enabled()
     pgather_ok = _oop_ssa_pgather_enabled()
+    scalar_ok = _oop_ssa_scalar_enabled()
     nlev = length(mat_levels)
 
     # ---- Slot ownership, in execution order (LAST writer owns) ----
@@ -3154,22 +3484,36 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
         end
     end
 
+    # The scalar surfaces' shared slot map (ess-oop-ssa blocker #4). Built HERE,
+    # after the ownership pass has settled `own_pid`/`own_pos`/`prod_level` and
+    # before the residual marking that consults it. With the arm declined it is
+    # the empty singleton: `_ssa_owner_pid` then answers 0 for every slot, so
+    # every scalar read marks residual exactly as it did before the arm, and no
+    # walk-time branch can fire.
+    # (named `scown`, not `own`: `desc_table` below already binds a local
+    # `own` for its lane-owner tuple, and a closure assigning that name would
+    # otherwise capture and clobber THIS binding.)
+    scown = scalar_ok ? _OopSSAOwn(own_pid, own_pos, prod_level) : _OOP_SSA_OWN_OFF
+
     # ---- Residual `ue` reads (everything that will NOT be redirected) ----
     resid = zeros(UInt8, n_total)
     markv!(v, why::UInt8) = (for s in v
                                  1 <= s <= n_total && (resid[s] |= why)
                              end)
+    # (sites, sites redirected, candidate slots, slots redirected)
+    sccnt = zeros(Int, 4)
+    # The CSE prelude and the state-RHS scalars run AFTER every fill level, so
+    # their consumer level is `nlev + 1`; a level's own scalars run BEFORE that
+    # level's kernels, so theirs is the level index itself. Both go through the
+    # BATCH surfaces, which are what actually run (`_oop_run_scalar_batches`):
+    # groups ∪ rest is exactly the entry list they were built from.
     for nd in cse_prelude
-        _ssa_mark_node_reads!(resid, nd)
+        _ssa_mark_node_reads!(resid, nd, scown, nlev + 1, sccnt)
     end
-    for (_, nd) in rhs_list
-        _ssa_mark_node_reads!(resid, nd)
-    end
+    _ssa_mark_surface_reads!(resid, rhs_batches, scown, nlev + 1, sccnt)
     for li in 1:nlev
-        scalars, _, _, scans = mat_levels[li]
-        for (_, nd) in scalars
-            _ssa_mark_node_reads!(resid, nd)
-        end
+        _, _, _, scans = mat_levels[li]
+        _ssa_mark_surface_reads!(resid, mat_batches[li], scown, li, sccnt)
         for S in scans
             # the fold reads its own slots back
             markv!((S::_ScanFold).slots, _SSA_R_SCAN)
@@ -3309,8 +3653,9 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
                          length(prod_level) - 1, n_skip, elems_skip, dynamic,
                          n_gedges, n_gfast, elems_gedges, elems_gfast,
                          n_sedges, n_sfast, elems_sedges, elems_sfast,
+                         sccnt[1], sccnt[2], sccnt[3], sccnt[4],
                          NTuple{8,Int}(blk), NTuple{8,Int}(blk_only))
-    return _OopSSAPlan(true, length(prod_level), mat, fin, stats)
+    return _OopSSAPlan(true, length(prod_level), mat, fin, scown, stats)
 end
 
 """
@@ -3331,6 +3676,8 @@ function oop_ssa_stats(f::_OopRHS)
             elems_ghost_edges = s.elems_gedges, elems_ghost_fast = s.elems_gfast,
             n_sub_edges = s.n_sedges, n_sub_fast = s.n_sfast,
             elems_sub_edges = s.elems_sedges, elems_sub_fast = s.elems_sfast,
+            n_scalar_edges = s.n_cedges, n_scalar_fast = s.n_cfast,
+            elems_scalar_edges = s.elems_cedges, elems_scalar_fast = s.elems_cfast,
             n_producers = s.n_prod, n_skipped_scatters = s.n_skip,
             elems_skipped = s.elems_skip, dynamic = s.dynamic,
             blockers = NamedTuple{_SSA_R_NAMES}(s.blk),
@@ -3380,8 +3727,11 @@ function _make_rhs_oop(rhs_list::AbstractVector{Tuple{Int,_Node}},
     # SSA-dataflow plan (ess-oop-ssa; `ESS_OOP_SSA=1`, read HERE at build time —
     # the OFF singleton keeps every runtime branch on the pre-existing path).
     # `ssa_mat` mirrors `mat_levels`' tuple shape for the tail-recursive fill.
-    ssa = _build_oop_ssa_plan(mat_levels, acc_kernels, acc_plans, rhs_list,
-                              cse_prelude, n_states, n_total)
+    ssa = _build_oop_ssa_plan(mat_levels, acc_kernels, acc_plans, rhs_batches,
+                              mat_batches, cse_prelude, n_states, n_total)
+    # The CSE prelude and the state-RHS scalars read `ue` after every fill
+    # level, so their scalar-redirect surface level is `n_lev + 1`.
+    n_lev = length(mat_levels)
     ssa_mat = ssa.enabled ? Tuple(ssa.mat) :
               ntuple(_ -> _OOP_SSA_EMPTY_KS, length(mat_levels))
     buf_names = sort!(String[String(k) for k in keys(pgather)])
@@ -3438,12 +3788,16 @@ function _make_rhs_oop(rhs_list::AbstractVector{Tuple{Int,_Node}},
         if !isempty(mat_levels)
             ue = _oop_prefix_copy(_oop_du_zeros(u, T, n_total), u, n_states)
             ue = _oop_fill_levels(ue, mat_levels, mat_batches, p, t, T, fb,
-                                  _EMPTY_OOP_CACHE(T), ssa_mat, vals)
+                                  _EMPTY_OOP_CACHE(T), ssa_mat, vals, ssa.own, 1)
         end
 
+        # Scalar read surface for everything that runs after the fills
+        # (ess-oop-ssa blocker #4); the OFF singleton with the arm or the
+        # feature declined, and then every branch below folds away.
+        sc_top = _oop_ssa_sctx(ssa.own, n_lev + 1, vals)
         cache = Vector{T}(undef, n_cse)
         @inbounds for s in 1:n_cse
-            cache[s] = _oop_eval(cse_prelude[s], ue, p, t, cache, fb)
+            cache[s] = _oop_eval(cse_prelude[s], ue, p, t, cache, fb, sc_top)
         end
 
         # Scalar state equations, through the lane-batched surface (ess-oop-
@@ -3454,7 +3808,8 @@ function _make_rhs_oop(rhs_list::AbstractVector{Tuple{Int,_Node}},
         # surface — now that the entries themselves live in `rhs_batches`.)
         du = _oop_du_zeros(u, T, n_states)
         if !isempty(rhs_list)
-            du = _oop_run_scalar_batches(du, rhs_batches, ue, p, t, cache, fb)
+            du = _oop_run_scalar_batches(du, rhs_batches, ue, p, t, cache, fb,
+                                         sc_top)
         end
 
         # Access kernels (the unified array IR), out of place. The vectorized form

--- a/pkg/EarthSciAST.jl/test/tree_walk_oop_ssa_test.jl
+++ b/pkg/EarthSciAST.jl/test/tree_walk_oop_ssa_test.jl
@@ -213,3 +213,242 @@ _s_ip(f!, u, p, t) = (du = zero(u); f!(du, u, p, t); du)
         @test Jon == Joff
     end
 end
+
+# ---------------------------------------------------------------------------
+# The three arms added after the spike (`SSA_SPIKE.md` "What blocks the rest"):
+# ghost-masked table gathers (#1), template sub-kernel descriptor tables (#2),
+# and tier 2b — the single-producer VALUE gather that fragmented mappings (#5)
+# take instead of the flat-buffer fallback. Each has a bisect knob
+# (`ESS_OOP_SSA_GHOST` / `_SUB` / `_PGATHER`, all default on), so every
+# engagement assertion below is paired with a NEGATIVE CONTROL: the same build
+# with that one arm declined must show the coverage gone.
+# ---------------------------------------------------------------------------
+
+# One producer occupying slots 5:8 at level 1, the state at slots 1:4 (level 0).
+const _SX_PID = Int32[1, 1, 1, 1, 2, 2, 2, 2]
+const _SX_POS = Int32[1, 2, 3, 4, 1, 2, 3, 4]
+const _SX_LVL = Int[0, 1]
+const _SX_LEN = Int[4, 4]
+_sx_owners(g, m = Bool[]; lvl = 2, pid = _SX_PID, pos = _SX_POS) =
+    ESMs._ssa_lane_owners(g, m, pid, pos, _SX_LVL, _SX_LEN, lvl)
+
+@testset "SSA reference forms (lane owners + tier choice)" begin
+
+    @testset "run decomposition and the level/ownership refusals" begin
+        o = _sx_owners([5, 6, 7, 8])
+        @test o !== nothing
+        r = ESMs._ssa_pack_ref(o[1], o[2], true)
+        @test r.pid == 0 && r.segs == [ESMs._OopSSASeg(2, 1, 4)]
+        # a producer that does NOT strictly precede the consumer is refused
+        @test _sx_owners([5, 6, 7, 8]; lvl = 1) === nothing
+        # so is a slot nothing owns (a later writer disowned it)
+        dis = copy(_SX_PID); dis[6] = 0
+        @test _sx_owners([5, 6, 7, 8]; pid = dis) === nothing
+        # out-of-range slots are refused rather than read
+        @test _sx_owners([5, 6, 7, 99]) === nothing
+    end
+
+    @testset "ghost mask: a wildcard lane takes whatever continues the run" begin
+        # A MIDDLE ghost (its safe-index gather read slot 1) is filled from its
+        # left neighbour and the whole descriptor collapses to ONE slice.
+        o = _sx_owners([5, 1, 7, 8], Bool[false, true, false, false])
+        @test o !== nothing
+        @test o[1] == [2, 2, 2, 2] && o[2] == [1, 2, 3, 4]
+        @test ESMs._ssa_pack_ref(o[1], o[2], true).segs == [ESMs._OopSSASeg(2, 1, 4)]
+        # A LEADING ghost cannot back-extend past position 1, so it takes the
+        # placeholder segment (the state's slot 1) and the rest is one slice.
+        o = _sx_owners([1, 5, 6, 7], Bool[true, false, false, false])
+        @test o !== nothing
+        @test o[1] == [1, 2, 2, 2] && o[2] == [1, 1, 2, 3]
+        @test ESMs._ssa_pack_ref(o[1], o[2], true).segs ==
+              [ESMs._OopSSASeg(1, 1, 1), ESMs._OopSSASeg(2, 1, 3)]
+        # A leading ghost that CAN back-extend does, and the run stays single.
+        o = _sx_owners([1, 6, 7, 8], Bool[true, false, false, false])
+        @test o[1] == [2, 2, 2, 2] && o[2] == [1, 2, 3, 4]
+        # Every invented position stays inside its producer's value, whichever
+        # lanes the mask covers.
+        raw = [5, 6, 7, 8]
+        for bits in 1:14                      # every mask but none-set / all-set
+            msk = Bool[(bits >> (l - 1)) & 1 == 1 for l in 1:4]
+            o = _sx_owners(Int[msk[l] ? 1 : raw[l] for l in 1:4], msk)
+            @test o !== nothing
+            for l in 1:4
+                @test 1 <= o[2][l] <= _SX_LEN[o[1][l]]
+            end
+        end
+        # An ALL-ghost descriptor is declined (it is a constant zero vector).
+        @test _sx_owners([1, 1, 1, 1], Bool[true, true, true, true]) === nothing
+    end
+
+    @testset "tier 2b: a fragmented SINGLE-producer mapping gathers the value" begin
+        pid = fill(Int32(2), 40)
+        pos = Int32.(1:40)
+        lvl = Int[0, 1]
+        len = Int[40, 40]
+        g = collect(40:-1:1)                      # reversed ⇒ 40 runs of length 1
+        o = ESMs._ssa_lane_owners(g, Bool[], pid, pos, lvl, len, 2)
+        @test o !== nothing
+        r = ESMs._ssa_pack_ref(o[1], o[2], true)
+        @test r.pid == 2 && r.pos == g && isempty(r.segs)
+        # NEGATIVE CONTROL: with tier 2b declined the mapping is too fragmented
+        # for slices and falls back to the flat buffer.
+        @test ESMs._ssa_pack_ref(o[1], o[2], false) === ESMs._OOP_SSA_NOREF
+        # A fragmented MULTI-producer mapping has no one-op form either way.
+        pid2 = Int32[i <= 20 ? 2 : 3 for i in 1:40]
+        pos2 = Int32[i <= 20 ? i : i - 20 for i in 1:40]
+        o2 = ESMs._ssa_lane_owners(g, Bool[], pid2, pos2, Int[0, 1, 1], Int[40, 20, 20], 2)
+        @test o2 !== nothing
+        @test ESMs._ssa_pack_ref(o2[1], o2[2], true) === ESMs._OOP_SSA_NOREF
+    end
+end
+
+# A REVERSED read of a materialized observed: `g[N+1-i]` is not `out .+ delta`,
+# so the build lowers it to a per-box slot table whose lanes descend — L runs of
+# length 1, past the slice worthwhileness bound. Tier 2b turns it into one
+# gather of `g`'s value; without tier 2b it is the dense `ue` gather, and `g`'s
+# scatter has to stay.
+function _s_rev(N)
+    _s_doc("SSAREV",
+        Dict{String,Any}("u" => _s_state(shape = Any["n"]),
+                         "g" => _s_state(shape = Any["n"]),
+                         "k" => _s_param(0.25)),
+        Any[Dict{String,Any}("lhs" => "g",
+                "rhs" => _s_ao(_s_o("+", _s_o("*", 2.0, _s_ix("u", "i")), 1.0))),
+            Dict{String,Any}("lhs" => _s_ao(_s_Dt(_s_ix("u", "i"))),
+                "rhs" => _s_ao(_s_o("-", _s_o("*", "k",
+                                    _s_ix("g", _s_o("-", Float64(N + 1), "i"))),
+                                    _s_ix("u", "i"))))],
+        N)
+end
+
+_s_build_env(doc, env...) = withenv("ESS_OOP_SSA" => "1", env...) do
+    ESMs.build_evaluator(doc; form = :oop)
+end
+
+@testset "tier 2b end to end (reversed observed read)" begin
+    N = 24
+    doc = _s_rev(N)
+    (fon, u0, p, _, _) = _s_build_env(doc)
+    (fno, _, _, _, _) = _s_build_env(doc, "ESS_OOP_SSA_PGATHER" => "0")
+    foff, = withenv("ESS_OOP_SSA" => nothing) do
+        ESMs.build_evaluator(doc; form = :oop)
+    end
+    fip, = ESMs.build_evaluator(doc)
+    for probe in (u0, _s_seed(length(u0))), t in (0.0, 0.41)
+        a = fon(probe, p, t)
+        @test a == foff(probe, p, t)
+        @test a == fno(probe, p, t)
+        @test a == _s_ip(fip, probe, p, t)
+    end
+    son = ESMs.oop_ssa_stats(fon)
+    sno = ESMs.oop_ssa_stats(fno)
+    # ENGAGEMENT + NEGATIVE CONTROL: the reversed edge redirects only with the
+    # arm on, and it is the last reader keeping `g`'s scatter alive.
+    @test son.n_fast > sno.n_fast
+    @test son.n_skipped_scatters > sno.n_skipped_scatters
+    @test son.n_producers == 1 && son.n_skipped_scatters == 1
+    Jon = ForwardDiff.jacobian(uu -> fon(uu, p, 0.2), _s_seed(N))
+    Joff = ForwardDiff.jacobian(uu -> foff(uu, p, 0.2), _s_seed(N))
+    @test Jon == Joff
+end
+
+# ---------------------------------------------------------------------------
+# Template SUB-KERNEL descriptor tables (`SSA_SPIKE.md` blocker #2). A sub is
+# evaluated at the PARENT's lanes and `_build_oop_desc_vectors` resolves its
+# descriptors against that same enumeration, so its gathers are ordinary slot
+# vectors into `ue` — but they index `S.acc`, not `K.acc`, which is why the
+# spike's per-kernel table could not carry them and every one of them held its
+# producers' scatters alive. Measured on the ReSEACT transport RHS at 6x6x8,
+# these are 885 of the 985 candidate descriptors and 1.07 M of the 1.11 M read
+# elements, so they are the read surface that matters.
+#
+# The fixture is the duo-rule shape from codegen_subcall_fn_test.jl — a
+# makearray whose region value applies an aggregate-bodied template whose expr
+# holds more applies as arithmetic OPERANDS — because that is what mints
+# `_NK_SUBCALL`s at all.
+function _s_sub_fixture(dir, N)
+    ix(f, i, j) = Dict("op" => "index", "args" => Any[f, i, j])
+    ap(a, b) = Dict("op" => "apply_expression_template", "args" => Any[],
+                    "name" => "leaf", "bindings" => Dict("a" => a, "b" => b))
+    leaf_terms = Any[]
+    for k in 1:12
+        push!(leaf_terms, Dict("op" => "*", "args" => Any[0.5 + 0.01k,
+            Dict("op" => "+", "args" => Any[
+                Dict("op" => "*", "args" => Any["a", "a"]),
+                Dict("op" => "*", "args" => Any["b", 0.3 + 0.02k])])]))
+    end
+    leaf = Dict("params" => Any["a", "b"],
+                "body" => Dict("op" => "+", "args" => leaf_terms))
+    inner_expr = Dict("op" => "+", "args" => Any[
+        Dict("op" => "*", "args" => Any[0.25, ap(ix("f", "i", "j"), ix("f", "i", "j"))]),
+        ap(ix("f", "i", "j"), ix("f", "j", "i")),
+        Dict("op" => "*", "args" => Any[ap(ix("f", "i", "j"), ix("f", "i", "j")), 0.125])])
+    inner = Dict("params" => Any["f"],
+                 "body" => Dict("op" => "aggregate", "output_idx" => Any["i", "j"],
+                                "args" => Any["f"],
+                                "ranges" => Dict("i" => Dict("from" => "x"),
+                                                 "j" => Dict("from" => "y")),
+                                "expr" => inner_expr))
+    rhs = Dict("op" => "makearray", "args" => Any[],
+               "regions" => Any[Any[Any[1, "N"], Any[1, "N"]]],
+               "values" => Any[Dict("op" => "apply_expression_template",
+                                    "args" => Any[], "name" => "inner",
+                                    "bindings" => Dict("f" => "u"))])
+    doc = Dict("esm" => "1.0.0",
+        "metadata" => Dict("name" => "ssa_subcall_fixture",
+                           "description" => "generated by tree_walk_oop_ssa_test.jl: sub-kernel redirect"),
+        "metaparameters" => Dict("N" => Dict("type" => "integer", "default" => N)),
+        "index_sets" => Dict("x" => Dict("kind" => "interval", "size" => "N"),
+                             "y" => Dict("kind" => "interval", "size" => "N")),
+        "models" => Dict("M" => Dict(
+            "expression_templates" => Dict("leaf" => leaf, "inner" => inner),
+            "variables" => Dict("u" => Dict("type" => "unknown", "units" => "1",
+                                            "shape" => Any["x", "y"], "default" => 1.0)),
+            "equations" => Any[Dict(
+                "lhs" => Dict("op" => "D", "args" => Any["u"], "wrt" => "t"),
+                "rhs" => rhs)])))
+    path = joinpath(dir, "ssa_subcall_fixture.esm")
+    open(path, "w") do io
+        JSON3.write(io, doc)
+    end
+    return path
+end
+
+@testset "sub-kernel descriptor tables redirect (blocker #2)" begin
+    mktempdir() do dir
+        F = _s_sub_fixture(dir, 5)
+        build(env...) = withenv(env...) do
+            ESMs.build_evaluator(ESMs.flatten(ESMs.load_path(F)); form = :oop)
+        end
+        # The nested-boundary tier is what mints the `_NK_SUBCALL`s.
+        nested = "ESS_NESTED_TEMPLATE_BOUNDARY" => "1"
+        (fon, u0, p, _, _) = build(nested, "ESS_OOP_SSA" => "1")
+        (fno, _, _, _, _) = build(nested, "ESS_OOP_SSA" => "1",
+                                  "ESS_OOP_SSA_SUB" => "0")
+        (foff, _, _, _, _) = build(nested, "ESS_OOP_SSA" => nothing)
+        fip, ui, pi_, _, _ = withenv(nested) do
+            ESMs.build_evaluator(ESMs.flatten(ESMs.load_path(F)))
+        end
+
+        son = ESMs.oop_ssa_stats(fon)
+        sno = ESMs.oop_ssa_stats(fno)
+        # ENGAGEMENT: the sub tables are where this fixture's reads live at all,
+        # and every one of them redirects.
+        @test son.n_sub_edges > 0
+        @test son.n_sub_fast == son.n_sub_edges
+        # NEGATIVE CONTROL: with the arm declined not one of them redirects.
+        @test sno.n_sub_edges == son.n_sub_edges
+        @test sno.n_sub_fast == 0
+
+        # BIT-IDENTITY across all three builds and the in-place `f!`.
+        for probe in (u0, _s_seed(length(u0))), t in (0.0, 0.63)
+            a = fon(probe, p, t)
+            @test a == foff(probe, p, t)
+            @test a == fno(probe, p, t)
+            @test a == _s_ip(fip, probe, pi_, t)
+        end
+        u = _s_seed(length(u0))
+        @test ForwardDiff.jacobian(uu -> fon(uu, p, 0.3), u) ==
+              ForwardDiff.jacobian(uu -> foff(uu, p, 0.3), u)
+    end
+end

--- a/pkg/EarthSciAST.jl/test/tree_walk_oop_ssa_test.jl
+++ b/pkg/EarthSciAST.jl/test/tree_walk_oop_ssa_test.jl
@@ -452,3 +452,260 @@ end
               ForwardDiff.jacobian(uu -> foff(uu, p, 0.3), u)
     end
 end
+
+# ---------------------------------------------------------------------------
+# SCALAR read surfaces (`SSA_SPIKE.md` blocker #4): the scalar `_Node` walker
+# (`_oop_eval` — a `_NK_STATE` pin, a `_NK_STATE_GATHER` slot table) and its
+# lane-batched twin (`_oop_eval_batch`, ess-oop-batch). Neither reads through a
+# consumer DESCRIPTOR, so neither could use the per-kernel redirect table; both
+# went through the flat `ue` and held their producers' scatters alive wherever
+# they landed. They redirect through the same slot→(producer, position) map the
+# descriptor arm resolves, published per surface as a consumer LEVEL
+# (`_OopSSAOwn` + `_OopSSASCtx`).
+#
+# THE ARM IS DEFAULT OFF — it MEASURED SLOWER (4.3% on the CONUS 4x5 transport
+# reverse; see the knob's note in oop.jl) — so `ESS_OOP_SSA_SCALAR=1` opts in
+# and every build below spells its intent. Three `:oop` builds are compared
+# throughout: the arm opted IN, the SHIPPED DEFAULT (`ESS_OOP_SSA=1` alone,
+# which must be indistinguishable from the explicit `=0` control — that is the
+# assertion that the default path is untouched), and the feature off entirely.
+#
+# Measured on the ReSEACT transport RHS at 6x6x8 (the campaign's steering
+# instrument, `oop_ssa_stats().blockers_only`): these reads were the SOLE
+# blocker on 2 of the 4 surviving producers, both of them level-3/4 per-column
+# fills reading a lower level's kernel output through a `_NK_STATE_GATHER`.
+# ---------------------------------------------------------------------------
+
+# One producer owning slots 5:8 at level 1 (`_SX_*` above), a second at 9:12.
+const _SC_PID = Int32[1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]
+const _SC_POS = Int32[1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4]
+const _SC_OWN = ESMs._OopSSAOwn(_SC_PID, _SC_POS, Int[0, 1, 2])
+
+@testset "scalar surface map (the redirect predicate)" begin
+    own = _SC_OWN
+    # a producer that strictly precedes the surface redirects; one at the same
+    # level or later does not (a fill level's own scalars run BEFORE its
+    # kernels, so `cons == producer level` must refuse)
+    @test ESMs._ssa_owner_pid(own, 5, 2) == 2
+    @test ESMs._ssa_owner_pid(own, 5, 1) == 0
+    @test ESMs._ssa_owner_pid(own, 9, 2) == 0
+    @test ESMs._ssa_owner_pid(own, 9, 3) == 3
+    # the raw state prefix is producer 1 at level 0, so it redirects everywhere
+    @test ESMs._ssa_owner_pid(own, 1, 1) == 1
+    # a disowned slot (a later writer took it, or a level scalar / scan fold
+    # rewrites it) and an out-of-range slot are both refused, never read
+    dis = ESMs._OopSSAOwn(Int32[1, 0, 1], Int32[1, 0, 3], Int[0])
+    @test ESMs._ssa_owner_pid(dis, 2, 1) == 0
+    @test ESMs._ssa_owner_pid(own, 99, 9) == 0
+    @test ESMs._ssa_owner_pid(own, 0, 9) == 0
+    # `cons == 0` is the OFF surface: nothing redirects, whatever the map says
+    @test ESMs._ssa_owner_pid(own, 5, 0) == 0
+    # …and the OFF singleton answers 0 for every slot
+    @test ESMs._ssa_owner_pid(ESMs._OOP_SSA_OWN_OFF, 5, 9) == 0
+    # the (pid, pos) form agrees with it and carries the producer-local position
+    sc = ESMs._OopSSASCtx(own, 2, Any[])
+    @test ESMs._oop_ssa_owner(sc, 7) == (2, 3)
+    @test ESMs._oop_ssa_owner(ESMs._OOP_SSA_SCTX_OFF, 7) == (0, 0)
+end
+
+@testset "scalar surface: lane vectors take ONE producer or nothing" begin
+    own = _SC_OWN
+    # BUILD-time verdict and RUN-time resolution are the same function of the
+    # same data — asserted here side by side, because a disagreement is exactly
+    # what would let a scatter be skipped under a live reader.
+    lanes(slots, mask = Bool[]; cons = 2) = begin
+        pos = Vector{Int}(undef, length(slots))
+        pid = ESMs._oop_ssa_lane_pid!(pos, ESMs._OopSSASCtx(own, cons, Any[]),
+                                      slots, mask)
+        (pid, pid == 0 ? Int[] : pos)
+    end
+    # one producer, in any order: redirected at producer-local positions
+    @test lanes([5, 6, 7, 8]) == (2, [1, 2, 3, 4])
+    @test lanes([8, 5, 8]) == (2, [4, 1, 4])
+    @test ESMs._ssa_lane_common_pid([8, 5, 8], own, 2) == 2
+    # TWO producers in one lane vector: no single-op form, so the `ue` gather
+    # stays (and the build marks both blocks residual)
+    @test lanes([5, 9]; cons = 3)[1] == 0
+    @test ESMs._ssa_lane_common_pid([5, 9], own, 3) == 0
+    # an unowned or not-yet-written lane refuses the whole vector
+    @test lanes([5, 6, 7, 8]; cons = 1)[1] == 0
+    @test ESMs._ssa_lane_common_pid([5, 6, 7, 8], own, 1) == 0
+    # GHOST lanes are wildcards (the caller's select overwrites them with 0),
+    # so they take position 1 instead of breaking the single-producer form
+    @test lanes([1, 6, 7, 1], Bool[true, false, false, true]) == (2, [1, 2, 3, 1])
+    # an ALL-ghost vector has no producer to name and declines
+    @test lanes([1, 1], Bool[true, true])[1] == 0
+    # the OFF surface never redirects
+    @test ESMs._oop_ssa_lane_pid!(zeros(Int, 4), ESMs._OOP_SSA_SCTX_OFF,
+                                  [5, 6, 7, 8], Bool[]) == 0
+end
+
+# `g` is a materialized array observed read BOTH by an array kernel (which the
+# descriptor arm already redirects) and by `M` SCALAR state equations. With
+# M == 1 that read is a leftover single on `_oop_eval`; with M > 1 the congruent
+# entries form ONE lane-batched group and the read becomes a `_NK_STATE` slot
+# VECTOR on `_oop_eval_batch` — the two scalar surfaces, same fixture.
+function _s_scalread(N, M)
+    vars = Dict{String,Any}("u" => _s_state(shape = Any["n"]),
+                            "g" => _s_state(shape = Any["n"]),
+                            "k" => _s_param(0.25))
+    eqs = Any[
+        Dict{String,Any}("lhs" => "g",
+            "rhs" => _s_ao(_s_o("+", _s_o("*", 2.0, _s_ix("u", "i")), 1.0))),
+        Dict{String,Any}("lhs" => _s_ao(_s_Dt(_s_ix("u", "i"))),
+            "rhs" => _s_ao(_s_o("-", _s_o("*", "k", _s_ix("g", "i")),
+                                _s_ix("u", "i")))),
+    ]
+    for m in 1:M
+        nm = "w$m"
+        vars[nm] = _s_state()
+        push!(eqs, Dict{String,Any}("lhs" => _s_Dt(nm),
+            "rhs" => _s_o("-", _s_ix("g", Float64(m)), nm)))
+    end
+    _s_doc("SSASCAL", vars, eqs, N)
+end
+
+@testset "scalar-walker reads redirect (blocker #4)" begin
+    @testset "$(M == 1 ? "leftover single" : "lane-batched group") (M = $M)" for M in (1, 4)
+        doc = _s_scalread(9, M)
+        (fon, u0, p, _, _) = _s_build_env(doc, "ESS_OOP_SSA_SCALAR" => "1")
+        (fno, _, _, _, _) = _s_build_env(doc, "ESS_OOP_SSA_SCALAR" => "0")
+        (fdef, _, _, _, _) = _s_build_env(doc)     # the SHIPPED default
+        foff, = withenv("ESS_OOP_SSA" => nothing) do
+            ESMs.build_evaluator(doc; form = :oop)
+        end
+        fip, = ESMs.build_evaluator(doc)
+
+        # BIT-IDENTITY across all four `:oop` builds and the in-place `f!`.
+        for probe in (u0, _s_seed(length(u0))), t in (0.0, 0.53)
+            a = fon(probe, p, t)
+            @test a == foff(probe, p, t)
+            @test a == fno(probe, p, t)
+            @test a == fdef(probe, p, t)
+            @test a == _s_ip(fip, probe, p, t)
+        end
+
+        son = ESMs.oop_ssa_stats(fon)
+        sno = ESMs.oop_ssa_stats(fno)
+        # The surface really is the one under test: with M > 1 the entries
+        # batched (one lane vector), with M == 1 they did not.
+        rhs = getfield(fon, :rhs)
+        rb = getfield(rhs, :rhs_batches)
+        @test (M > 1) == !isempty(rb.groups)
+        # ENGAGEMENT: every scalar read site redirected, at full element volume.
+        @test son.n_scalar_edges > 0
+        @test son.n_scalar_fast == son.n_scalar_edges
+        @test son.elems_scalar_fast == son.elems_scalar_edges > 0
+        # …and it was the LAST reader keeping `g`'s scatter into `ue` alive.
+        @test son.n_producers == 1
+        @test son.n_skipped_scatters == 1
+        @test son.blockers_only.scalar == 0
+
+        # NEGATIVE CONTROL: with the arm declined the sites are still counted
+        # (the tally is the steering instrument), none of them redirects, and
+        # `g` scatters again — blamed on this surface by name.
+        @test sno.n_scalar_edges == son.n_scalar_edges
+        @test sno.n_scalar_fast == 0
+        @test sno.elems_scalar_fast == 0
+        @test sno.n_skipped_scatters == 0
+        @test sno.blockers_only.scalar == 1
+        # SHIPPED DEFAULT: `ESS_OOP_SSA=1` alone must be the control, column for
+        # column — the arm is opt-in, so merging it may not move any build that
+        # does not ask for it.
+        @test ESMs.oop_ssa_stats(fdef) == sno
+        # the DESCRIPTOR arm is untouched either way (this is one arm, alone)
+        @test sno.n_fast == son.n_fast
+        @test sno.n_edges == son.n_edges
+
+        # AD: a redirect changes where an operand comes from, never the value.
+        u = _s_seed(length(u0))
+        @test ForwardDiff.jacobian(uu -> fon(uu, p, 0.35), u) ==
+              ForwardDiff.jacobian(uu -> foff(uu, p, 0.35), u)
+    end
+end
+
+# The surface that actually held ReSEACT's two producers: a per-column
+# materialized fill whose body is a runtime CONTRACTION LOOP, so its state read
+# is a `_NK_STATE_GATHER` at a loop-counter subscript — a slot resolved per
+# iteration out of a static table. Here `q` is itself a materialized array
+# observed (a level-1 kernel producer) and `S[i] = Σ_k q[i,k]` fragments into
+# per-column scalars at level 2, which batch into ONE lane group: exactly the
+# ReSEACT transport shape (level-3/4 per-column fills over a level-1/2 kernel's
+# output). Built through the typed AST because a runtime contraction loop needs
+# an `aggregate` with an inner range, which the JSON helpers above do not spell.
+include("testutils.jl")
+
+@testset "state-gather fill levels redirect (blocker #4, the ReSEACT shape)" begin
+    N, M = 6, 12                       # M ≥ the contraction-loop floor
+    isets = Dict("x" => ESMs.IndexSet("interval"; size = N),
+                 "y" => ESMs.IndexSet("interval"; size = M))
+    vars = Dict("u" => ESMs.ModelVariable(ESMs.UnknownVariable; shape = ["x"]),
+                "q" => ESMs.ModelVariable(ESMs.UnknownVariable; shape = ["x", "y"]),
+                "S" => ESMs.ModelVariable(ESMs.UnknownVariable; shape = ["x"]))
+    rng_i = Dict{String,Any}("i" => ESMs.IndexSetRef("x"))
+    rng_ik = Dict{String,Any}("i" => ESMs.IndexSetRef("x"),
+                              "k" => ESMs.IndexSetRef("y"))
+    rng_ab = Dict{String,Any}("a" => ESMs.IndexSetRef("x"),
+                              "b" => ESMs.IndexSetRef("y"))
+    eqs = [
+        ESMs.Equation(_v("q"), _op("aggregate"; output_idx = Any["a", "b"],
+            ranges = rng_ab,
+            expr_body = _op("+", _op("*", _n(2.0), _idx("u", _v("a"))), _n(1.0)))),
+        ESMs.Equation(_v("S"), _op("aggregate"; output_idx = Any["i"],
+            ranges = rng_ik, semiring = "sum_product",
+            expr_body = _idx("q", _v("i"), _v("k")))),
+        ESMs.Equation(_op("aggregate"; output_idx = Any["i"], ranges = rng_i,
+                          expr_body = _Didx("u", _v("i"))),
+                      _op("aggregate"; output_idx = Any["i"], ranges = rng_i,
+                          expr_body = _op("-", _idx("S", _v("i")),
+                                          _idx("u", _v("i"))))),
+    ]
+    model = ESMs.Model(vars, eqs)
+    ics = Dict{String,Any}("u[$j]" => 0.3 * j for j in 1:N)
+    bld(env = (); form = :oop) = withenv("ESS_CONTRACTION_LOOP" => "1",
+            "ESS_CONTRACTION_LOOP_MIN" => "8", env...) do
+        ESMs.build_evaluator(model; index_sets = isets, initial_conditions = ics,
+                             form = form)
+    end
+    fon, u0, p, _, _ = bld(("ESS_OOP_SSA" => "1", "ESS_OOP_SSA_SCALAR" => "1"))
+    fno, = bld(("ESS_OOP_SSA" => "1", "ESS_OOP_SSA_SCALAR" => "0"))
+    fdef, = bld(("ESS_OOP_SSA" => "1",))            # the SHIPPED default
+    foff, = bld(("ESS_OOP_SSA" => nothing,))
+    fip, ui, pi_, = bld((); form = :inplace)
+
+    # The fixture really is the shape under test: `q` is a level-1 kernel
+    # producer and `S`'s fill fragmented into per-column scalars that batched.
+    rhs = getfield(fon, :rhs)
+    ml = getfield(rhs, :mat_levels)
+    @test length(ml) == 2
+    @test length(ml[1][2]) == 1 && isempty(ml[1][1])   # level 1: one kernel
+    @test length(ml[2][1]) == N && isempty(ml[2][2])   # level 2: N scalars
+    @test length(getfield(rhs, :mat_batches)[2].groups) == 1
+
+    # BIT-IDENTITY across all four `:oop` builds and the in-place `f!`.
+    for t in (0.0, 0.29)
+        a = fon(u0, p, t)
+        @test a == foff(u0, p, t)
+        @test a == fno(u0, p, t)
+        @test a == fdef(u0, p, t)
+        @test a == _s_ip(fip, ui, pi_, t)
+    end
+
+    son = ESMs.oop_ssa_stats(fon)
+    sno = ESMs.oop_ssa_stats(fno)
+    # ENGAGEMENT: the state-gather site redirected at full element volume, and
+    # it was the only reader keeping `q`'s scatter into `ue` alive.
+    @test son.n_scalar_edges == sno.n_scalar_edges > 0
+    @test son.n_scalar_fast == son.n_scalar_edges
+    @test son.elems_scalar_fast == son.elems_scalar_edges > 0
+    @test son.n_producers == 1 && son.n_skipped_scatters == 1
+    @test son.blockers_only.scalar == 0
+    # NEGATIVE CONTROL, and the SHIPPED DEFAULT is that control exactly.
+    @test sno.n_scalar_fast == 0 && sno.elems_scalar_fast == 0
+    @test sno.n_skipped_scatters == 0
+    @test sno.blockers_only.scalar == 1
+    @test ESMs.oop_ssa_stats(fdef) == sno
+
+    @test ForwardDiff.jacobian(uu -> fon(uu, p, 0.17), u0) ==
+          ForwardDiff.jacobian(uu -> foff(uu, p, 0.17), u0)
+end


### PR DESCRIPTION
**This arm ships DEFAULT OFF because it measured SLOWER.** It is correct, its
coverage is real, and it closes `SSA_SPIKE.md` blocker #4 — and on the CONUS 4x5
transport reverse it costs **4.3%**. `ESS_OOP_SSA_SCALAR=1` opts in; nothing on
the default path moves.

The durable parts of this PR are the blocker-tally instrumentation, the 108
assertions with their negative controls, and the measurement that says why the
arm is off.

**Stacks on #283** (`ctessum-claude:perf/ssa-read-redirect-arms`). GitHub will
not take a base branch that lives on the fork, so this PR is opened against
`main` and its diff therefore CONTAINS #283's three commits. **Review only the
last commit**; merge #283 first and this rebases to that one commit.

## The measurement

CONUS 4x5 (13x7x72), one process, both arm orders, `off` = #283 exactly,
`on` = #283 + this arm:

| program | off | on | ratio |
|---|---|---|---|
| `rhs` | 6.383 ms | 6.321 ms | 1.010 (flat) |
| `rhs_vjp` | 71.410 ms | 74.594 ms | **0.957 — 4.3% slower** |

The copy census (`p11_ue_traffic.py`, off the buffer-assignment dump) explains
it and is the reason the timing A/B was not run until it returned:

| | off | on |
|---|---|---|
| whole-buffer copies | 82 | **80** (−2) |
| total copy instructions | 290 | **432** (+142) |
| real element writes | 55.22 M | 56.11 M |

Two whole-buffer copies removed — exactly the two scatters the coverage number
says were freed — against 142 copy instructions added.

## Why it does not pay

The scalar surfaces' reads were **already cheap relative to the buffer versions
they kept alive**. On the transport RHS they are a handful of gathers per fill
level, not O(cells) of them; what made them matter to the *coverage* metric is
that a cheap read is still a read, and one read anywhere in a producer's block
pins that producer's whole scatter. So redirecting them frees two scatters —
real, and worth 2 whole-buffer copies — while the redirect's own materialization
adds cost: a producer-value gather per lane group, off a value XLA must now keep
live across the level boundary instead of letting it die into `ue`.

That is the same mechanism the concurrent scatter-skip **gate** work
established, not a separate mystery: **a partial skip pays twice** — once for
the buffer that still gets assembled by the producers that did not skip, and
once for the values kept alive beside it. Coverage is not the objective
function; the copy census is. Seven documented conclusions in this campaign
have been refuted by measurement and this is the eighth, on my own change.

## What the arm actually does (for review, and for whoever opts in)

One shared slot→(producer, position) map — the very vectors the plan build
already computes for the descriptor arm — published **per read surface as a
consumer LEVEL** (`_OopSSAOwn` + `_OopSSASCtx`). A scalar read of slot `s` at
level `ℓ` redirects iff `s` has an owner and that owner's level is strictly
below `ℓ`: the same two soundness facts the descriptor arm rests on (fills read
strictly lower levels; slot ownership is LAST-writer, so a slot a later kernel
rewrites is owned by that later kernel or by nobody and the level test refuses
it).

Not one slot-indexed table per surface: that would be O(levels × n_total) host
data (≈12 MB at CONUS) for a decision that is the same function of the slot
everywhere.

Granularity differs between the two walkers because their fallbacks do:

* `_oop_eval` reads ONE slot and can fall back per read ⇒ the verdict is per
  **slot**;
* `_oop_eval_batch` returns a whole lane vector through one gather ⇒ the verdict
  is per **node** and requires one common producer across every lane. Ghost
  lanes are wildcards (the caller's select overwrites them with 0), so a
  boundary lane does not break the single-producer form.

Build-time marking (`_ssa_mark_node_reads!` / `_ssa_mark_batch_reads!` /
`_ssa_mark_surface_reads!`) and the walk-time seams share **one** predicate,
`_ssa_owner_pid`, so a slot is marked residual exactly when the walker will read
it off `ue` — the two cannot drift. The feature's existing runtime guard still
covers the one divergence: a producer whose spine hoisted to a lane-invariant
scalar records no value, every redirect to it falls back to the (still-written)
gather, and `_oop_run_acc_vec` emits its scatter after all.

## Coverage, when opted in — ReSEACT transport RHS 6x6x8, `oop_ssa_stats`

| | arm off (= #283, = the shipped default) | arm on |
|---|---|---|
| scatters skipped | 13/17 (4 874 slots) | **15/17 (5 450 slots)** |
| `blockers` | scalar **2**, scan 1, sub 2 | scalar **0**, scan 1, sub 2 |
| `blockers_only` | scalar **2**, sub 1 | scalar **0**, sub 1 |
| scalar sites | 0/6 | **6/6** |
| scalar elements | 0 / 404 352 | **404 352 / 404 352** |
| descriptor edges | 97/100 | 97/100 |
| sub-kernel edges | 731/885 | 731/885 |

**Design-note item 4 was correct**: the surface is redirectable through the
existing map, and #283's per-reason tally is what pointed at it. It said
`blockers_only.scalar == 2`; a probe (not inference) then put both of those
producers on level-3/4 per-column fills reading a *lower* level's kernel output
through a `_NK_STATE_GATHER`, each batched into one lane group. Every such node
was "pure" — one common redirectable producer over its whole static slot table —
which is why the single-producer criterion suffices and why exactly those two
producers were released. That tally is also what let the concurrent gate work
find its own discriminator, which is the argument for keeping it.

With the knob off, **every** column of `oop_ssa_stats` reproduces #283 exactly
at that scale — only the new tally columns are populated — and the tests assert
that the shipped default is that control column for column.

The note's four host fixtures are unchanged (they were already 100% and have no
scalar read surface at all), which is why this branch adds fixtures that do.

## Exactness

`:oop`(arm on) == `:oop`(arm off) == `:oop`(shipped default) ==
`:oop`(feature off) == `:inplace` at Float64 `==`, and ForwardDiff jacobians
`==`, on all fixtures.

## Tests

`test/tree_walk_oop_ssa_test.jl` gains **108 assertions** in 4 testsets: the
redirect predicate and the lane-vector resolution as units (build-time verdict
asserted beside the walk-time one, because a disagreement is exactly what would
let a scatter be skipped under a live reader), and three end-to-end fixtures — a
leftover single on `_oop_eval`, a lane-batched `_NK_STATE` slot vector, and the
ReSEACT shape: a per-column fill whose contraction loop reads a level-1 kernel
producer through a `_NK_STATE_GATHER`. Every engagement assertion is paired with
the `ESS_OOP_SSA_SCALAR=0` negative control **and** with a shipped-default
assertion that `ESS_OOP_SSA=1` alone equals that control.

Host suite, 10 files, run with the emitter flag OFF and forced ON, both arms
identical and green: `tree_walk_oop` 164, `oop_scalar_batch` 42,
`array_obs_materialize` 71+3, `scan_prefix` 333, `observed_materialization`
8+12, `oop_merge`, `contraction_loop` 14+35+19, `tree_walk_observed_slots` 36,
`tree_walk_iip_generic` 69 (which also pins the in-place path's
zero-allocation property — threading the extra surface argument through the two
`:oop` walkers did not touch it), `tree_walk_oop_ssa` 274.

**Missing:** the full `Pkg.test()` sweep. That job died **OUT_OF_MEMORY at 64 G
after 54 minutes**; it needs `--mem>=128G` if anyone reruns it. It is moot for
merge now that the arm defaults off and the ten-file sweep above was green in
both arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P67eFnfXX9S1XKTEiG2yd3
