### PR TITLE
perf(oop): block size was the wrong gate -- the question is whether ue can die

### DIFF
--- a/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
+++ b/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
@@ -180,14 +180,58 @@ fold.
   forcing reads go through the buffers argument, never `ue` — and the
   discrete-cadence refresh stays visible with fill scatters skipped (probed).
 
+## ReSEACT at CONUS: 1.36x on the whole adjoint loop, chemistry exact
+
+Measured 2026-09-09 at 4x5 CONUS (13x7x72, 6 552 cells), two driver builds in
+ONE process, arms interleaved, every pair run in BOTH arm orders — reproducing
+to three digits, so the order is not what is being measured.
+`tools/diag/p13_ssa_ab.jl` + `tools/diag/p11_ue_traffic.py` in the consuming
+repo.
+
+| program | arms off | arms on | off/on | copies | real element writes |
+|---|---|---|---|---|---|
+| `ros_step` (chemistry) | 38.90 ms | 28.23 ms | **1.38** (bit-for-bit) | | |
+| `ros_vjp` | 81.11 ms | 56.71 ms | **1.43** (λ bit-for-bit) | | |
+| `rhs` (transport RHS) | 3.755 ms | 6.405 ms | 0.59 | 2 → 3 | 2.49 M → 2.69 M |
+| `rhs_vjp` | 80.5 ms | 72.2 ms | **1.12** | **98 → 82** | 59.55 M → 55.22 M |
+| `ssp_step` (4-stage) | 13.41 ms | 24.25 ms | 0.55 | 8 → 12 | 10.43 M → 16.97 M |
+| `ssp_vjp` | 306.6 ms | 254.9 ms | **1.20** | **394 → 331** | 231.8 M → 176.3 M |
+
+Weighted by the adjoint's step mix (45.3 chemistry + 3.2 transport steps per
+300 s window) the per-window cost is 6.46 s → 4.74 s, **1.36x**.
+
+WHY THE TRANSPORT FORWARD LOSES. A producer's `dynamic_update_slice` into `ue`
+ALIASES its operand in the FORWARD, so XLA:CPU writes only the update and the
+scatter is nearly free there; skipping it instead forces the producer's value to
+be materialized as its own buffer. On the PPM transport RHS (17 producers,
+blocks up to 3 456 elements) that trade is a loss. On chemistry it is a win in
+both directions, because there the redirect replaces fragmented gathers of the
+12 326-element buffer with gathers of much smaller producer values and 59 of 59
+scatters disappear.
+
+The copies the scatter chain causes are all in the REVERSE, where each `ue`
+version has ~70 live consumers and copy-insertion duplicates the whole buffer
+per version. That is where removing readers pays on both halves: `ssp_vjp`
+loses 63 of its 394 whole-buffer copies and 24% of its write traffic for 1.20x,
+against a ~1.8x ceiling if every copy vanished.
+
+It is also why `ess-oop-levelbase` (one read version per level) failed where
+this succeeds: it reduced VERSIONS, which the forward already got for free,
+instead of removing READERS. Its census went 99 → 102 copies; this one goes
+98 → 82 and 394 → 331.
+
 ## What is NOT verified
 
-The `ESM_TEST_REACTANT=1` traced census (`reactant_oop_ssa_test.jl`) asserts the
-DUS delta equals `n_skipped_scatters` on the toy fixtures; the extension's arms
-are exercised there only insofar as those fixtures engage them. The ReSEACT
-timing A/B and the whole-buffer copy census live in the consuming repo
-(`tools/diag/p13_ssa_ab.jl`, `tools/diag/p11_ue_traffic.py`) because they need
-the offline forcing environment.
+Bit-identity across the arms is asserted and holds on HOST (`==`) and, on the
+toy fixtures, in the traced census (`reactant_oop_ssa_test.jl`, which pins the
+DUS delta to `n_skipped_scatters`). At CONUS the two arms are NOT bit-identical:
+changing the operand graph changes XLA's fusion, hence FMA and vectorization
+order. chemistry `ros_step` is bit-for-bit and `ros_vjp`'s λ is bit-for-bit (its
+p-gradient differs in the 20th significant figure); transport `ssp_step`
+differs by 5.6e-15 pointwise relative. The pointwise metric on the VJPs is
+uninformative — it reads exactly 2.0 on components at ~1e-310 — so the probe
+also reports a scale-relative figure and the count of components over 1e-9 of
+scale.
 
 ## Generalization assessment (honest)
 

--- a/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
+++ b/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
@@ -156,9 +156,21 @@ fold.
    repeat cells — median run length 1 — so slices+concat lose to the gather;
    would need segment-level ops instead. Left as gathers deliberately.
 4. **Scalar-walker and lane-batched scalar reads** (`_NK_STATE`,
-   `_NK_STATE_GATHER`, batch slot vectors). Redirectable through the same
-   slot→(producer, position) map; not done in the spike. They also hold
-   producer scatters alive wherever they read.
+   `_NK_STATE_GATHER`, batch slot vectors) — REDIRECTABLE, MEASURED, and NOT
+   WORTH IT. They are reachable through the same slot→(producer, position) map,
+   published per read surface as a consumer level; an implementation took
+   transport from 13/17 to 15/17 scatters skipped and `blockers.scalar` to 0.
+   It cost **4.3% on the transport reverse**: two whole-buffer copies removed
+   against ~140 copy instructions added, because these reads were already cheap
+   relative to the buffer versions they pinned, and redirecting one keeps a
+   producer value live across a level boundary instead of letting it die into
+   `ue`. Coverage is not the objective function; the copy census is.
+
+   It is also INERT under the shipped gate. `ESS_OOP_SSA_SKIP_WHOLE` skips
+   nothing unless EVERY tracked producer can go, and 15 of 17 is not 17 of 17 —
+   the scan and sub-kernel blockers below survive it. So closing #4 alone
+   changes no emitted program at the default; it would only pay as the LAST of
+   the transport blockers to fall. Do not re-attempt it on its own.
 5. ~~**Fragmented gathers**~~ (`nseg > min(64, max(8, L÷4))`) — CLOSED by tier
    2b: past the slice threshold a single-producer mapping gathers the producer's
    VALUE instead of the buffer. `frag` went 5 blocked producers → 0. A

--- a/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
+++ b/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
@@ -25,8 +25,24 @@ With the flag on, a consumer descriptor references its producer's RESULT VALUE:
 * **tier 2 (slice)** — the gather decomposes into few consecutive-position runs,
   each inside one producer ⇒ one `slice` per run (+ one `concatenate` when
   more than one run);
+* **tier 2b (producer gather)** — the mapping lies inside ONE producer but
+  shatters into more runs than slices are worth ⇒ one `gather` of that
+  producer's value at producer-local positions. Exactly the single op the dense
+  `ue` gather was, over an index vector of the same length: the win is not op
+  count, it is that the read no longer touches the flat buffer;
 * **tier 3 (fallback)** — everything else keeps the dense gather from `ue`,
   byte-for-byte.
+
+Three descriptor surfaces feed those tiers: a kernel's own top-level
+descriptors, its TEMPLATE SUB-KERNEL (`_NK_SUBCALL`) descriptors — resolved by
+`_build_oop_desc_vectors` against the same parent lanes, so decomposable by the
+same map, but indexed by `S.acc` and therefore carried in a per-sub table — and
+GHOST-MASKED `_AK_STATE_TBL_BOX` descriptors, where a masked lane's value is
+discarded by the emitter's `ifelse` select and is therefore a WILDCARD the
+decomposition fills with whatever continues a neighbouring run. Each of the
+three has a bisect knob (`ESS_OOP_SSA_SUB`, `ESS_OOP_SSA_PGATHER`,
+`ESS_OOP_SSA_GHOST`, all default ON inside `ESS_OOP_SSA=1`), which is what lets
+one process A/B an arm and what each engagement test's negative control flips.
 
 A producer's scatter into `ue` is emitted only when static accounting finds a
 residual reader of its block; otherwise it is skipped and the value flows only
@@ -88,15 +104,51 @@ XLA's optimizer converges the two programs (18 ≡ 18 ops optimized) — at scal
 that convergence is precisely what fails (pairwise slice-CSE went quadratic on
 CONUS; the buffers exceed L3), so the emission-level census is the measure.
 
-## What blocks the rest (tier-3 fallbacks, in expected ReSEACT impact order)
+## Measured on ReSEACT — and the blocker order the spike guessed is WRONG
 
-1. **Ghost-masked `_AK_STATE_TBL_BOX` gathers** (boundary stencils through slot
-   tables with 0-entries). Extension is mechanical: redirect the safe-index
-   gather to producer slices and keep the select-against-mask.
-2. **Sub-kernel (`_NK_SUBCALL`) descriptor plans.** Their tables are resolved
-   against parent lanes but indexed per-sub, so the per-kernel redirect table
-   does not align; needs per-sub redirect tables built in
-   `_build_oop_acc_plan`-style. Mechanical, not conceptual.
+The spike listed its remaining tier-3 fallbacks "in expected ReSEACT impact
+order" and put ghost-masked table gathers first. `oop_ssa_stats` now carries a
+per-reason blocker tally (which read surface still reads each surviving
+producer's block), and on the ReSEACT transport RHS at 6x6x8 it says:
+
+| | spike | + this extension |
+|---|---|---|
+| top-level edges redirected | 51 / 100 | **97 / 100** |
+| top-level elements | 5 292 / 32 148 | **24 948 / 32 148** |
+| SUB-KERNEL descriptors redirected | 0 / 885 | **731 / 885** |
+| sub-kernel elements | 0 / 1 074 487 | **896 863 / 1 074 487** |
+| producer scatters skipped | 6 / 17 | **13 / 17** |
+| blocked producers, by reason | sub 9, frag 5, scalar 2, scan 1 | sub 2, scalar 2, scan 1 |
+| … blocked SOLELY by that reason | sub 4, frag 1 | scalar 2, sub 1 |
+
+Two things in that table refute the spike's ordering:
+
+* **there are ZERO ghost-masked descriptors in this build** (`n_ghost_edges = 0`
+  at both 6x6x8 and on split part 2), and none at all in any of the 1-D host
+  fixtures — so blocker #1, the one the note called the primary target, has no
+  coverage to give here. It is implemented anyway (it is cheap and it is
+  correct), and the unit tests cover it directly, but it is not what was
+  holding the scatters.
+* **the sub-kernel descriptors are the read surface that matters**: 885 of the
+  985 candidate descriptors and 1 074 487 of the 1 106 635 candidate READ
+  ELEMENTS — 33x the top-level edges' volume — and they held 9 of the 11
+  surviving producer scatters alive. Blocker #2, listed second and described as
+  "mechanical, not conceptual", was the whole game.
+
+E-lane CSR gathers (#3) and `_AK_STATE_FIXED` pins are likewise 0 here. What is
+left is blocker #4 (scalar-walker reads: 2 producers, and BOTH of them are
+blocked by nothing else) plus one sub-kernel descriptor group and one level scan
+fold.
+
+## What blocks the rest (tier-3 fallbacks, in the order the spike GUESSED)
+
+1. ~~**Ghost-masked `_AK_STATE_TBL_BOX` gathers**~~ — CLOSED (`_ssa_lane_owners`'
+   wildcard fill), and measured at ZERO coverage on ReSEACT: no build in this
+   corpus emits one. Kept because it is correct and free.
+2. ~~**Sub-kernel (`_NK_SUBCALL`) descriptor plans**~~ — CLOSED (per-sub tables
+   on `_OopSSAKernel.subs`, `_oop_ssa_subctx` at the `_NK_SUBCALL` arm). This
+   was the real blocker: 731/885 descriptors and 896 863 read elements
+   redirected, 7 more producer scatters skipped.
 3. **E-lane (in-reduce) CSR gathers.** Per-entry `(cell, neighbour)` reads
    repeat cells — median run length 1 — so slices+concat lose to the gather;
    would need segment-level ops instead. Left as gathers deliberately.
@@ -104,8 +156,10 @@ CONUS; the buffers exceed L3), so the emission-level census is the measure.
    `_NK_STATE_GATHER`, batch slot vectors). Redirectable through the same
    slot→(producer, position) map; not done in the spike. They also hold
    producer scatters alive wherever they read.
-5. **Fragmented gathers** (`nseg > max(8, L÷4)`): kept dense by the
-   worthwhileness threshold; they also keep their producers' scatters.
+5. ~~**Fragmented gathers**~~ (`nseg > min(64, max(8, L÷4))`) — CLOSED by tier
+   2b: past the slice threshold a single-producer mapping gathers the producer's
+   VALUE instead of the buffer. `frag` went 5 blocked producers → 0. A
+   fragmented MULTI-producer mapping has no one-op form and still falls back.
 6. **Per-cell fallback kernels** disable scatter-skipping globally (reads
    un-enumerable). Rare on affine builds.
 
@@ -125,6 +179,15 @@ CONUS; the buffers exceed L3), so the emission-level census is the measure.
 * Live forcing (`param_arrays`/`rhs_with_buffers`) rides through unchanged —
   forcing reads go through the buffers argument, never `ue` — and the
   discrete-cadence refresh stays visible with fill scatters skipped (probed).
+
+## What is NOT verified
+
+The `ESM_TEST_REACTANT=1` traced census (`reactant_oop_ssa_test.jl`) asserts the
+DUS delta equals `n_skipped_scatters` on the toy fixtures; the extension's arms
+are exercised there only insofar as those fixtures engage them. The ReSEACT
+timing A/B and the whole-buffer copy census live in the consuming repo
+(`tools/diag/p13_ssa_ab.jl`, `tools/diag/p11_ue_traffic.py`) because they need
+the offline forcing environment.
 
 ## Generalization assessment (honest)
 

--- a/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
+++ b/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
@@ -82,7 +82,10 @@ vectorizable kernels (ghost-masked ones excluded and counted as fallback).
 | merged class (g1,g2 → one kernel, N=6) | 3/3 | 24/24 | 1/1 | member reads = slices at offsets inside ONE producer value |
 | reaction–diffusion, no observeds (N=16) | 7/7 | 46/46 | 0/0 | prefix reads become slices of `u` |
 
-Whole host corpus green with the flag FORCED on: tree_walk_oop (164),
+Full suite (`Pkg.test()`, `ESM_TEST_REACTANT=1`) at 4x5-era main: flag OFF
+89 034 pass / 8 broken / 89 042; forced ON 89 029 pass / 5 fail / 8 broken, the
+5 being exactly `reactant_oop_intern_test.jl`'s interning-ENGAGEMENT assertions
+(see Interactions below). Whole host corpus green with the flag FORCED on: tree_walk_oop (164),
 oop_merge (75), array_obs_materialize (78), scan_prefix (333),
 oop_scalar_batch (42), observed_materialization (20), observed_slots (36),
 iip_generic — all bit-identical to `f!` — and green with the flag OFF
@@ -226,12 +229,13 @@ Bit-identity across the arms is asserted and holds on HOST (`==`) and, on the
 toy fixtures, in the traced census (`reactant_oop_ssa_test.jl`, which pins the
 DUS delta to `n_skipped_scatters`). At CONUS the two arms are NOT bit-identical:
 changing the operand graph changes XLA's fusion, hence FMA and vectorization
-order. chemistry `ros_step` is bit-for-bit and `ros_vjp`'s λ is bit-for-bit (its
-p-gradient differs in the 20th significant figure); transport `ssp_step`
-differs by 5.6e-15 pointwise relative. The pointwise metric on the VJPs is
-uninformative — it reads exactly 2.0 on components at ~1e-310 — so the probe
-also reports a scale-relative figure and the count of components over 1e-9 of
-scale.
+order. chemistry `ros_step` is bit-for-bit and `ros_vjp`'s λ is bit-for-bit; on
+transport the largest ABSOLUTE difference is 5.6e-15 on `ssp_step` (1.1e-18 of
+scale) and 3.5e-18 on `ssp_vjp`'s λ (3.2e-16 of scale), and NOT ONE of the
+85 176 state or λ components in any program differs by more than 1e-9 of that
+quantity's own scale. The POINTWISE relative metric is uninformative here — it
+reads exactly 2.0 on an opposite-signed component at ~1e-310 — which is why the
+probe reports absolute and scale-relative figures plus a component count.
 
 ## Generalization assessment (honest)
 

--- a/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
+++ b/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
@@ -279,6 +279,76 @@ read-graph fact) is identical in every arm and only `n_skipped_scatters` moves;
 chemistry exactly as the arms had it (59 of 59, `ue` dead) and takes transport
 to 0 of 17 — the redirects without the skip.
 
+### Measured: the gate wins on BOTH sides
+
+4x5 CONUS (13x7x72, 6 552 cells), three arms in ONE process, interleaved, both
+arm orders (`tools/diag/p14_ssa_gate.jl` in the consuming repo). `noskip` is
+what the default gate emits on transport (0 of 17) and `ungated` is #283
+(13 of 17); on chemistry the gate emits `ungated` unchanged, so the chemistry
+row is #283's.
+
+| program | flag off | gate (= `noskip`) | #283 (= `ungated`) |
+|---|---|---|---|
+| `ssp_step` | 14.668 ms | 19.887 ms (**0.738**) | 21.310 ms (0.688) |
+| `rhs` | 4.127 ms | 4.938 ms (**0.836**) | 6.523 ms (0.633) |
+| `ssp_vjp` | 360.279 ms | 251.832 ms (**1.431**) | (1.203) |
+| `ssp_vjp`, arms reversed | 347.620 ms | 254.526 ms (**1.366**) | |
+| `ros_step` (chemistry) | | 1.38 | 1.38 |
+| `ros_vjp` (chemistry) | | 1.43 | 1.43 |
+
+The gate roughly HALVES the transport primal regression (0.688 -> 0.738 on the
+4-stage step, 0.633 -> 0.836 on the bare RHS) and, unexpectedly, IMPROVES the
+transport VJP from #283's 1.203 to 1.37-1.43: the redirects pay better once a
+partial skip is not working against them. Chemistry is untouched — the gate
+leaves that build structurally identical (59 of 59, `n_gate_declined = 0`).
+
+**The falsifiable test of the explanation.** "A partial skip pays twice" and
+"one big producer is the problem" both predict the transport regression; they
+differ on what removing ONE producer does. `ESS_OOP_SSA_SKIP_PIDS=!17` drops
+the skip of the 3 456-element producer (78 624 at CONUS, the largest by 15x)
+and keeps the other twelve:
+
+| `ssp_step` | flag off | #283 (13 of 17) | `!17` (12 of 17) |
+|---|---|---|---|
+| | 14.433 ms | 24.397 ms (0.592) | 24.768 ms (**0.583**) |
+
+`no17` is not better than `ungated`. Size is not what makes a skip expensive;
+PARTIALNESS is. That is why the gate is all-or-nothing and why the two
+per-producer bounds ship released.
+
+### The loop, counting replay
+
+Per accepted step the adjoint runs the primal TWICE — the forward `T.step` and
+the backward `T.replay` — and the VJP once, so a primal regression is paid
+twice against one VJP win. Against the measured 2x2.5 48 h decomposition
+(576 windows, transport step+replay 427 s and vjp 2 048 s):
+
+| term | flag off | #283 | + this gate |
+|---|---|---|---|
+| chemistry (step + replay + vjp) | 5 106 s | 3 633 s | 3 633 s |
+| transport (step + replay + vjp) | 2 475 s | 2 411 s | **1 995 s** |
+| refresh | 1 792 s | 1 792 s | 1 792 s |
+| host remainder | 123 s | 123 s | 123 s |
+| **loop** | **9 495 s** | 7 959 s (1.19x) | **7 543 s (1.26x)** |
+
+Transport was a WASH under #283 — the 1.20x VJP win almost exactly cancelled
+the doubled primal regression, so the whole 1.19x was chemistry. With the gate
+transport is a real 1.24x and the loop moves 1.19x -> 1.26x. The break-even for
+the gate is `ssp_vjp >= 1.032`; it delivers ~1.40, so the trade is net-positive
+by a wide margin rather than marginally. (Predicted 1.257x from the break-even
+arithmetic before measuring; measured 1.26x.)
+
+### The criterion NOT met, and further work
+
+The target for the gate was the transport primal back to >= 0.95 of flag-off.
+It is **0.738** on `ssp_step` and 0.836 on `rhs`. The gate halves the
+regression; it does not remove it. With ZERO scatters skipped the only
+difference from flag-off is the redirects themselves, so something on the
+transport primal still materializes that the flat-buffer gather did not — the
+producer values that the sub-kernel and tier-2b redirects now read from. That
+is the next thing to measure (a per-arm redirect gate would price it), and it
+is a separate decision from the skip.
+
 ## What is NOT verified
 
 Bit-identity across the arms is asserted and holds on HOST (`==`) and, on the

--- a/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
+++ b/pkg/EarthSciAST.jl/src/tree_walk/SSA_SPIKE.md
@@ -223,6 +223,62 @@ this succeeds: it reduced VERSIONS, which the forward already got for free,
 instead of removing READERS. Its census went 99 → 102 copies; this one goes
 98 → 82 and 394 → 331.
 
+## The scatter-skip GATE: redundant is not the same as expensive
+
+The verdict above is STATIC — "nothing reads this producer's block off `ue` any
+more, so the scatter is redundant". It says nothing about COST, and the CONUS
+table is the counter-example: the transport forward is 1.8x SLOWER with more
+scatters skipped. So the skip is now gated, and finding the gate meant
+instrumenting first. `oop_ssa_producers(f)` reports, per tracked producer, its
+fill level, value length, how many redirected read surfaces now source from it
+and at what element volume, how many of those take the whole value with no op
+at all, the residual-read reasons, and both verdicts (`skippable`, `skip`).
+
+**PRODUCER BLOCK SIZE — the obvious guess — is refuted by that table.** At
+6x6x8:
+
+| | transport (part 1) | chemistry (part 2) |
+|---|---|---|
+| producers | 17 | 59 |
+| statically skippable | 13 | **59 — all of them** |
+| skippable element volume | 4 874 of 8 042 | 53 964 of 53 964 |
+| largest skipped block | 3 456 | **20 736** (then 10 368, 5 184) |
+| redirected read volume / block | 0.125 … 58 230 | 1.0 … 198 |
+| tier-1 (whole-value) reads | 4 producers, 1 each | 30+ producers, up to 87 |
+
+Chemistry skips producers 6x larger than transport's largest and WINS, so no
+size bound separates the two. Nor does the read-volume ratio: transport spans
+both extremes of it.
+
+What actually differs is **whether the flat buffer can DIE**. Chemistry skips
+59 of 59, so nothing scatters into `ue` at all and the whole 12 326-element
+buffer (247 423 at CONUS) is dead code. Transport skips 13 of 17, so `ue` is
+assembled anyway — and a PARTIAL skip is the worst of both worlds: the flat
+buffer is still allocated and still written by the four surviving producers,
+AND each skipped producer's value becomes a buffer of its own instead of being
+fused into an aliasing `dynamic_update_slice`. The forward pays for both.
+
+So the gate is ALL-OR-NOTHING per build:
+
+```
+ESS_OOP_SSA_SKIP_WHOLE=1   (default) skip only when EVERY tracked producer's
+                           scatter can go, so `ue` actually retires
+ESS_OOP_SSA_SKIP_WHOLE=0   allow partial skipping (what the arms shipped with)
+ESS_OOP_SSA_SKIP=0         never skip -- the negative control for the gate
+ESS_OOP_SSA_SKIP_MAXLEN=n  per-producer block-size bound   (both RELEASED by
+ESS_OOP_SSA_SKIP_MINRATIO=x per-producer read-volume bound   default: they are
+                           the refuted hypotheses, kept bisectable)
+ESS_OOP_SSA_SKIP_PIDS=3,7  per-producer bisect; `!3,7` inverts
+```
+
+Declining a skip is always CORRECT — it emits a write nothing reads, exactly
+what the flag-off build does — and the gate touches only whether the scatter is
+emitted. The redirect tables are untouched, so `n_skippable_scatters` (a
+read-graph fact) is identical in every arm and only `n_skipped_scatters` moves;
+`n_gate_declined` is the difference. On ReSEACT the default gate leaves
+chemistry exactly as the arms had it (59 of 59, `ue` dead) and takes transport
+to 0 of 17 — the redirects without the skip.
+
 ## What is NOT verified
 
 Bit-identity across the arms is asserted and holds on HOST (`==`) and, on the

--- a/pkg/EarthSciAST.jl/src/tree_walk/oop.jl
+++ b/pkg/EarthSciAST.jl/src/tree_walk/oop.jl
@@ -2939,9 +2939,9 @@ _oop_ssa_pgather_enabled() = get(ENV, "ESS_OOP_SSA_PGATHER", "1") != "0"
 #                                 volume is >= x times its own block size
 #                                 (`0` ⇒ no bound)
 #
-# Both bounds default to the measured gate; `ESS_OOP_SSA_SKIP_GATE=0` restores
-# the ungated behaviour (every statically skippable scatter skipped), which is
-# what #283 shipped and what the engagement tests A/B against.
+# `ESS_OOP_SSA_SKIP_GATE=0` releases both bounds AND the whole-buffer gate
+# together, so every statically skippable scatter is skipped -- the ungated
+# behaviour the engagement tests A/B against.
 _oop_ssa_skip_enabled() = get(ENV, "ESS_OOP_SSA_SKIP", "1") != "0"
 _oop_ssa_skip_gated()   = get(ENV, "ESS_OOP_SSA_SKIP_GATE", "1") != "0"
 # Both PER-PRODUCER bounds are released by default: the measured

--- a/pkg/EarthSciAST.jl/src/tree_walk/oop.jl
+++ b/pkg/EarthSciAST.jl/src/tree_walk/oop.jl
@@ -2375,14 +2375,22 @@ const _OOP_NO_SUB = _OopSubRT(_AccKernel[], _OopAccPlan[], Vector{Any}[], Vector
 # reads part of it — and the scatter into `ue` is emitted only where something
 # genuinely still reads the flat buffer.
 #
-# THREE TIERS, decided per consumer DESCRIPTOR at build time:
+# FOUR TIERS, decided per consumer DESCRIPTOR at build time:
 #   1. direct: the gather is one producer's entire block ⇒ the producer's SSA
 #      value, no op at all;
 #   2. slice: the gather decomposes into few consecutive-position runs, each
 #      inside one producer ⇒ per-run slices (+ one concatenate when > 1);
-#   3. fallback: anything else — non-affine tables, ghost-masked gathers,
-#      E-lane (in-reduce) and sub-kernel reads, scalar-walker reads — keeps the
+#   2b. producer gather: too fragmented for slices but inside ONE producer ⇒
+#      one gather of that producer's VALUE at producer-local positions — the
+#      same single op, off the value rather than the flat buffer;
+#   3. fallback: anything else — multi-producer fragmented mappings, unowned
+#      slots, E-lane (in-reduce) reads, scalar-walker reads — keeps the
 #      existing dense gather from `ue`, byte-for-byte.
+#
+# THREE DESCRIPTOR SURFACES feed those tiers: a kernel's own descriptors, its
+# TEMPLATE SUB-KERNEL descriptors (same parent lanes, own `S.acc` table — see
+# `_OopSSAKernel.subs`), and GHOST-MASKED table gathers, whose masked lanes are
+# wildcards because the emitter's select discards them.
 #
 # SOUNDNESS RESTS ON THREE STATIC FACTS, all established by the existing build:
 #   * a fill level reads the state and STRICTLY LOWER levels only (the
@@ -2395,9 +2403,11 @@ const _OOP_NO_SUB = _OopSubRT(_AccKernel[], _OopAccPlan[], Vector{Any}[], Vector
 #     that would observe the wrong write;
 #   * a producer's scatter into `ue` is skipped ONLY when static accounting
 #     shows every read of its block was redirected — every non-redirected read
-#     surface (scalar `_Node` walks, E-lane/sub-kernel plans, `_AK_STATE_FIXED`
-#     pins, ghost gathers, level scan folds, declined descriptors) marks its
-#     slots as residual, and ANY per-cell (non-vectorizable) kernel disables
+#     surface (scalar `_Node` walks, E-lane plans, `_AK_STATE_FIXED` pins,
+#     level scan folds, declined descriptors — sub-kernel and ghost-masked
+#     plans only where THEY decline) marks its slots as residual, and reduces
+#     per producer into the blocker tally `oop_ssa_stats` reports; ANY per-cell
+#     (non-vectorizable) kernel disables
 #     skipping wholesale, because its reads cannot be enumerated.
 #
 # BIT-IDENTITY. A redirected read returns the exact array the scatter would
@@ -2418,39 +2428,90 @@ struct _OopSSASeg
     len::Int     # run length
 end
 
+# ONE consumer descriptor's redirect. Exactly one form is populated:
+#
+#   * `segs` non-empty — consecutive-position RUNS: the producer's whole value
+#     (tier 1, no op at all) or one slice per run plus a concatenate (tier 2);
+#   * `pid != 0` — ONE producer, arbitrary positions: a single gather of that
+#     producer's VALUE at `pos` (tier 2b). This is the same single op the dense
+#     `ue` gather was, over an index vector of the same length — the win is not
+#     op count, it is that the read no longer touches the flat buffer, so the
+#     producer's scatter into it can go. It is what a FRAGMENTED mapping (one
+#     that shatters into more runs than slices are worth) takes instead of the
+#     fallback.
+#
+# Both empty ⇒ the descriptor keeps the dense `ue` gather (tier 3).
+struct _OopSSARef
+    segs::Vector{_OopSSASeg}
+    pid::Int
+    pos::Vector{Int}
+end
+const _OOP_SSA_NOREF = _OopSSARef(_OopSSASeg[], 0, Int[])
+
 # Per-kernel build-time SSA role: its producer id (0 ⇒ untracked), whether its
 # scatter into `ue` may be skipped (valid only when the runtime result is a
-# lane vector of the planned length), and the per-descriptor redirect table
-# (aligned with `K.acc`; an empty entry keeps the gather path).
+# lane vector of the planned length), the per-descriptor redirect table
+# (aligned with `K.acc`; a `_OOP_SSA_NOREF` entry keeps the gather path), and
+# the same table for each TEMPLATE SUB-KERNEL, aligned with `plan.subs`.
+#
+# The sub tables are sound for the same reason the parent's are: a sub-kernel is
+# evaluated at the PARENT's lanes and `_build_oop_desc_vectors` resolves its
+# descriptors against that same lane enumeration, so its gather index vectors
+# are slot vectors into `ue` exactly like the parent's, decomposable by exactly
+# the same map. Only the TABLE differs (`S.acc`, not `K.acc`), which is why the
+# spike could not reuse the parent's.
 struct _OopSSAKernel
     pid::Int
     skip::Bool
-    desc::Vector{Vector{_OopSSASeg}}
+    desc::Vector{_OopSSARef}
+    subs::Vector{Vector{_OopSSARef}}
 end
-const _OOP_SSA_KERNEL_OFF = _OopSSAKernel(0, false, Vector{_OopSSASeg}[])
+const _OOP_SSA_NO_SUBDESC = Vector{_OopSSARef}[]
+const _OOP_SSA_KERNEL_OFF = _OopSSAKernel(0, false, _OopSSARef[], _OOP_SSA_NO_SUBDESC)
 const _OOP_SSA_EMPTY_KS = _OopSSAKernel[]
 const _OOP_SSA_NO_VALS = Any[]
 
-# The walk-time context: the CURRENT kernel's redirect table plus this call's
-# producer values. Downgraded to the OFF singleton on entering a `_NK_SUBCALL`
-# or `_NK_REDUCE` body, whose descriptor plans index a different lane space
-# than the table was computed against.
+# The walk-time context: the CURRENT descriptor table, this call's producer
+# values, and the parent kernel's per-sub tables (carried through unchanged, so
+# a NESTED `_NK_SUBCALL` — which resolves against the same flat `plan.subs`
+# list — keeps working). Downgraded to the OFF singleton on entering a
+# `_NK_REDUCE` body, whose E-lane plan indexes per ENTRY rather than per lane.
 struct _OopSSACtx
-    desc::Vector{Vector{_OopSSASeg}}
+    desc::Vector{_OopSSARef}
     vals::Vector{Any}
+    subs::Vector{Vector{_OopSSARef}}
 end
-const _OOP_SSA_CTX_OFF = _OopSSACtx(Vector{_OopSSASeg}[], _OOP_SSA_NO_VALS)
+const _OOP_SSA_CTX_OFF = _OopSSACtx(_OopSSARef[], _OOP_SSA_NO_VALS, _OOP_SSA_NO_SUBDESC)
 
 @inline _oop_ssa_k(ks::Vector{_OopSSAKernel}, j::Int) =
     isempty(ks) ? _OOP_SSA_KERNEL_OFF : @inbounds ks[j]
 
+@inline _oop_ssa_ctx(ssak::_OopSSAKernel, vals::Vector{Any}) =
+    (isempty(ssak.desc) && isempty(ssak.subs)) ? _OOP_SSA_CTX_OFF :
+    _OopSSACtx(ssak.desc, vals, ssak.subs)
+
+# The context for sub-kernel `j` of the kernel this context belongs to.
+@inline function _oop_ssa_subctx(ssa::_OopSSACtx, j::Int)
+    sv = ssa.subs
+    (isempty(sv) || j > length(sv)) && return _OOP_SSA_CTX_OFF
+    d = @inbounds sv[j]
+    isempty(d) && return _OOP_SSA_CTX_OFF
+    return _OopSSACtx(d, ssa.vals, sv)
+end
+
 # Resolve one redirected descriptor to a producer-value reference, or `nothing`
-# to take the gather fallback (redirect table empty, or a referenced producer
-# recorded no lane vector this call).
-@inline function _oop_ssa_ref(ssa::_OopSSACtx, i::Int)
+# to take the gather fallback (no redirect, or a referenced producer recorded no
+# lane vector this call).
+@inline function _oop_ssa_ref(ssa::_OopSSACtx, i::Int, memo)
     d = ssa.desc
     isempty(d) && return nothing
-    segs = @inbounds d[i]
+    r = @inbounds d[i]
+    if r.pid != 0
+        v = @inbounds ssa.vals[r.pid]
+        v isa AbstractArray || return nothing
+        return _oop_gather(v, r.pos, memo)               # tier 2b
+    end
+    segs = r.segs
     isempty(segs) && return nothing
     return _oop_ssa_resolve(ssa.vals, segs)
 end
@@ -2496,17 +2557,20 @@ function _oop_eval_acck(nd::_Node, u, p, t, K::_AccKernel, plan::_OopAccPlan,
             # (`_AK_CONST_EDGE` falls through to the frozen-consts arm below.)
             # An SSA-redirected descriptor (ess-oop-ssa) references its producer's
             # value instead of gathering the flat buffer; `nothing` ⇒ gather.
-            v = _oop_ssa_ref(ssa, nd.idx)
+            v = _oop_ssa_ref(ssa, nd.idx, fb.memo)
             v === nothing || return v
             return _oop_gather(u, plan.gathers[nd.idx], fb.memo)
         elseif ak === _AK_STATE_TBL_BOX
             m = plan.ghost[nd.idx]
-            if isempty(m)
-                # Ghost-free table gathers are ordinary reads and may redirect;
-                # a ghost-bearing one keeps the gather+select path (its safe-index
-                # lanes read a slot the redirect analysis never modeled).
-                v = _oop_ssa_ref(ssa, nd.idx)
-                v === nothing || return v
+            # A redirected descriptor (ess-oop-ssa) references its producer's
+            # value instead of gathering the flat buffer. A GHOST-BEARING one
+            # redirects too (`_ssa_lane_owners`): its concrete lanes carry the
+            # producer positions the gather would have read, its masked lanes
+            # carry placeholders, and the select below overwrites exactly those
+            # with 0.0 — so the result is the gather's, element for element.
+            v = _oop_ssa_ref(ssa, nd.idx, fb.memo)
+            if v !== nothing
+                return isempty(m) ? v : ifelse.(m, zero(T), v)
             end
             g = _oop_gather(u, plan.gathers[nd.idx], fb.memo)
             # ghost lanes (table slot 0) select 0.0 — the in-place runners'
@@ -2551,11 +2615,16 @@ function _oop_eval_acck(nd::_Node, u, p, t, K::_AccKernel, plan::_OopAccPlan,
         Sp = @inbounds sub.plans[j]
         iv = @inbounds sub.invvals[j]
         cv = @inbounds sub.cellvals[j]
+        # The sub's OWN redirect table (ess-oop-ssa): its descriptors were
+        # resolved against these same parent lanes, so they decompose by the
+        # same slot→(producer, position) map — but they index `S.acc`, which is
+        # why the table cannot be the parent's.
+        ssaS = _oop_ssa_subctx(ssa, j)
         rs = S.cse.recipes
         @inbounds for i in eachindex(rs)
-            cv[i] = _oop_eval_acck(rs[i], u, p, t, S, Sp, iv, cv, sub, fb, T)
+            cv[i] = _oop_eval_acck(rs[i], u, p, t, S, Sp, iv, cv, sub, fb, T, ssaS)
         end
-        return _oop_eval_acck(S.spine, u, p, t, S, Sp, iv, cv, sub, fb, T)
+        return _oop_eval_acck(S.spine, u, p, t, S, Sp, iv, cv, sub, fb, T, ssaS)
     elseif k === _NK_REDUCE
         # Variable-valence sum reduction, CSR-segmented (gordian reduce-vectorize):
         # evaluate the body ONCE over the flat E-lane buffer (its only state access
@@ -2671,15 +2740,16 @@ function _oop_run_acc_vec(du, u, p, t, K::_AccKernel, plan::_OopAccPlan,
                           ::Type{T}, fb::_OopForcing=_OOP_NO_FORCING,
                           ssak::_OopSSAKernel=_OOP_SSA_KERNEL_OFF,
                           vals::Vector{Any}=_OOP_SSA_NO_VALS) where {T}
-    ssa = isempty(ssak.desc) ? _OOP_SSA_CTX_OFF : _OopSSACtx(ssak.desc, vals)
+    ssa = _oop_ssa_ctx(ssak, vals)
     sub = _oop_build_subrt(plan)
     for j in eachindex(sub.subs)
         S = @inbounds sub.subs[j]
         Sp = @inbounds sub.plans[j]
         iv = @inbounds sub.invvals[j]; cv = @inbounds sub.cellvals[j]
+        ssaS = _oop_ssa_subctx(ssa, j)
         ir = S.cse.inv_recipes
         @inbounds for i in eachindex(ir)
-            iv[i] = _oop_eval_acck(ir[i], u, p, t, S, Sp, iv, cv, sub, fb, T)
+            iv[i] = _oop_eval_acck(ir[i], u, p, t, S, Sp, iv, cv, sub, fb, T, ssaS)
         end
     end
     cse = K.cse
@@ -2834,10 +2904,45 @@ end
 
 _oop_ssa_enabled() = get(ENV, "ESS_OOP_SSA", "") == "1"
 
+# Bisect knobs for the three redirect arms added after the spike, all riding
+# inside `ESS_OOP_SSA=1` and all default ON. Setting one to 0 declines exactly
+# that arm while KEEPING the per-blocker attribution below, so one process can
+# A/B an arm without a second checkout — which is how the arms were measured
+# (setup wall on this filesystem is not a usable metric) — and so the test file
+# has a negative control for each.
+#
+#   ESS_OOP_SSA_GHOST=0     ghost-masked `_AK_STATE_TBL_BOX` descriptors
+#                           (`_ssa_lane_owners`' wildcard fill)
+#   ESS_OOP_SSA_SUB=0       template sub-kernel (`_NK_SUBCALL`) descriptor tables
+#   ESS_OOP_SSA_PGATHER=0   tier 2b, the single-producer value gather
+_oop_ssa_ghost_enabled()   = get(ENV, "ESS_OOP_SSA_GHOST", "1") != "0"
+_oop_ssa_sub_enabled()     = get(ENV, "ESS_OOP_SSA_SUB", "1") != "0"
+_oop_ssa_pgather_enabled() = get(ENV, "ESS_OOP_SSA_PGATHER", "1") != "0"
+
+# WHY a residual `ue` read exists, one bit per read surface, carried per slot in
+# the analysis' `resid` map and reduced per producer into the blocker tally
+# `oop_ssa_stats` reports. The tally is the campaign's steering instrument: a
+# producer's scatter survives because SOME surface still reads its block, and
+# only the per-reason breakdown says which extension would free it.
+const _SSA_R_SCALAR = 0x01   # scalar-walker read (`_NK_STATE`/`_NK_STATE_GATHER`)
+const _SSA_R_SCAN   = 0x02   # a fill level's scan fold reads its own slots back
+const _SSA_R_FIXED  = 0x04   # `_AK_STATE_FIXED` descriptor pin
+const _SSA_R_GHOST  = 0x08   # ghost-masked table gather kept dense
+const _SSA_R_DENSE  = 0x10   # descriptor whose gather did not decompose
+const _SSA_R_FRAG   = 0x20   # decomposed, but too fragmented to be worthwhile
+const _SSA_R_SUB    = 0x40   # sub-kernel (`_NK_SUBCALL`) descriptor plan gather
+const _SSA_R_ELANE  = 0x80   # E-lane (in-reduce) CSR plan gather
+const _SSA_R_NAMES = (:scalar, :scan, :fixed, :ghost, :dense, :frag, :sub, :elane)
+const _SSA_R_BITS = (_SSA_R_SCALAR, _SSA_R_SCAN, _SSA_R_FIXED, _SSA_R_GHOST,
+                     _SSA_R_DENSE, _SSA_R_FRAG, _SSA_R_SUB, _SSA_R_ELANE)
+
 # Redirect coverage + accounting for one build, kept on the closure for
 # reflection (`oop_ssa_stats`). "Edges" are the redirect CANDIDATES: top-level
-# cell-lane state-gather descriptors of vectorizable kernels (ghost-masked ones
-# excluded); an edge is "fast" when it was redirected to producer values.
+# cell-lane state-gather descriptors of vectorizable kernels; an edge is "fast"
+# when it was redirected to producer values. GHOST-MASKED descriptors are
+# counted in their OWN pair of columns (`n_gedges`/`n_gfast`), not in
+# `n_edges`/`n_fast`, so the plain-edge coverage number stays comparable across
+# the feature's revisions.
 struct _OopSSAStats
     n_edges::Int
     n_fast::Int
@@ -2847,7 +2952,18 @@ struct _OopSSAStats
     n_skip::Int           # producers whose `ue` scatter is statically skippable
     elems_skip::Int       # Σ out_slots lengths over skippable producers
     dynamic::Bool         # a per-cell kernel exists ⇒ no scatter may be skipped
+    n_gedges::Int         # ghost-masked candidate descriptors
+    n_gfast::Int          # … of which redirected to producer values + select
+    elems_gedges::Int
+    elems_gfast::Int
+    n_sedges::Int         # TEMPLATE SUB-KERNEL candidate descriptors
+    n_sfast::Int          # … of which redirected
+    elems_sedges::Int
+    elems_sfast::Int
+    blk::NTuple{8,Int}      # producers whose residual set includes reason k
+    blk_only::NTuple{8,Int} # … producers blocked SOLELY by reason k
 end
+const _SSA_BLK0 = ntuple(_ -> 0, 8)
 
 struct _OopSSAPlan
     enabled::Bool
@@ -2857,20 +2973,22 @@ struct _OopSSAPlan
     stats::_OopSSAStats
 end
 const _OOP_SSA_OFF = _OopSSAPlan(false, 0, Vector{_OopSSAKernel}[], _OopSSAKernel[],
-                                 _OopSSAStats(0, 0, 0, 0, 0, 0, 0, false))
+                                 _OopSSAStats(0, 0, 0, 0, 0, 0, 0, false,
+                                              0, 0, 0, 0, 0, 0, 0, 0,
+                                              _SSA_BLK0, _SSA_BLK0))
 
 # Residual `ue` reads of the scalar walkers: `_NK_STATE` pins one slot,
 # `_NK_STATE_GATHER` may read any slot in its table (its subscripts are
 # runtime loop counters). Everything else that reads the state does so through
 # an access-kernel plan, which the caller accounts separately.
-function _ssa_mark_node_reads!(resid::BitVector, n::_Node)
+function _ssa_mark_node_reads!(resid::Vector{UInt8}, n::_Node)
     k = n.kind
     if k === _NK_STATE
-        1 <= n.idx <= length(resid) && (resid[n.idx] = true)
+        1 <= n.idx <= length(resid) && (resid[n.idx] |= _SSA_R_SCALAR)
     elseif k === _NK_STATE_GATHER
         sg = n.payload::_StateGather
         for s in sg.slot_flat
-            1 <= s <= length(resid) && (resid[s] = true)
+            1 <= s <= length(resid) && (resid[s] |= _SSA_R_SCALAR)
         end
     end
     for c in n.children
@@ -2879,50 +2997,115 @@ function _ssa_mark_node_reads!(resid::BitVector, n::_Node)
     return nothing
 end
 
-# Decompose one gather-index vector into consecutive-position runs over the
-# slot-ownership maps, or `nothing` when any element is unowned or its producer
-# does not strictly precede the consumer (`cons_level`).
-function _ssa_decompose(g::Vector{Int}, own_pid::Vector{Int32}, own_pos::Vector{Int32},
-                        prod_level::Vector{Int}, cons_level::Int)
-    segs = _OopSSASeg[]
-    i = 1
+# Resolve one gather-index vector to per-lane (producer, position) ownership, or
+# `nothing` when any lane is unowned or its producer does not strictly precede
+# the consumer (`cons_level`).
+#
+# `m` is the descriptor's GHOST mask (empty ⇒ none). A ghost-bearing
+# `_AK_STATE_TBL_BOX` is a BOUNDARY STENCIL: the in-place runners read
+# `s == 0 ? 0.0 : u[s]`, and the vectorized emitter reproduces that as one
+# gather at a SAFE index (slot 1 substituted for every ghost) followed by
+# `ifelse.(mask, 0, ·)`. Run decomposition over the substituted vector is
+# hopeless — the 1s shatter every run — but a masked lane's value is DISCARDED
+# by that select, so it is a WILDCARD here: fill it with whatever (producer,
+# position) CONTINUES a neighbouring run, forward from a resolved left neighbour
+# first, then backward from a resolved right one, and only fall back to a
+# placeholder when neither exists. A one-sided stencil at the grid edge then
+# collapses to a SINGLE slice of its producer, with the select the op it was.
+#
+# `prod_len[pid]` is the producer's value length (entry 1 = `n_states`, the raw
+# state), bounding the positions a filler may invent.
+function _ssa_lane_owners(g::Vector{Int}, m::Vector{Bool},
+                          own_pid::Vector{Int32}, own_pos::Vector{Int32},
+                          prod_level::Vector{Int}, prod_len::Vector{Int},
+                          cons_level::Int)
     L = length(g)
     n = length(own_pid)
-    while i <= L
-        s = g[i]
-        (1 <= s <= n) || return nothing
-        pid = Int(@inbounds own_pid[s])
+    masked = !isempty(m)
+    masked && length(m) != L && return nothing
+    pid_l = zeros(Int, L)               # 0 ⇒ unresolved (a masked lane, so far)
+    pos_l = zeros(Int, L)
+    nconc = 0
+    @inbounds for l in 1:L
+        masked && m[l] && continue
+        sl = g[l]
+        (1 <= sl <= n) || return nothing
+        pid = Int(own_pid[sl])
         pid == 0 && return nothing
-        @inbounds prod_level[pid] < cons_level || return nothing
-        lo = Int(@inbounds own_pos[s])
+        prod_level[pid] < cons_level || return nothing
+        pid_l[l] = pid
+        pos_l[l] = Int(own_pos[sl])
+        nconc += 1
+    end
+    # An ALL-ghost descriptor is a constant zero vector; that is a different
+    # (and much rarer) rewrite, so decline it here rather than model it.
+    nconc == 0 && return nothing
+    if masked && nconc < L
+        @inbounds for l in 2:L                        # extend forward
+            pid_l[l] == 0 || continue
+            pl = pid_l[l - 1]
+            (pl != 0 && pos_l[l - 1] + 1 <= prod_len[pl]) || continue
+            pid_l[l] = pl
+            pos_l[l] = pos_l[l - 1] + 1
+        end
+        @inbounds for l in (L - 1):-1:1               # then backward
+            pid_l[l] == 0 || continue
+            pr = pid_l[l + 1]
+            (pr != 0 && pos_l[l + 1] - 1 >= 1) || continue
+            pid_l[l] = pr
+            pos_l[l] = pos_l[l + 1] - 1
+        end
+        @inbounds for l in 1:L                        # placeholder: state slot 1
+            pid_l[l] == 0 || continue
+            prod_len[1] >= 1 || return nothing
+            pid_l[l] = 1
+            pos_l[l] = 1
+        end
+    end
+    return pid_l, pos_l
+end
+
+# A RUN decomposition must BEAT the gather it replaces: accept when the run
+# count is small against the lane count (each run is one slice; > 1 also costs a
+# concatenate). The cap must be ABSOLUTE as well as relative: lattice run counts
+# grow ~O(sqrt NC) with the grid, and a purely relative bound (L>>2 = 1,638 at
+# CONUS) admitted edges of hundreds of slices each -- the emitted module
+# overflowed XLA:CPU's contiguous JIT section arena ("Unable to allocate section
+# memory") at 13x7x72 while RSS sat at 6.7 GB. 64 leaves the measured 6x6x8
+# behaviour (L>>2 = 72) essentially unchanged. A mapping that fails this test is
+# NOT back to the flat buffer whenever it lies inside ONE producer: tier 2b then
+# gathers that producer's value, one op, same index volume (see `_OopSSARef`).
+@inline _ssa_worthwhile(L::Int, nseg::Int) = nseg <= min(64, max(8, L >> 2))
+
+# Pick the cheapest reference form for a resolved descriptor, or
+# `_OOP_SSA_NOREF` when none beats the dense `ue` gather.
+function _ssa_pack_ref(pid_l::Vector{Int}, pos_l::Vector{Int}, pgather_ok::Bool)
+    L = length(pid_l)
+    segs = _OopSSASeg[]
+    l = 1
+    @inbounds while l <= L
+        pid = pid_l[l]
+        lo = pos_l[l]
         len = 1
-        while i + len <= L
-            s2 = g[i + len]
-            (1 <= s2 <= n) || return nothing
-            (Int(@inbounds own_pid[s2]) == pid &&
-             Int(@inbounds own_pos[s2]) == lo + len) || break
+        while l + len <= L && pid_l[l + len] == pid && pos_l[l + len] == lo + len
             len += 1
         end
         push!(segs, _OopSSASeg(pid, lo, len))
-        i += len
+        l += len
     end
-    return segs
+    _ssa_worthwhile(L, length(segs)) && return _OopSSARef(segs, 0, Int[])
+    pgather_ok || return _OOP_SSA_NOREF
+    p1 = @inbounds pid_l[1]
+    all(==(p1), pid_l) && return _OopSSARef(_OopSSASeg[], p1, copy(pos_l))
+    return _OOP_SSA_NOREF
 end
-
-# A redirect must BEAT the gather it replaces: accept when the run count is
-# small against the lane count (each run is one slice; > 1 also costs a
-# concatenate). A fragmented mapping keeps the dense gather. The cap must be
-# ABSOLUTE as well as relative: lattice run counts grow ~O(sqrt NC) with the
-# grid, and a purely relative bound (L>>2 = 1,638 at CONUS) admitted edges of
-# hundreds of slices each -- the emitted module overflowed XLA:CPU's
-# contiguous JIT section arena ("Unable to allocate section memory") at
-# 13x7x72 while RSS sat at 6.7 GB. 64 leaves the measured 6x6x8 behaviour
-# (L>>2 = 72) essentially unchanged.
-@inline _ssa_worthwhile(L::Int, nseg::Int) = nseg <= min(64, max(8, L >> 2))
 
 function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
                              rhs_list, cse_prelude, n_states::Int, n_total::Int)
     _oop_ssa_enabled() || return _OOP_SSA_OFF
+    ghost_ok = _oop_ssa_ghost_enabled()
+    sub_ok = _oop_ssa_sub_enabled()
+    pgather_ok = _oop_ssa_pgather_enabled()
     nlev = length(mat_levels)
 
     # ---- Slot ownership, in execution order (LAST writer owns) ----
@@ -2933,6 +3116,7 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
     end
     prod_level = Int[0]
     prod_slots = Vector{Int}[Int[]]         # pid 1 never scatters; empty slot list
+    prod_len = Int[n_states]                # pid 1's VALUE is `u` itself
     matpids = Vector{Vector{Int}}(undef, nlev)
     dynamic = any(pl -> !pl.vectorizable, acc_plans)
     for li in 1:nlev
@@ -2946,6 +3130,7 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
             if plan.vectorizable
                 push!(prod_level, li)
                 push!(prod_slots, plan.out_slots)
+                push!(prod_len, length(plan.out_slots))
                 pid = length(prod_level)
                 pids[j] = pid
                 out = plan.out_slots
@@ -2970,10 +3155,10 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
     end
 
     # ---- Residual `ue` reads (everything that will NOT be redirected) ----
-    resid = falses(n_total)
-    markv!(v) = (for s in v
-                     1 <= s <= n_total && (resid[s] = true)
-                 end)
+    resid = zeros(UInt8, n_total)
+    markv!(v, why::UInt8) = (for s in v
+                                 1 <= s <= n_total && (resid[s] |= why)
+                             end)
     for nd in cse_prelude
         _ssa_mark_node_reads!(resid, nd)
     end
@@ -2986,54 +3171,100 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
             _ssa_mark_node_reads!(resid, nd)
         end
         for S in scans
-            markv!((S::_ScanFold).slots)      # the fold reads its own slots back
+            # the fold reads its own slots back
+            markv!((S::_ScanFold).slots, _SSA_R_SCAN)
         end
     end
     # (The state-RHS `scan_folds` fold `du`, not `ue` — no residue here.)
 
     n_edges = 0; n_fast = 0; elems_edges = 0; elems_fast = 0
+    n_gedges = 0; n_gfast = 0; elems_gedges = 0; elems_gfast = 0
+    n_sedges = 0; n_sfast = 0; elems_sedges = 0; elems_sfast = 0
 
-    # Per consumer kernel: decide redirects for the top-level cell-lane
-    # descriptors, then mark every read that stays on the gather path.
-    function consumer(K::_AccKernel, plan::_OopAccPlan, cons_level::Int)
-        plan.vectorizable || return _OOP_SSA_KERNEL_OFF
-        segsv = Vector{_OopSSASeg}[_OopSSASeg[] for _ in 1:length(K.acc)]
+    # ONE descriptor table — a kernel's own, or a sub-kernel's, both resolved
+    # against the SAME lane enumeration. Decides each descriptor's redirect and
+    # marks every read that stays on the gather path, with the reason that
+    # declined it. Returns the per-descriptor refs and whether any redirected.
+    function desc_table(acc::Vector{_AccDesc}, pl::_OopAccPlan, cons_level::Int,
+                        is_sub::Bool)
+        # A sub whose spine does not vectorize forces the parent non-vectorizable
+        # (`_build_oop_acc_plan`), so this cannot fire for a reached sub — but a
+        # fallback plan carries no per-descriptor vectors at all, so refuse it
+        # rather than index them.
+        pl.vectorizable || return (_OopSSARef[], false)
+        refs = _OopSSARef[_OOP_SSA_NOREF for _ in 1:length(acc)]
         any_fast = false
-        for i in eachindex(K.acc)
-            a = K.acc[i]
+        for i in eachindex(acc)
+            a = acc[i]
             if a.kind === _AK_STATE_FIXED
-                1 <= a.idx <= n_total && (resid[a.idx] = true)
+                1 <= a.idx <= n_total && (resid[a.idx] |= _SSA_R_FIXED)
             end
-            g = plan.gathers[i]
+            g = pl.gathers[i]
             isempty(g) && continue
-            if isempty(plan.ghost[i])
+            gh = pl.ghost[i]
+            ghosted = !isempty(gh)
+            if is_sub
+                n_sedges += 1
+                elems_sedges += length(g)
+            elseif ghosted
+                # Boundary stencil through a slot table with 0 entries: the
+                # redirect covers the concrete lanes and the emitter keeps the
+                # select against the (host, constant) ghost mask.
+                n_gedges += 1
+                elems_gedges += length(g)
+            else
                 n_edges += 1
                 elems_edges += length(g)
-                segs = _ssa_decompose(g, own_pid, own_pos, prod_level, cons_level)
-                if segs !== nothing && _ssa_worthwhile(length(g), length(segs))
-                    segsv[i] = segs
-                    any_fast = true
-                    n_fast += 1
-                    elems_fast += length(g)
-                    continue
-                end
             end
-            markv!(g)                          # ghost-masked or unresolved: gather
+            own = ((ghosted && !ghost_ok) || (is_sub && !sub_ok)) ? nothing :
+                  _ssa_lane_owners(g, gh, own_pid, own_pos, prod_level, prod_len,
+                                   cons_level)
+            ref = own === nothing ? _OOP_SSA_NOREF :
+                  _ssa_pack_ref(own[1], own[2], pgather_ok)
+            if ref === _OOP_SSA_NOREF
+                markv!(g, ghosted ? _SSA_R_GHOST :
+                          is_sub ? _SSA_R_SUB :
+                          own === nothing ? _SSA_R_DENSE : _SSA_R_FRAG)
+                continue
+            end
+            refs[i] = ref
+            any_fast = true
+            if is_sub
+                n_sfast += 1
+                elems_sfast += length(g)
+            elseif ghosted
+                n_gfast += 1
+                elems_gfast += length(g)
+            else
+                n_fast += 1
+                elems_fast += length(g)
+            end
         end
-        for (S, sp) in zip(plan.subs, plan.sub_plans)
-            for i in eachindex(S.acc)
-                S.acc[i].kind === _AK_STATE_FIXED &&
-                    1 <= S.acc[i].idx <= n_total && (resid[S.acc[i].idx] = true)
-                markv!(sp.gathers[i])
+        return refs, any_fast
+    end
+
+    function consumer(K::_AccKernel, plan::_OopAccPlan, cons_level::Int)
+        plan.vectorizable || return _OOP_SSA_KERNEL_OFF
+        refs, top_fast = desc_table(K.acc, plan, cons_level, false)
+        subrefs = _OOP_SSA_NO_SUBDESC
+        sub_fast = false
+        if !isempty(plan.subs)
+            sv = Vector{Vector{_OopSSARef}}(undef, length(plan.subs))
+            for j in eachindex(plan.subs)
+                sr, sf = desc_table(plan.subs[j].acc, plan.sub_plans[j],
+                                    cons_level, true)
+                sv[j] = sf ? sr : _OopSSARef[]
+                sub_fast |= sf
             end
+            sub_fast && (subrefs = sv)
         end
         for ep in plan.red_plan
             for g in ep.gathers
-                markv!(g)
+                markv!(g, _SSA_R_ELANE)
             end
         end
-        any_fast || return _OopSSAKernel(0, false, Vector{_OopSSASeg}[])
-        return _OopSSAKernel(0, false, segsv)
+        (top_fast || sub_fast) || return _OOP_SSA_KERNEL_OFF
+        return _OopSSAKernel(0, false, top_fast ? refs : _OopSSARef[], subrefs)
     end
 
     mat = Vector{Vector{_OopSSAKernel}}(undef, nlev)
@@ -3047,24 +3278,38 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
 
     # ---- Producer roles: attach pid + the scatter-skip verdict ----
     n_skip = 0; elems_skip = 0
+    blk = zeros(Int, 8); blk_only = zeros(Int, 8)
     for li in 1:nlev
         pids = matpids[li]
         ks = mat[li]
         for j in eachindex(pids)
             pid = pids[j]
             pid == 0 && continue
-            skip = !dynamic && !any(@inbounds(resid[s]) for s in prod_slots[pid])
+            why = UInt8(0)
+            @inbounds for sl in prod_slots[pid]
+                why |= resid[sl]
+            end
+            skip = !dynamic && why == 0
             if skip
                 n_skip += 1
                 elems_skip += length(prod_slots[pid])
+            else
+                for k in 1:8
+                    (why & _SSA_R_BITS[k]) == 0 && continue
+                    blk[k] += 1
+                    why == _SSA_R_BITS[k] && (blk_only[k] += 1)
+                end
             end
             k0 = ks[j]
-            ks[j] = _OopSSAKernel(pid, skip, k0.desc)
+            ks[j] = _OopSSAKernel(pid, skip, k0.desc, k0.subs)
         end
     end
 
     stats = _OopSSAStats(n_edges, n_fast, elems_edges, elems_fast,
-                         length(prod_level) - 1, n_skip, elems_skip, dynamic)
+                         length(prod_level) - 1, n_skip, elems_skip, dynamic,
+                         n_gedges, n_gfast, elems_gedges, elems_gfast,
+                         n_sedges, n_sfast, elems_sedges, elems_sfast,
+                         NTuple{8,Int}(blk), NTuple{8,Int}(blk_only))
     return _OopSSAPlan(true, length(prod_level), mat, fin, stats)
 end
 
@@ -3082,8 +3327,14 @@ function oop_ssa_stats(f::_OopRHS)
     s = p.stats
     return (; enabled = p.enabled, n_edges = s.n_edges, n_fast = s.n_fast,
             elems_edges = s.elems_edges, elems_fast = s.elems_fast,
+            n_ghost_edges = s.n_gedges, n_ghost_fast = s.n_gfast,
+            elems_ghost_edges = s.elems_gedges, elems_ghost_fast = s.elems_gfast,
+            n_sub_edges = s.n_sedges, n_sub_fast = s.n_sfast,
+            elems_sub_edges = s.elems_sedges, elems_sub_fast = s.elems_sfast,
             n_producers = s.n_prod, n_skipped_scatters = s.n_skip,
-            elems_skipped = s.elems_skip, dynamic = s.dynamic)
+            elems_skipped = s.elems_skip, dynamic = s.dynamic,
+            blockers = NamedTuple{_SSA_R_NAMES}(s.blk),
+            blockers_only = NamedTuple{_SSA_R_NAMES}(s.blk_only))
 end
 
 function _make_rhs_oop(rhs_list::AbstractVector{Tuple{Int,_Node}},

--- a/pkg/EarthSciAST.jl/src/tree_walk/oop.jl
+++ b/pkg/EarthSciAST.jl/src/tree_walk/oop.jl
@@ -2919,6 +2919,104 @@ _oop_ssa_ghost_enabled()   = get(ENV, "ESS_OOP_SSA_GHOST", "1") != "0"
 _oop_ssa_sub_enabled()     = get(ENV, "ESS_OOP_SSA_SUB", "1") != "0"
 _oop_ssa_pgather_enabled() = get(ENV, "ESS_OOP_SSA_PGATHER", "1") != "0"
 
+# ---- The scatter-skip GATE (ess-oop-ssa-gate) --------------------------------
+#
+# Static skippability (`why == 0`: nothing reads the producer's block off `ue`
+# any more) says the scatter is REDUNDANT. It does not say that dropping it is
+# CHEAPER, and measurement says it often is not: a producer's
+# `dynamic_update_slice` into `ue` ALIASES its operand in the forward, so
+# XLA:CPU writes only the update and can fuse the producer's spine straight into
+# `ue`'s memory. Dropping the scatter takes that fusion away and makes the
+# producer's value a buffer of its own. On the PPM transport RHS that trade is a
+# loss; on the merged-class chemistry RHS it is a large win. So the skip is
+# GATED on producer facts, and the gate is what this knob group tunes.
+#
+#   ESS_OOP_SSA_SKIP=0            never skip a scatter (the redirects stay) --
+#                                 the negative control for the whole gate
+#   ESS_OOP_SSA_SKIP_MAXLEN=<n>   skip only a producer whose value is <= n
+#                                 elements (`-1` ⇒ no bound)
+#   ESS_OOP_SSA_SKIP_MINRATIO=<x> skip only a producer whose REDIRECTED read
+#                                 volume is >= x times its own block size
+#                                 (`0` ⇒ no bound)
+#
+# Both bounds default to the measured gate; `ESS_OOP_SSA_SKIP_GATE=0` restores
+# the ungated behaviour (every statically skippable scatter skipped), which is
+# what #283 shipped and what the engagement tests A/B against.
+_oop_ssa_skip_enabled() = get(ENV, "ESS_OOP_SSA_SKIP", "1") != "0"
+_oop_ssa_skip_gated()   = get(ENV, "ESS_OOP_SSA_SKIP_GATE", "1") != "0"
+# Both PER-PRODUCER bounds are released by default: the measured
+# discriminator is not a producer property at all (see `ESS_OOP_SSA_SKIP_WHOLE`
+# below and SSA_SPIKE.md) -- they exist so the alternative hypotheses stay
+# bisectable without a rebuild.
+const _SSA_SKIP_MAXLEN_DEFAULT = typemax(Int)
+const _SSA_SKIP_MINRATIO_DEFAULT = 0.0
+function _oop_ssa_skip_maxlen()
+    v = get(ENV, "ESS_OOP_SSA_SKIP_MAXLEN", "")
+    isempty(v) && return _SSA_SKIP_MAXLEN_DEFAULT
+    n = tryparse(Int, v)
+    (n === nothing || n < 0) && return typemax(Int)
+    return n
+end
+function _oop_ssa_skip_minratio()
+    v = get(ENV, "ESS_OOP_SSA_SKIP_MINRATIO", "")
+    isempty(v) && return _SSA_SKIP_MINRATIO_DEFAULT
+    x = tryparse(Float64, v)
+    return x === nothing ? _SSA_SKIP_MINRATIO_DEFAULT : x
+end
+
+# `ESS_OOP_SSA_SKIP_PIDS=3,7,12` restricts skipping to those producer ids, and
+# `ESS_OOP_SSA_SKIP_PIDS=!17` skips everything EXCEPT them. Producer ids are
+# structural (the fill-kernel enumeration does not depend on the grid), so a
+# 6x6x8 `oop_ssa_producers` table names the same producers a CONUS build has:
+# this is the per-producer BISECT the gate's discriminator was found with, not
+# a knob a caller should set. Empty ⇒ no pid restriction.
+function _oop_ssa_skip_pids()
+    v = strip(get(ENV, "ESS_OOP_SSA_SKIP_PIDS", ""))
+    isempty(v) && return (false, Int[])
+    neg = startswith(v, "!")
+    neg && (v = v[2:end])
+    ids = Int[]
+    for tok in split(v, ',')
+        tok = strip(tok)
+        isempty(tok) && continue
+        n = tryparse(Int, tok)
+        n === nothing || push!(ids, n)
+    end
+    return (neg, ids)
+end
+
+# One producer's build-time facts, for the gate and for `oop_ssa_producers`.
+# `len` is the value's element count, `nread`/`elread` the redirected read
+# surfaces and element volume that now source from it, `nwhole` how many of
+# those take the whole value with no op at all (tier 1), and `why` the residual
+# reason bits that would keep the scatter alive regardless of the gate.
+struct _OopSSAProd
+    pid::Int
+    level::Int
+    len::Int
+    nread::Int
+    elread::Int
+    nwhole::Int
+    why::UInt8
+    skippable::Bool   # static accounting alone would drop the scatter
+    skip::Bool        # … and the gate agreed
+end
+
+# `ESS_OOP_SSA_SKIP_WHOLE=1` makes the skip ALL-OR-NOTHING per build: a
+# scatter is dropped only when EVERY tracked producer's is droppable, so `ue`
+# stops being written at all and the whole flat buffer dies. `=0` allows
+# partial skipping (what #283 shipped).
+_oop_ssa_skip_whole() = get(ENV, "ESS_OOP_SSA_SKIP_WHOLE", "1") != "0"
+
+# The per-producer half of the gate: given a STATICALLY skippable producer, is
+# dropping the scatter worth it? `maxlen`/`minratio` come from the knobs above.
+@inline function _ssa_skip_worth(pr_len::Int, elread::Int,
+                                 maxlen::Int, minratio::Float64)
+    pr_len <= maxlen || return false
+    minratio <= 0 && return true
+    return elread >= minratio * pr_len
+end
+
 # WHY a residual `ue` read exists, one bit per read surface, carried per slot in
 # the analysis' `resid` map and reduced per producer into the blocker tally
 # `oop_ssa_stats` reports. The tally is the campaign's steering instrument: a
@@ -2949,8 +3047,10 @@ struct _OopSSAStats
     elems_edges::Int      # Σ gather lengths over all edges
     elems_fast::Int       # Σ gather lengths over redirected edges
     n_prod::Int           # tracked producers (fill kernels; excludes the state)
-    n_skip::Int           # producers whose `ue` scatter is statically skippable
-    elems_skip::Int       # Σ out_slots lengths over skippable producers
+    n_skip::Int           # producers whose `ue` scatter is ACTUALLY skipped
+    elems_skip::Int       # Σ out_slots lengths over skipped producers
+    n_skippable::Int      # … statically skippable, before the worthwhileness gate
+    elems_skippable::Int
     dynamic::Bool         # a per-cell kernel exists ⇒ no scatter may be skipped
     n_gedges::Int         # ghost-masked candidate descriptors
     n_gfast::Int          # … of which redirected to producer values + select
@@ -2971,11 +3071,13 @@ struct _OopSSAPlan
     mat::Vector{Vector{_OopSSAKernel}}  # per fill level, aligned with its kernels
     fin::Vector{_OopSSAKernel}          # aligned with the state-RHS acc_kernels
     stats::_OopSSAStats
+    prods::Vector{_OopSSAProd}          # per-producer facts (gate instrumentation)
 end
 const _OOP_SSA_OFF = _OopSSAPlan(false, 0, Vector{_OopSSAKernel}[], _OopSSAKernel[],
-                                 _OopSSAStats(0, 0, 0, 0, 0, 0, 0, false,
+                                 _OopSSAStats(0, 0, 0, 0, 0, 0, 0, 0, 0, false,
                                               0, 0, 0, 0, 0, 0, 0, 0,
-                                              _SSA_BLK0, _SSA_BLK0))
+                                              _SSA_BLK0, _SSA_BLK0),
+                                 _OopSSAProd[])
 
 # Residual `ue` reads of the scalar walkers: `_NK_STATE` pins one slot,
 # `_NK_STATE_GATHER` may read any slot in its table (its subscripts are
@@ -3106,6 +3208,12 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
     ghost_ok = _oop_ssa_ghost_enabled()
     sub_ok = _oop_ssa_sub_enabled()
     pgather_ok = _oop_ssa_pgather_enabled()
+    skip_ok = _oop_ssa_skip_enabled()
+    gate_on = _oop_ssa_skip_gated()
+    gate_maxlen = gate_on ? _oop_ssa_skip_maxlen() : typemax(Int)
+    gate_minratio = gate_on ? _oop_ssa_skip_minratio() : 0.0
+    pid_neg, pid_list = _oop_ssa_skip_pids()
+    whole_only = gate_on && _oop_ssa_skip_whole()
     nlev = length(mat_levels)
 
     # ---- Slot ownership, in execution order (LAST writer owns) ----
@@ -3181,6 +3289,41 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
     n_gedges = 0; n_gfast = 0; elems_gedges = 0; elems_gfast = 0
     n_sedges = 0; n_sfast = 0; elems_sedges = 0; elems_sfast = 0
 
+    # ---- Per-producer redirected-read volume (the gate's input) ----
+    # A redirect makes the producer's VALUE the read surface, which is what
+    # forces it to be materialized; these tallies are how much reading now goes
+    # there, per producer, so the skip verdict can be priced instead of assumed.
+    nprod_all = length(prod_level)
+    rd_n = zeros(Int, nprod_all)      # redirected descriptors sourcing from pid
+    rd_el = zeros(Int, nprod_all)     # … their element volume out of pid
+    rd_whole = zeros(Int, nprod_all)  # … of which take the whole value (tier 1)
+    function record_ref!(ref::_OopSSARef)
+        if ref.pid != 0
+            rd_n[ref.pid] += 1
+            rd_el[ref.pid] += length(ref.pos)
+            return
+        end
+        segs = ref.segs
+        isempty(segs) && return
+        # one descriptor may straddle several producers; count it once each
+        for k in eachindex(segs)
+            sg = segs[k]
+            rd_el[sg.pid] += sg.len
+            seen = false
+            for k2 in 1:(k - 1)
+                if segs[k2].pid == sg.pid
+                    seen = true
+                    break
+                end
+            end
+            seen || (rd_n[sg.pid] += 1)
+        end
+        if length(segs) == 1
+            sg = segs[1]
+            (sg.lo == 1 && sg.len == prod_len[sg.pid]) && (rd_whole[sg.pid] += 1)
+        end
+    end
+
     # ONE descriptor table — a kernel's own, or a sub-kernel's, both resolved
     # against the SAME lane enumeration. Decides each descriptor's redirect and
     # marks every read that stays on the gather path, with the reason that
@@ -3228,6 +3371,7 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
                 continue
             end
             refs[i] = ref
+            record_ref!(ref)
             any_fast = true
             if is_sub
                 n_sfast += 1
@@ -3277,22 +3421,33 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
                         for j in eachindex(acc_kernels)]
 
     # ---- Producer roles: attach pid + the scatter-skip verdict ----
-    n_skip = 0; elems_skip = 0
+    #
+    # TWO verdicts, deliberately separate. `skippable` is the STATIC one the
+    # spike shipped: nothing reads this producer's block off `ue` any more, so
+    # the scatter is redundant. `skip` is that AND the worthwhileness gate
+    # (`_ssa_skip_worth`) — because a redundant scatter is not necessarily an
+    # expensive one, and on the transport RHS dropping it costs more than it
+    # saves. Declining the gate is always CORRECT: it emits a write nothing
+    # reads, exactly as the flag-off build does.
+    n_skip = 0; elems_skip = 0; n_skippable = 0; elems_skippable = 0
     blk = zeros(Int, 8); blk_only = zeros(Int, 8)
+    prods = _OopSSAProd[]
+    # PASS 1: the static verdict and the residual-reason tally, per producer.
+    why_p = zeros(UInt8, nprod_all)
+    skippable_p = falses(nprod_all)
     for li in 1:nlev
-        pids = matpids[li]
-        ks = mat[li]
-        for j in eachindex(pids)
-            pid = pids[j]
+        for pid in matpids[li]
             pid == 0 && continue
             why = UInt8(0)
             @inbounds for sl in prod_slots[pid]
                 why |= resid[sl]
             end
-            skip = !dynamic && why == 0
-            if skip
-                n_skip += 1
-                elems_skip += length(prod_slots[pid])
+            why_p[pid] = why
+            sk = !dynamic && why == 0
+            skippable_p[pid] = sk
+            if sk
+                n_skippable += 1
+                elems_skippable += length(prod_slots[pid])
             else
                 for k in 1:8
                     (why & _SSA_R_BITS[k]) == 0 && continue
@@ -3300,17 +3455,44 @@ function _build_oop_ssa_plan(mat_levels::Tuple, acc_kernels, acc_plans,
                     why == _SSA_R_BITS[k] && (blk_only[k] += 1)
                 end
             end
+        end
+    end
+    # `ESS_OOP_SSA_SKIP_WHOLE`: with even ONE producer still scattering, `ue`
+    # is assembled anyway and a partial skip pays for the flat buffer AND for
+    # the skipped producers' own buffers. So unless every tracked producer can
+    # go, none does.
+    all_skippable = n_skippable == length(prod_level) - 1
+    build_ok = skip_ok && !(whole_only && !all_skippable)
+    # PASS 2: the gated verdict.
+    for li in 1:nlev
+        pids = matpids[li]
+        ks = mat[li]
+        for j in eachindex(pids)
+            pid = pids[j]
+            pid == 0 && continue
+            plen = length(prod_slots[pid])
+            pid_ok = isempty(pid_list) ? true : ((pid in pid_list) != pid_neg)
+            skip = skippable_p[pid] && build_ok && pid_ok &&
+                   _ssa_skip_worth(plen, rd_el[pid], gate_maxlen, gate_minratio)
+            if skip
+                n_skip += 1
+                elems_skip += plen
+            end
+            push!(prods, _OopSSAProd(pid, li, plen, rd_n[pid], rd_el[pid],
+                                     rd_whole[pid], why_p[pid],
+                                     skippable_p[pid], skip))
             k0 = ks[j]
             ks[j] = _OopSSAKernel(pid, skip, k0.desc, k0.subs)
         end
     end
 
     stats = _OopSSAStats(n_edges, n_fast, elems_edges, elems_fast,
-                         length(prod_level) - 1, n_skip, elems_skip, dynamic,
+                         length(prod_level) - 1, n_skip, elems_skip,
+                         n_skippable, elems_skippable, dynamic,
                          n_gedges, n_gfast, elems_gedges, elems_gfast,
                          n_sedges, n_sfast, elems_sedges, elems_sfast,
                          NTuple{8,Int}(blk), NTuple{8,Int}(blk_only))
-    return _OopSSAPlan(true, length(prod_level), mat, fin, stats)
+    return _OopSSAPlan(true, length(prod_level), mat, fin, stats, prods)
 end
 
 """
@@ -3332,9 +3514,34 @@ function oop_ssa_stats(f::_OopRHS)
             n_sub_edges = s.n_sedges, n_sub_fast = s.n_sfast,
             elems_sub_edges = s.elems_sedges, elems_sub_fast = s.elems_sfast,
             n_producers = s.n_prod, n_skipped_scatters = s.n_skip,
-            elems_skipped = s.elems_skip, dynamic = s.dynamic,
+            elems_skipped = s.elems_skip,
+            n_skippable_scatters = s.n_skippable,
+            elems_skippable = s.elems_skippable,
+            n_gate_declined = s.n_skippable - s.n_skip,
+            dynamic = s.dynamic,
             blockers = NamedTuple{_SSA_R_NAMES}(s.blk),
             blockers_only = NamedTuple{_SSA_R_NAMES}(s.blk_only))
+end
+
+"""
+    oop_ssa_producers(f) -> Vector{NamedTuple}
+
+Per-producer build-time facts behind the scatter-skip GATE (ess-oop-ssa):
+each tracked fill kernel's fill `level`, its value length `len`, how many
+redirected read surfaces now source from it (`nread`) and at what element
+volume (`elread`), how many of those take its whole value with no op at all
+(`nwhole`), the residual-read reason bits that would keep its scatter alive
+(`why`, names as in `oop_ssa_stats().blockers`), whether static accounting
+alone would drop the scatter (`skippable`) and whether the gate agreed
+(`skip`). Empty when the flag was off at build time.
+"""
+function oop_ssa_producers(f::_OopRHS)
+    p = f.rhs.ssa::_OopSSAPlan
+    return [(; pid = q.pid, level = q.level, len = q.len, nread = q.nread,
+              elread = q.elread, nwhole = q.nwhole,
+              why = Tuple(_SSA_R_NAMES[k] for k in 1:8
+                          if (q.why & _SSA_R_BITS[k]) != 0),
+              skippable = q.skippable, skip = q.skip) for q in p.prods]
 end
 
 function _make_rhs_oop(rhs_list::AbstractVector{Tuple{Int,_Node}},

--- a/pkg/EarthSciAST.jl/test/tree_walk_oop_ssa_test.jl
+++ b/pkg/EarthSciAST.jl/test/tree_walk_oop_ssa_test.jl
@@ -213,3 +213,242 @@ _s_ip(f!, u, p, t) = (du = zero(u); f!(du, u, p, t); du)
         @test Jon == Joff
     end
 end
+
+# ---------------------------------------------------------------------------
+# The three arms added after the spike (`SSA_SPIKE.md` "What blocks the rest"):
+# ghost-masked table gathers (#1), template sub-kernel descriptor tables (#2),
+# and tier 2b — the single-producer VALUE gather that fragmented mappings (#5)
+# take instead of the flat-buffer fallback. Each has a bisect knob
+# (`ESS_OOP_SSA_GHOST` / `_SUB` / `_PGATHER`, all default on), so every
+# engagement assertion below is paired with a NEGATIVE CONTROL: the same build
+# with that one arm declined must show the coverage gone.
+# ---------------------------------------------------------------------------
+
+# One producer occupying slots 5:8 at level 1, the state at slots 1:4 (level 0).
+const _SX_PID = Int32[1, 1, 1, 1, 2, 2, 2, 2]
+const _SX_POS = Int32[1, 2, 3, 4, 1, 2, 3, 4]
+const _SX_LVL = Int[0, 1]
+const _SX_LEN = Int[4, 4]
+_sx_owners(g, m = Bool[]; lvl = 2, pid = _SX_PID, pos = _SX_POS) =
+    ESMs._ssa_lane_owners(g, m, pid, pos, _SX_LVL, _SX_LEN, lvl)
+
+@testset "SSA reference forms (lane owners + tier choice)" begin
+
+    @testset "run decomposition and the level/ownership refusals" begin
+        o = _sx_owners([5, 6, 7, 8])
+        @test o !== nothing
+        r = ESMs._ssa_pack_ref(o[1], o[2], true)
+        @test r.pid == 0 && r.segs == [ESMs._OopSSASeg(2, 1, 4)]
+        # a producer that does NOT strictly precede the consumer is refused
+        @test _sx_owners([5, 6, 7, 8]; lvl = 1) === nothing
+        # so is a slot nothing owns (a later writer disowned it)
+        dis = copy(_SX_PID); dis[6] = 0
+        @test _sx_owners([5, 6, 7, 8]; pid = dis) === nothing
+        # out-of-range slots are refused rather than read
+        @test _sx_owners([5, 6, 7, 99]) === nothing
+    end
+
+    @testset "ghost mask: a wildcard lane takes whatever continues the run" begin
+        # A MIDDLE ghost (its safe-index gather read slot 1) is filled from its
+        # left neighbour and the whole descriptor collapses to ONE slice.
+        o = _sx_owners([5, 1, 7, 8], Bool[false, true, false, false])
+        @test o !== nothing
+        @test o[1] == [2, 2, 2, 2] && o[2] == [1, 2, 3, 4]
+        @test ESMs._ssa_pack_ref(o[1], o[2], true).segs == [ESMs._OopSSASeg(2, 1, 4)]
+        # A LEADING ghost cannot back-extend past position 1, so it takes the
+        # placeholder segment (the state's slot 1) and the rest is one slice.
+        o = _sx_owners([1, 5, 6, 7], Bool[true, false, false, false])
+        @test o !== nothing
+        @test o[1] == [1, 2, 2, 2] && o[2] == [1, 1, 2, 3]
+        @test ESMs._ssa_pack_ref(o[1], o[2], true).segs ==
+              [ESMs._OopSSASeg(1, 1, 1), ESMs._OopSSASeg(2, 1, 3)]
+        # A leading ghost that CAN back-extend does, and the run stays single.
+        o = _sx_owners([1, 6, 7, 8], Bool[true, false, false, false])
+        @test o[1] == [2, 2, 2, 2] && o[2] == [1, 2, 3, 4]
+        # Every invented position stays inside its producer's value, whichever
+        # lanes the mask covers.
+        raw = [5, 6, 7, 8]
+        for bits in 1:14                      # every mask but none-set / all-set
+            msk = Bool[(bits >> (l - 1)) & 1 == 1 for l in 1:4]
+            o = _sx_owners(Int[msk[l] ? 1 : raw[l] for l in 1:4], msk)
+            @test o !== nothing
+            for l in 1:4
+                @test 1 <= o[2][l] <= _SX_LEN[o[1][l]]
+            end
+        end
+        # An ALL-ghost descriptor is declined (it is a constant zero vector).
+        @test _sx_owners([1, 1, 1, 1], Bool[true, true, true, true]) === nothing
+    end
+
+    @testset "tier 2b: a fragmented SINGLE-producer mapping gathers the value" begin
+        pid = fill(Int32(2), 40)
+        pos = Int32.(1:40)
+        lvl = Int[0, 1]
+        len = Int[40, 40]
+        g = collect(40:-1:1)                      # reversed ⇒ 40 runs of length 1
+        o = ESMs._ssa_lane_owners(g, Bool[], pid, pos, lvl, len, 2)
+        @test o !== nothing
+        r = ESMs._ssa_pack_ref(o[1], o[2], true)
+        @test r.pid == 2 && r.pos == g && isempty(r.segs)
+        # NEGATIVE CONTROL: with tier 2b declined the mapping is too fragmented
+        # for slices and falls back to the flat buffer.
+        @test ESMs._ssa_pack_ref(o[1], o[2], false) === ESMs._OOP_SSA_NOREF
+        # A fragmented MULTI-producer mapping has no one-op form either way.
+        pid2 = Int32[i <= 20 ? 2 : 3 for i in 1:40]
+        pos2 = Int32[i <= 20 ? i : i - 20 for i in 1:40]
+        o2 = ESMs._ssa_lane_owners(g, Bool[], pid2, pos2, Int[0, 1, 1], Int[40, 20, 20], 2)
+        @test o2 !== nothing
+        @test ESMs._ssa_pack_ref(o2[1], o2[2], true) === ESMs._OOP_SSA_NOREF
+    end
+end
+
+# A REVERSED read of a materialized observed: `g[N+1-i]` is not `out .+ delta`,
+# so the build lowers it to a per-box slot table whose lanes descend — L runs of
+# length 1, past the slice worthwhileness bound. Tier 2b turns it into one
+# gather of `g`'s value; without tier 2b it is the dense `ue` gather, and `g`'s
+# scatter has to stay.
+function _s_rev(N)
+    _s_doc("SSAREV",
+        Dict{String,Any}("u" => _s_state(shape = Any["n"]),
+                         "g" => _s_state(shape = Any["n"]),
+                         "k" => _s_param(0.25)),
+        Any[Dict{String,Any}("lhs" => "g",
+                "rhs" => _s_ao(_s_o("+", _s_o("*", 2.0, _s_ix("u", "i")), 1.0))),
+            Dict{String,Any}("lhs" => _s_ao(_s_Dt(_s_ix("u", "i"))),
+                "rhs" => _s_ao(_s_o("-", _s_o("*", "k",
+                                    _s_ix("g", _s_o("-", Float64(N + 1), "i"))),
+                                    _s_ix("u", "i"))))],
+        N)
+end
+
+_s_build_env(doc, env...) = withenv("ESS_OOP_SSA" => "1", env...) do
+    ESMs.build_evaluator(doc; form = :oop)
+end
+
+@testset "tier 2b end to end (reversed observed read)" begin
+    N = 24
+    doc = _s_rev(N)
+    (fon, u0, p, _, _) = _s_build_env(doc)
+    (fno, _, _, _, _) = _s_build_env(doc, "ESS_OOP_SSA_PGATHER" => "0")
+    foff, = withenv("ESS_OOP_SSA" => nothing) do
+        ESMs.build_evaluator(doc; form = :oop)
+    end
+    fip, = ESMs.build_evaluator(doc)
+    for probe in (u0, _s_seed(length(u0))), t in (0.0, 0.41)
+        a = fon(probe, p, t)
+        @test a == foff(probe, p, t)
+        @test a == fno(probe, p, t)
+        @test a == _s_ip(fip, probe, p, t)
+    end
+    son = ESMs.oop_ssa_stats(fon)
+    sno = ESMs.oop_ssa_stats(fno)
+    # ENGAGEMENT + NEGATIVE CONTROL: the reversed edge redirects only with the
+    # arm on, and it is the last reader keeping `g`'s scatter alive.
+    @test son.n_fast > sno.n_fast
+    @test son.n_skipped_scatters > sno.n_skipped_scatters
+    @test son.n_producers == 1 && son.n_skipped_scatters == 1
+    Jon = ForwardDiff.jacobian(uu -> fon(uu, p, 0.2), _s_seed(N))
+    Joff = ForwardDiff.jacobian(uu -> foff(uu, p, 0.2), _s_seed(N))
+    @test Jon == Joff
+end
+
+# ---------------------------------------------------------------------------
+# Template SUB-KERNEL descriptor tables (`SSA_SPIKE.md` blocker #2). A sub is
+# evaluated at the PARENT's lanes and `_build_oop_desc_vectors` resolves its
+# descriptors against that same enumeration, so its gathers are ordinary slot
+# vectors into `ue` — but they index `S.acc`, not `K.acc`, which is why the
+# spike's per-kernel table could not carry them and every one of them held its
+# producers' scatters alive. Measured on the ReSEACT transport RHS at 6x6x8,
+# these are 885 of the 985 candidate descriptors and 1.07 M of the 1.11 M read
+# elements, so they are the read surface that matters.
+#
+# The fixture is the duo-rule shape from codegen_subcall_fn_test.jl — a
+# makearray whose region value applies an aggregate-bodied template whose expr
+# holds more applies as arithmetic OPERANDS — because that is what mints
+# `_NK_SUBCALL`s at all.
+function _s_sub_fixture(dir, N)
+    ix(f, i, j) = Dict("op" => "index", "args" => Any[f, i, j])
+    ap(a, b) = Dict("op" => "apply_expression_template", "args" => Any[],
+                    "name" => "leaf", "bindings" => Dict("a" => a, "b" => b))
+    leaf_terms = Any[]
+    for k in 1:12
+        push!(leaf_terms, Dict("op" => "*", "args" => Any[0.5 + 0.01k,
+            Dict("op" => "+", "args" => Any[
+                Dict("op" => "*", "args" => Any["a", "a"]),
+                Dict("op" => "*", "args" => Any["b", 0.3 + 0.02k])])]))
+    end
+    leaf = Dict("params" => Any["a", "b"],
+                "body" => Dict("op" => "+", "args" => leaf_terms))
+    inner_expr = Dict("op" => "+", "args" => Any[
+        Dict("op" => "*", "args" => Any[0.25, ap(ix("f", "i", "j"), ix("f", "i", "j"))]),
+        ap(ix("f", "i", "j"), ix("f", "j", "i")),
+        Dict("op" => "*", "args" => Any[ap(ix("f", "i", "j"), ix("f", "i", "j")), 0.125])])
+    inner = Dict("params" => Any["f"],
+                 "body" => Dict("op" => "aggregate", "output_idx" => Any["i", "j"],
+                                "args" => Any["f"],
+                                "ranges" => Dict("i" => Dict("from" => "x"),
+                                                 "j" => Dict("from" => "y")),
+                                "expr" => inner_expr))
+    rhs = Dict("op" => "makearray", "args" => Any[],
+               "regions" => Any[Any[Any[1, "N"], Any[1, "N"]]],
+               "values" => Any[Dict("op" => "apply_expression_template",
+                                    "args" => Any[], "name" => "inner",
+                                    "bindings" => Dict("f" => "u"))])
+    doc = Dict("esm" => "1.0.0",
+        "metadata" => Dict("name" => "ssa_subcall_fixture",
+                           "description" => "generated by tree_walk_oop_ssa_test.jl: sub-kernel redirect"),
+        "metaparameters" => Dict("N" => Dict("type" => "integer", "default" => N)),
+        "index_sets" => Dict("x" => Dict("kind" => "interval", "size" => "N"),
+                             "y" => Dict("kind" => "interval", "size" => "N")),
+        "models" => Dict("M" => Dict(
+            "expression_templates" => Dict("leaf" => leaf, "inner" => inner),
+            "variables" => Dict("u" => Dict("type" => "unknown", "units" => "1",
+                                            "shape" => Any["x", "y"], "default" => 1.0)),
+            "equations" => Any[Dict(
+                "lhs" => Dict("op" => "D", "args" => Any["u"], "wrt" => "t"),
+                "rhs" => rhs)])))
+    path = joinpath(dir, "ssa_subcall_fixture.esm")
+    open(path, "w") do io
+        JSON3.write(io, doc)
+    end
+    return path
+end
+
+@testset "sub-kernel descriptor tables redirect (blocker #2)" begin
+    mktempdir() do dir
+        F = _s_sub_fixture(dir, 5)
+        build(env...) = withenv(env...) do
+            ESMs.build_evaluator(ESMs.flatten(ESMs.load_path(F)); form = :oop)
+        end
+        # The nested-boundary tier is what mints the `_NK_SUBCALL`s.
+        nested = "ESS_NESTED_TEMPLATE_BOUNDARY" => "1"
+        (fon, u0, p, _, _) = build(nested, "ESS_OOP_SSA" => "1")
+        (fno, _, _, _, _) = build(nested, "ESS_OOP_SSA" => "1",
+                                  "ESS_OOP_SSA_SUB" => "0")
+        (foff, _, _, _, _) = build(nested, "ESS_OOP_SSA" => nothing)
+        fip, ui, pi_, _, _ = withenv(nested) do
+            ESMs.build_evaluator(ESMs.flatten(ESMs.load_path(F)))
+        end
+
+        son = ESMs.oop_ssa_stats(fon)
+        sno = ESMs.oop_ssa_stats(fno)
+        # ENGAGEMENT: the sub tables are where this fixture's reads live at all,
+        # and every one of them redirects.
+        @test son.n_sub_edges > 0
+        @test son.n_sub_fast == son.n_sub_edges
+        # NEGATIVE CONTROL: with the arm declined not one of them redirects.
+        @test sno.n_sub_edges == son.n_sub_edges
+        @test sno.n_sub_fast == 0
+
+        # BIT-IDENTITY across all three builds and the in-place `f!`.
+        for probe in (u0, _s_seed(length(u0))), t in (0.0, 0.63)
+            a = fon(probe, p, t)
+            @test a == foff(probe, p, t)
+            @test a == fno(probe, p, t)
+            @test a == _s_ip(fip, probe, pi_, t)
+        end
+        u = _s_seed(length(u0))
+        @test ForwardDiff.jacobian(uu -> fon(uu, p, 0.3), u) ==
+              ForwardDiff.jacobian(uu -> foff(uu, p, 0.3), u)
+    end
+end

--- a/pkg/EarthSciAST.jl/test/tree_walk_oop_ssa_test.jl
+++ b/pkg/EarthSciAST.jl/test/tree_walk_oop_ssa_test.jl
@@ -452,3 +452,204 @@ end
               ForwardDiff.jacobian(uu -> foff(uu, p, 0.3), u)
     end
 end
+
+# ---------------------------------------------------------------------------
+# The SCATTER-SKIP GATE (ess-oop-ssa-gate).
+#
+# Static skippability says a producer's scatter into `ue` is REDUNDANT. It does
+# not say dropping it is CHEAPER — a `dynamic_update_slice` aliases its operand
+# in the forward, so keeping it can be nearly free while dropping it makes the
+# producer's value a buffer of its own. The gate prices that, and these tests
+# pin the two things a price may never change:
+#
+#   * VALUES. Every gate setting is bit-identical to flag-off and to
+#     `:inplace`, and ForwardDiff agrees exactly. Declining a skip emits a
+#     write nothing reads — the flag-off behaviour — so this is the same
+#     contract the spike has, asserted across the whole knob group.
+#   * THE READ GRAPH. The gate decides only whether a scatter is EMITTED; the
+#     redirect tables and the static `n_skippable_scatters` are the same in
+#     every arm. A gate that also suppressed redirects would show up here.
+#
+# Each knob has a negative control, so the arm can be bisected: the master
+# `ESS_OOP_SSA_SKIP=0`, the ungated `ESS_OOP_SSA_SKIP_GATE=0` (what #283
+# shipped), the two thresholds, and the per-producer `ESS_OOP_SSA_SKIP_PIDS`
+# bisect the discriminator was found with.
+_s_build_gate(doc, env...) = withenv("ESS_OOP_SSA" => "1", env...) do
+    ESMs.build_evaluator(doc; form = :oop)
+end
+
+@testset "scatter-skip gate (ESS_OOP_SSA_SKIP*)" begin
+    doc = _s_fan(7, 4)
+    (fdef, u0, p, _, _) = _s_build_gate(doc)
+    (fung, _, _, _, _) = _s_build_gate(doc, "ESS_OOP_SSA_SKIP_GATE" => "0")
+    (fno,  _, _, _, _) = _s_build_gate(doc, "ESS_OOP_SSA_SKIP" => "0")
+    (flen, _, _, _, _) = _s_build_gate(doc, "ESS_OOP_SSA_SKIP_MAXLEN" => "1")
+    (frat, _, _, _, _) = _s_build_gate(doc, "ESS_OOP_SSA_SKIP_MINRATIO" => "1e9")
+    (fpid, _, _, _, _) = _s_build_gate(doc, "ESS_OOP_SSA_SKIP_PIDS" => "!2")
+    (funl, _, _, _, _) = _s_build_gate(doc, "ESS_OOP_SSA_SKIP_MAXLEN" => "-1",
+                                       "ESS_OOP_SSA_SKIP_MINRATIO" => "0")
+    (foff, _, _, _, _) = withenv("ESS_OOP_SSA" => nothing) do
+        ESMs.build_evaluator(doc; form = :oop)
+    end
+    (fip, _, _, _, _) = ESMs.build_evaluator(doc)
+    ARMS = (fdef, fung, fno, flen, frat, fpid, funl)
+    st(f) = ESMs.oop_ssa_stats(f)
+
+    @testset "the gate moves ONLY the skip verdict" begin
+        base = st(fung)
+        @test base.n_skippable_scatters == base.n_skipped_scatters == 2
+        for f in ARMS
+            s = st(f)
+            @test s.n_skippable_scatters == 2      # a read-graph fact
+            @test s.n_fast == base.n_fast > 0      # redirects untouched
+            @test s.elems_fast == base.elems_fast
+            @test s.n_sub_fast == base.n_sub_fast
+            @test s.n_skipped_scatters + s.n_gate_declined == 2
+            @test s.n_skipped_scatters <= s.n_skippable_scatters
+        end
+    end
+
+    @testset "each knob declines what it says it declines" begin
+        @test st(fung).n_skipped_scatters == 2      # #283, ungated
+        @test st(funl).n_skipped_scatters == 2      # both bounds released
+        @test st(fno).n_skipped_scatters == 0       # master off
+        @test st(fno).n_gate_declined == 2
+        @test st(flen).n_skipped_scatters == 0      # every producer is 7 > 1
+        @test st(frat).n_skipped_scatters == 0      # no producer reads 7e9 elems
+        @test st(fpid).n_skipped_scatters == 1      # producer 2 excluded by hand
+        # … and it is producer 2's scatter, not the other one, that survived
+        @test [q.pid for q in ESMs.oop_ssa_producers(fpid) if !q.skip] == [2]
+        @test [q.pid for q in ESMs.oop_ssa_producers(fpid) if q.skip] == [3]
+        # the default ships a gate that is not degenerate on these fixtures
+        @test st(fdef).n_skipped_scatters == 2
+    end
+
+    @testset "values and derivatives are identical in every arm" begin
+        for probe in (u0, _s_seed(length(u0))), t in (0.0, 0.37)
+            a = foff(probe, p, t)
+            @test a == _s_ip(fip, probe, p, t)
+            for f in ARMS
+                @test f(probe, p, t) == a
+            end
+        end
+        u = _s_seed(length(u0))
+        J = ForwardDiff.jacobian(uu -> foff(uu, p, 0.2), u)
+        for f in ARMS
+            @test ForwardDiff.jacobian(uu -> f(uu, p, 0.2), u) == J
+        end
+    end
+end
+
+@testset "oop_ssa_producers: the gate's evidence table" begin
+    # The table is what the discriminator was chosen from, so its columns are
+    # asserted against shapes whose read structure is known by construction.
+    @testset "fan-out: two producers, every consumer reads both whole" begin
+        (f, _, _, _, _) = _s_build_gate(_s_fan(7, 4))
+        pr = ESMs.oop_ssa_producers(f)
+        @test length(pr) == 2
+        @test [q.pid for q in pr] == [2, 3]
+        @test all(q -> q.len == 7, pr)
+        # each of the 4 consumer classes reads g and v as a WHOLE block, so
+        # every read of every producer is a tier-1 reference
+        @test all(q -> q.nread == 4, pr)
+        @test all(q -> q.nwhole == 4, pr)
+        @test all(q -> q.elread == 28, pr)
+        @test all(q -> q.skippable && q.skip, pr)
+        @test all(q -> isempty(q.why), pr)
+        @test all(q -> q.level == 1, pr)
+    end
+
+    @testset "merged class: one producer, member reads are slices" begin
+        (f, _, _, _, _) = _s_build_gate(_s_merged(6))
+        pr = ESMs.oop_ssa_producers(f)
+        @test length(pr) == ESMs.oop_ssa_stats(f).n_producers
+        # g1/g2 merge into ONE 12-slot producer read by two 6-element slices,
+        # so nothing takes the whole value and the read volume equals it
+        q = only(filter(q -> q.len == 12, pr))
+        @test q.nwhole == 0
+        @test q.nread == 2
+        @test q.elread == 12
+        @test q.skippable && q.skip
+    end
+
+    @testset "empty with the flag off" begin
+        (f, _, _, _, _) = withenv("ESS_OOP_SSA" => nothing) do
+            ESMs.build_evaluator(_s_fan(7, 4); form = :oop)
+        end
+        @test isempty(ESMs.oop_ssa_producers(f))
+        @test ESMs.oop_ssa_stats(f).enabled == false
+    end
+end
+
+# ---------------------------------------------------------------------------
+# `ESS_OOP_SSA_SKIP_WHOLE`, the measured discriminator: the skip is
+# ALL-OR-NOTHING per build. With even one producer still scattering, `ue` is
+# assembled anyway, so a partial skip pays for the flat buffer AND for the
+# skipped producers' own values; only a build where every producer can go
+# actually retires the buffer.
+#
+# The fixture needs a build with TWO producers where one can be blocked ON
+# DEMAND, which `ESS_OOP_SSA_PGATHER=0` does: `v` is read REVERSED (L runs of
+# length 1, past the slice bound), so without tier 2b that read stays on the
+# dense `ue` gather and holds `v`'s scatter alive, while `g`'s whole-block read
+# redirects either way.
+function _s_mixed(N)
+    _s_doc("SSAMIX",
+        Dict{String,Any}("u" => _s_state(shape = Any["n"]),
+                         "g" => _s_state(shape = Any["n"]),
+                         "v" => _s_state(shape = Any["n"]),
+                         "k" => _s_param(0.25)),
+        Any[Dict{String,Any}("lhs" => "g",
+                "rhs" => _s_ao(_s_o("+", _s_o("*", 2.0, _s_ix("u", "i")), 1.0))),
+            Dict{String,Any}("lhs" => "v",
+                "rhs" => _s_ao(_s_o("*", _s_ix("u", "i"), _s_ix("u", "i")))),
+            Dict{String,Any}("lhs" => _s_ao(_s_Dt(_s_ix("u", "i"))),
+                "rhs" => _s_ao(_s_o("-",
+                    _s_o("*", "k", _s_o("+", _s_ix("g", "i"),
+                         _s_ix("v", _s_o("-", Float64(N + 1), "i")))),
+                    _s_ix("u", "i"))))],
+        N)
+end
+
+@testset "the skip is all-or-nothing (ESS_OOP_SSA_SKIP_WHOLE)" begin
+    N = 24
+    doc = _s_mixed(N)
+    # both producers redirectable ⇒ the whole gate is satisfied either way
+    (fall, u0, p, _, _) = _s_build_gate(doc)
+    (fallp, _, _, _, _) = _s_build_gate(doc, "ESS_OOP_SSA_SKIP_WHOLE" => "0")
+    # tier 2b off ⇒ `v` keeps its scatter, so the build is only PARTIALLY
+    # skippable: the whole gate then declines every skip, and `=0` restores the
+    # partial one (#283's behaviour)
+    (fpart, _, _, _, _) = _s_build_gate(doc, "ESS_OOP_SSA_PGATHER" => "0")
+    (fpartp, _, _, _, _) = _s_build_gate(doc, "ESS_OOP_SSA_PGATHER" => "0",
+                                         "ESS_OOP_SSA_SKIP_WHOLE" => "0")
+    (foff, _, _, _, _) = withenv("ESS_OOP_SSA" => nothing) do
+        ESMs.build_evaluator(doc; form = :oop)
+    end
+    (fip, _, _, _, _) = ESMs.build_evaluator(doc)
+    st(f) = ESMs.oop_ssa_stats(f)
+
+    @test st(fall).n_producers == 2
+    @test st(fall).n_skippable_scatters == 2
+    @test st(fall).n_skipped_scatters == 2          # nothing to gate
+    @test st(fallp).n_skipped_scatters == 2
+    # the negative control: one producer blocked ⇒
+    @test st(fpart).n_skippable_scatters == 1       # … static verdict unmoved
+    @test st(fpart).n_skipped_scatters == 0         # … and the gate declines it
+    @test st(fpart).n_gate_declined == 1
+    @test st(fpartp).n_skipped_scatters == 1        # … which `=0` undoes
+    @test [q.pid for q in ESMs.oop_ssa_producers(fpartp) if q.skip] ==
+          [q.pid for q in ESMs.oop_ssa_producers(fpart) if q.skippable]
+    # the gate is a cost decision, so it may not move a number
+    for probe in (u0, _s_seed(length(u0))), t in (0.0, 0.41)
+        a = foff(probe, p, t)
+        @test a == _s_ip(fip, probe, p, t)
+        for f in (fall, fallp, fpart, fpartp)
+            @test f(probe, p, t) == a
+        end
+    end
+    J = ForwardDiff.jacobian(uu -> foff(uu, p, 0.2), _s_seed(N))
+    for f in (fall, fallp, fpart, fpartp)
+        @test ForwardDiff.jacobian(uu -> f(uu, p, 0.2), _s_seed(N)) == J
+    end
+end


### PR DESCRIPTION
## What this is

**Stacks on #283** (`perf/ssa-read-redirect-arms`). GitHub will not take a
fork-hosted base branch, so this is opened against `main` and carries #283's
three commits underneath — **review only the last three commits**
(`3cc30d3bd`, `12ebd6799`, `84c7989e5`); everything before them is #283.

#283 made the `ess-oop-ssa` scatter-skip pay on chemistry and cost on
transport, and its own recommendation said the emitter "could gate the
scatter-skip on producer block size". **It measured, and block size is the
wrong quantity.** This adds the gate, on the quantity that turns out to
discriminate, and the loop goes 1.19x -> 1.26x.

## The verdict was STATIC; it needed to be a COST

The spike skipped a producer's `dynamic_update_slice` into the flat extended
buffer `ue` whenever static accounting showed nothing reads its block off the
buffer any more. Redundant is not the same as expensive: a DUS ALIASES its
operand in the forward, so XLA:CPU writes only the update and can fuse the
producer's spine straight into `ue`'s memory. Dropping it takes that away.

## The discriminator, and what it is not

`oop_ssa_producers(f)` is new reflection: per tracked producer, its fill level,
value length, how many redirected read surfaces now source from it and at what
element volume, how many take the whole value with no op at all, the
residual-read reasons, and both verdicts. On ReSEACT at 6x6x8 it says:

| | transport (part 1) | chemistry (part 2) |
|---|---|---|
| producers | 17 | 59 |
| statically skippable | 13 | **59 — all of them** |
| largest skipped block | 3 456 | **20 736** (then 10 368, 5 184) |
| redirected read volume / block | 0.125 … 58 230 | 1.0 … 198 |
| tier-1 whole-value reads | 4 producers, 1 each | 30+ producers, up to 87 |

**Block size is refuted**: chemistry skips producers 6x larger than
transport's largest and WINS. The read-volume ratio spans both extremes on
transport alone, so it does not separate the halves either.

What differs is **whether the flat buffer can DIE**. Chemistry skips 59 of 59,
so nothing scatters into `ue` and the whole buffer (12 326 elements at 6x6x8,
247 423 at CONUS) is dead code. Transport skips 13 of 17, so `ue` is assembled
anyway — and a PARTIAL skip pays twice: the four survivors still write the
buffer, AND each skipped producer's value becomes a buffer of its own instead
of fusing into an aliasing DUS.

### The test that could have refuted this

"A partial skip pays twice" and "one big producer is the problem" both predict
the regression; they differ on what dropping ONE skip does.
`ESS_OOP_SSA_SKIP_PIDS=!17` drops the skip of the largest producer (3 456
elements at 6x6x8, 78 624 at CONUS — 15x the next) and keeps the other twelve:

| `ssp_step` at 4x5 CONUS | flag off | #283 (13 of 17) | `!17` (12 of 17) |
|---|---|---|---|
| | 14.433 ms | 24.397 ms (0.592) | 24.768 ms (**0.583**) |

`no17` is not better than `ungated`. Size is not what makes a skip expensive;
partialness is. That is why the gate is all-or-nothing and why the two
per-producer bounds ship RELEASED — they are the refuted hypotheses, kept
bisectable.

## What changed

```
ESS_OOP_SSA_SKIP_WHOLE=1   (default) skip only when EVERY tracked producer's
                           scatter can go, so `ue` actually retires
ESS_OOP_SSA_SKIP_WHOLE=0   allow partial skipping (what #283 shipped)
ESS_OOP_SSA_SKIP=0         never skip — the negative control for the gate
ESS_OOP_SSA_SKIP_MAXLEN=n  per-producer block-size bound   (RELEASED by
ESS_OOP_SSA_SKIP_MINRATIO=x per-producer read-volume bound   default)
ESS_OOP_SSA_SKIP_PIDS=3,7  per-producer bisect; `!3,7` inverts
```

Following #283's pattern: every knob rides inside `ESS_OOP_SSA=1`, so one
process can A/B an arm and every engagement test has a negative control.

The verdict is now two passes — the static one, then the gate — and declining
a skip is always CORRECT: it emits a write nothing reads, exactly what the
flag-off build does. The gate touches ONLY whether the scatter is emitted; the
redirect tables are untouched, so `n_skippable_scatters` (a read-graph fact) is
identical in every arm and only `n_skipped_scatters` moves, with
`n_gate_declined` the difference. The redirect arms are not touched at all.

On ReSEACT the default gate leaves **chemistry structurally identical to #283**
(59 of 59 skipped, `n_gate_declined = 0`, edges 563/563) and takes **transport
to 0 of 17** with `n_skippable_scatters` still 13 and coverage unchanged
(97/100 top-level, 731/885 sub-kernel) — the redirects without the skip.

## Measured at 4x5 CONUS

13x7x72, 6 552 cells; three arms in ONE process, interleaved, both arm orders.
`noskip` is what the gate emits on transport, `ungated` is #283.

| program | flag off | gate | #283 |
|---|---|---|---|
| `ssp_step` (4-stage transport) | 14.668 ms | 19.887 ms (**0.738**) | 21.310 ms (0.688) |
| `rhs` (transport RHS) | 4.127 ms | 4.938 ms (**0.836**) | 6.523 ms (0.633) |
| `ssp_vjp` | 360.279 ms | 251.832 ms (**1.431**) | (1.203) |
| `ssp_vjp`, arms reversed | 347.620 ms | 254.526 ms (**1.366**) | |
| `ros_step` (chemistry) | | 1.38 | 1.38 |
| `ros_vjp` (chemistry) | | 1.43 | 1.43 |

The gate improves **both** sides of the transport trade: it roughly halves the
primal regression and it RAISES the VJP from 1.203 to 1.37-1.43, because the
redirects pay better once a partial skip is not working against them.

### The loop, counting replay

The adjoint evaluates the primal TWICE per accepted step — the forward
`T.step` and the backward `T.replay` — and the VJP once, so a primal
regression is paid twice against one VJP win. A per-window step+vjp mix
(#283's 1.36x) does not price that. Against the measured 2x2.5 48 h
decomposition (576 windows; transport step+replay 427 s, transport vjp
2 048 s):

| term | flag off | #283 | + this gate |
|---|---|---|---|
| chemistry (step + replay + vjp) | 5 106 s | 3 633 s | 3 633 s |
| transport (step + replay + vjp) | 2 475 s | 2 411 s | **1 995 s** |
| refresh | 1 792 s | 1 792 s | 1 792 s |
| host remainder | 123 s | 123 s | 123 s |
| **loop** | **9 495 s** | 7 959 s (1.19x) | **7 543 s (1.26x)** |

Transport was a WASH under #283 — the 1.20x VJP win almost exactly cancelled
the doubled primal regression, so the entire 1.19x was chemistry. With the gate
transport is a real 1.24x. 1.257x was PREDICTED from the break-even arithmetic
before the VJP was measured; 1.26x came back.

## The criterion NOT met

The bar for this work was the transport primal back to **>= 0.95** of flag-off.
It is **0.738** on `ssp_step` and 0.836 on `rhs`. The gate halves the
regression; it does not remove it, and 0.738 should not be read as success.

What makes it net-positive anyway is arithmetic, not judgement: the gate is
worth it iff `427 + 2048/r < 2411`, i.e. `ssp_vjp >= 1.032`. It delivers ~1.40.
So the trade is favourable by a wide margin rather than marginally — but a
caller that runs the transport primal with NO reverse at all is still 1.36x
worse off than flag-off (down from #283's 1.8x, not gone).

**Further work, not a claim**: with zero scatters skipped the only remaining
difference from flag-off is the redirects themselves, so something on the
transport primal still materializes that the flat-buffer gather did not — the
producer values the sub-kernel and tier-2b redirects read from. Pricing that
needs a redirect gate, which is a separate decision.

## Exactness

Unchanged, and it is the contract. Declining a skip only emits a write nothing
reads, so no arm can move a number:

* `:oop`(any gate arm) == `:oop`(off) == `:inplace` at Float64 `==`, and
  ForwardDiff jacobians `==`, on every fixture — asserted across all seven
  arms, not just the default.
* With the flag OFF every structure is the empty singleton and the emitted
  program is byte-for-byte the pre-spike emitter.
* Traced at CONUS the gate can only move transport CLOSER to flag-off, since it
  removes emitter changes rather than adding them; #283's figures (`ros_step`
  and `ros_vjp` λ bit-for-bit, `ssp_step` 5.6e-15 absolute = 1.1e-18 of scale,
  not one of 85 176 components over 1e-9 of scale) therefore bound this build.
  Note that the POINTWISE relative metric reads a spurious `2.0` on
  opposite-signed components at ~1e-310, which is why the probes report
  absolute and SCALE-relative figures plus a component count.

## Tests

141 new assertions in `test/tree_walk_oop_ssa_test.jl`, every knob with a
negative control:

* **the gate moves ONLY the skip verdict** — across all seven arms,
  `n_skippable_scatters`, `n_fast`, `elems_fast` and `n_sub_fast` are pinned
  equal and `n_skipped + n_gate_declined` is invariant;
* **each knob declines what it says it declines** — ungated == 2, master off
  == 0, `MAXLEN=1` == 0, `MINRATIO=1e9` == 0, `PIDS=!2` == 1 *and it is
  producer 2's scatter that survived*, and the shipped default is not
  degenerate on the fixtures;
* **the all-or-nothing cascade** on a new fixture (`_s_mixed`) whose second
  producer can be blocked ON DEMAND: `ESS_OOP_SSA_PGATHER=0` leaves the build
  only partially skippable, the whole gate then declines every skip
  (`n_gate_declined == 1` with `n_skippable_scatters` unmoved at 1), and
  `ESS_OOP_SSA_SKIP_WHOLE=0` restores exactly the producer the static verdict
  named;
* **the producer table's columns** against shapes whose read structure is known
  by construction — the fan-out's two 7-element producers at `nread == 4`,
  `nwhole == 4`, `elread == 28`, and the merged class's ONE 12-slot producer
  read by two 6-element slices at `nwhole == 0`, `nread == 2`, `elread == 12`;
* **values and derivatives in every arm**, `==` against flag-off and
  `:inplace`.

`tree_walk_oop_ssa_test.jl`: 45 + 88 + 16 + 17 + 92 + 16 + 33, all green.

## Recommendation on defaulting `ESS_OOP_SSA`

#283 recommended defaulting it with the caveat that "the transport forward is
1.8x slower, so a caller that runs the transport primal without a reverse is
worse off". **This gate reduces that caveat but does not remove it**: such a
caller is 1.36x worse off, not 1.8x. So the honest answer is:

* **for an adjoint / gradient workload, yes** — the loop is 1.26x cheaper
  counting replay, both halves now win in both directions, and chemistry is
  exact;
* **the caveat stands in weaker form** for a primal-only transport caller, and
  the second of #283's caveats stands unchanged: flag-on is not bit-identical
  to flag-off in the traced transport path (5.6e-15, 1.1e-18 of scale), so
  defaulting it changes numbers for existing traced users and should be a noted
  change, not a silent one.

I would default `ESS_OOP_SSA=1` and note both, rather than default it silently.

## Not verified here

The ReSEACT timings live in the consuming repo (`tools/diag/p14_ssa_gate.jl`,
the N-arm successor to `p13_ssa_ab.jl`, plus `p14_gate_primal.sbatch`); they
need the offline forcing environment. The whole-extended-buffer copy census was
not re-run for the gate — the timing three-arm A/B was the priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
