### PR TITLE
test(fixtures)!: reduce the isrm corpus fixture to unit-test extents

### DIFF
--- a/pkg/EarthSciAST.jl/src/errors.jl
+++ b/pkg/EarthSciAST.jl/src/errors.jl
@@ -51,3 +51,28 @@ root only so the rule "every exception in the package is an
 `EarthSciASTError`" has no exceptions.
 """
 abstract type EarthSciASTError <: Exception end
+
+"""
+    _is_resource_error(e) -> Bool
+
+True for the exceptions that mean THE PROCESS ran out of something, not that
+the DOCUMENT is wrong: `OutOfMemoryError`, `StackOverflowError` and
+`InterruptException`.
+
+Several passes bracket a speculative evaluation in a broad `catch` and, on
+failure, either decline (fall through to a slower form) or rebrand the failure
+as the diagnostic that describes the document — "this RHS does not const-fold",
+say. Both readings are wrong for a resource error. A rebranded one is worse
+than merely wrong: `TreeWalkError` is on the `_foldable_failure` allowlist and
+is swallowed outright at several `err isa TreeWalkError || rethrow()` sites, so
+wrapping an `OutOfMemoryError` in one can turn running out of memory into a
+silent decline several frames up. Test-side corpus sweeps then record it as an
+ordinary "this model cannot build standalone" skip and stay green.
+
+So every such site MUST let these three through unwrapped before it decides
+anything. The sweeps keep their own copy of this predicate
+(`corpus_is_resource_error` in test/testutils.jl) as a backstop, but the
+library is expected not to make it fire.
+"""
+_is_resource_error(e) =
+    e isa OutOfMemoryError || e isa StackOverflowError || e isa InterruptException

--- a/pkg/EarthSciAST.jl/src/lower_expression_templates.jl
+++ b/pkg/EarthSciAST.jl/src/lower_expression_templates.jl
@@ -1450,7 +1450,8 @@ function _validate_manifolds_in_refs(node, named::AbstractDict,
         if name != "" && get(manifold_bearing, name, false)
             expansion = try
                 _expand_all(node, named, path)
-            catch
+            catch err
+                _is_resource_error(err) && rethrow()
                 nothing
             end
             if expansion !== nothing
@@ -2430,7 +2431,8 @@ function _esm_stamp_floor(declared)
     declared isa AbstractString || return TEMPLATE_MACHINERY_MIN_ESM
     parse_v(v) = try
         Tuple(parse(Int, p) for p in split(split(String(v), '-')[1], '.'))
-    catch
+    catch err
+        _is_resource_error(err) && rethrow()
         nothing
     end
     d = parse_v(declared)

--- a/pkg/EarthSciAST.jl/src/pointwise_lift.jl
+++ b/pkg/EarthSciAST.jl/src/pointwise_lift.jl
@@ -73,7 +73,8 @@ function _detect_lift_loops(ma::OpExpr, lifted::Set{String}, rank::Int,
             body = get!(peek, e) do
                 try
                     _expand_expr_refs(e, reg)
-                catch
+                catch err
+                    _is_resource_error(err) && rethrow()
                     # Unknown template / bad bindings: leave detection to fail
                     # as before; the build path raises the real diagnostic.
                     nothing
@@ -340,7 +341,8 @@ function _lift_axis_names(mas::Vector{OpExpr}, loops::Vector{String},
             body = get!(peek, e) do
                 try
                     _expand_expr_refs(e, reg)
-                catch
+                catch err
+                    _is_resource_error(err) && rethrow()
                     nothing   # unknown template: the build path raises the real diagnostic
                 end
             end

--- a/pkg/EarthSciAST.jl/src/tree_walk/build.jl
+++ b/pkg/EarthSciAST.jl/src/tree_walk/build.jl
@@ -553,7 +553,14 @@ function _materialized_obs_dims(def::ASTExpr, shape, index_sets::AbstractDict,
                 haskey(ranges, n) || return nothing
                 r = try
                     collect(_expand_int_range(ranges[n]))
-                catch
+                catch err
+                    # A range this pass cannot read as a dense integer interval
+                    # means "not a declared-dims producer" — decline. Running
+                    # out of memory MATERIALIZING one does not: `collect` on a
+                    # huge range is exactly how a document's own extents exhaust
+                    # the allocator, and declining here would hide that behind a
+                    # shape the caller reports some other way.
+                    _is_resource_error(err) && rethrow()
                     return nothing
                 end
                 (!isempty(r) && r == collect(1:length(r))) || return nothing

--- a/pkg/EarthSciAST.jl/src/tree_walk/build.jl
+++ b/pkg/EarthSciAST.jl/src/tree_walk/build.jl
@@ -1389,6 +1389,11 @@ function _fold_ic_equations(equations::Vector{Equation}, model::Model,
                     Float64(evaluate_expr(eq.rhs, param_scope;
                                           registered_functions=registered_functions))
                 catch err
+                    # Running out of memory or stack is not a statement about
+                    # this RHS, and a `TreeWalkError` saying it is would be
+                    # swallowed as an ordinary decline further up
+                    # (`_is_resource_error`).
+                    _is_resource_error(err) && rethrow()
                     throw(TreeWalkError("E_TREEWALK_UNSUPPORTED_EQUATION",
                         "ic($(vn)) RHS must const-fold to a scalar for the " *
                         "tree-walk path ($(sprint(showerror, err)))"))

--- a/pkg/EarthSciAST.jl/src/tree_walk/geometry_setup.jl
+++ b/pkg/EarthSciAST.jl/src/tree_walk/geometry_setup.jl
@@ -1346,10 +1346,14 @@ function _materialize_setup_general_map(rhs::OpExpr, env::AbstractDict,
             # Anything the compiled tree cannot evaluate (a gather the guards did
             # not anticipate, an unsupported leaf) → the per-cell reference below,
             # which reproduces the original values or the original error. A
-            # user interrupt is NOT a fallback trigger: this sweep can be long,
-            # and silently restarting it on the slower path is the opposite of
-            # what Ctrl-C asked for.
-            err isa InterruptException && rethrow()
+            # RESOURCE error is NOT a fallback trigger: a user interrupt asked
+            # for this sweep to stop, not to restart on the slower path, and
+            # running out of memory or stack says nothing about whether the
+            # compiled tree can evaluate this map — the per-cell path allocates
+            # the same output array and would only fail again, later and with
+            # the cause erased. Path selection for every OTHER error is
+            # untouched: still `nothing`, still the per-cell reference.
+            _is_resource_error(err) && rethrow()
             nothing
         end
         if fast !== nothing

--- a/pkg/EarthSciAST.jl/src/tree_walk/helpers.jl
+++ b/pkg/EarthSciAST.jl/src/tree_walk/helpers.jl
@@ -721,7 +721,8 @@ function _try_field_ic_fastpath(rhs, params::AbstractDict,
     end
     node = try
         _compile(body, Dict{String,Int}(), Set{Symbol}(psyms), reg)
-    catch
+    catch err
+        _is_resource_error(err) && rethrow()
         return nothing   # anything the closed-form guard missed → per-cell fallback
     end
     pbase = Float64[Float64(params[k]) for k in pkeys]
@@ -856,7 +857,8 @@ function _cellwise_compile_once_impl(expr::EarthSciAST.ASTExpr, nidx::Int,
                                     Dict{String,Int}(), const_arrays,
                                     _EMPTY_PGATHER, nothing, bound)
         _compile(resolved, Dict{String,Int}(), Set{Symbol}(psyms), reg)
-    catch
+    catch err
+        _is_resource_error(err) && rethrow()
         return nothing   # anything unsupported → per-cell fallback
     end
     base = ntuple(i -> Float64(params[pkeys[i]]), length(pkeys))

--- a/pkg/EarthSciAST.jl/src/tree_walk/helpers.jl
+++ b/pkg/EarthSciAST.jl/src/tree_walk/helpers.jl
@@ -546,6 +546,10 @@ function _resolve_field_ic(target::AbstractString, rhs::EarthSciAST.ASTExpr,
         return Float64(evaluate_expr(rhs, params;
                                      registered_functions=registered_functions))
     catch err
+        # A resource error is not a reason to try the NEXT form — the next form
+        # allocates too — and step (4) would rebrand it as a statement about
+        # this RHS. Out, unwrapped.
+        _is_resource_error(err) && rethrow()
         push!(_errs, "as constant: $(sprint(showerror, err))")
     end
     # (3) Coordinate expression over the grid geometry (per-cell field); model
@@ -556,6 +560,7 @@ function _resolve_field_ic(target::AbstractString, rhs::EarthSciAST.ASTExpr,
                                   registered_functions=registered_functions,
                                   params=params)
         catch err
+            _is_resource_error(err) && rethrow()
             push!(_errs, "as coordinate expression: $(sprint(showerror, err))")
         end
     end

--- a/pkg/EarthSciAST.jl/src/tree_walk/oop_merge.jl
+++ b/pkg/EarthSciAST.jl/src/tree_walk/oop_merge.jl
@@ -549,7 +549,8 @@ function _merge_oop_acc_kernels(kernels::AbstractVector{_AccKernel},
             K = _oop_merge_group(kernels, plans, js)
             pl = _build_oop_acc_plan(K)
             pl.vectorizable ? (K, pl) : nothing
-        catch
+        catch err
+            _is_resource_error(err) && rethrow()
             nothing
         end
         if merged === nothing
@@ -976,7 +977,8 @@ function _merge_oop_x_kernels(kernels::AbstractVector{_AccKernel},
             K = _oop_x_merge_group(kernels, plans, js)
             pl = _build_oop_acc_plan(K)
             pl.vectorizable ? (K, pl) : nothing
-        catch
+        catch err
+            _is_resource_error(err) && rethrow()
             nothing
         end
         if merged === nothing

--- a/pkg/EarthSciAST.jl/src/tree_walk/resolve.jl
+++ b/pkg/EarthSciAST.jl/src/tree_walk/resolve.jl
@@ -553,7 +553,8 @@ function _try_build_contraction_loop(body::ASTExpr, contract_names::Vector{Strin
         # concrete RHS-build memo (same invariant the compile-once path relies on).
         _resolve_indices(subbed, array_var_info, var_map, const_arrays,
                          pgather, nothing, bsyms)
-    catch
+    catch err
+        _is_resource_error(err) && rethrow()
         return nothing
     end
     # Publish the refs so `_compile` lowers each surviving loop-var `VarExpr` to an

--- a/pkg/EarthSciAST.jl/test/array_obs_materialize_test.jl
+++ b/pkg/EarthSciAST.jl/test/array_obs_materialize_test.jl
@@ -6,6 +6,7 @@
 # gather that buffer (build.jl §2b-f). `ESS_ARRAY_OBS_INLINE=1` restores the
 # inlining build, which is the oracle every case below compares against —
 # bit-for-bit, not approximately.
+using Test
 include("testutils.jl")
 
 using EarthSciAST

--- a/pkg/EarthSciAST.jl/test/build_once_spatial_field_conformance_test.jl
+++ b/pkg/EarthSciAST.jl/test/build_once_spatial_field_conformance_test.jl
@@ -17,6 +17,7 @@ import SciMLBase
 import SciMLBase: solve, remake
 import OrdinaryDiffEqTsit5: Tsit5
 using JSON3
+include("testutils.jl")   # _require_fixture
 const _ESS_BO = EarthSciAST
 
 @testset "build_once_spatial_field conformance — setup makearray + gather into ODE (§5.12)" begin

--- a/pkg/EarthSciAST.jl/test/cg_foreign_scratch_test.jl
+++ b/pkg/EarthSciAST.jl/test/cg_foreign_scratch_test.jl
@@ -155,7 +155,8 @@ _cfs_ics(N) = Dict{String,Float64}("$x[$k]" => 0.2j + 0.01k
                 try
                     f!, u0, p, _t, _vm = ESM.build_evaluator(file; model_name=name)
                     return (f=f!, u0=u0, p=p)
-                catch
+                catch e
+                    corpus_is_resource_error(e) && rethrow()
                     return nothing
                 end
             end
@@ -164,7 +165,8 @@ _cfs_ics(N) = Dict{String,Float64}("$x[$k]" => 0.2j + 0.01k
             du = zeros(length(u0))
             try
                 f!(du, u0, p, t)
-            catch
+            catch e
+                corpus_is_resource_error(e) && rethrow()
                 return nothing
             end
             return du
@@ -174,7 +176,8 @@ _cfs_ics(N) = Dict{String,Float64}("$x[$k]" => 0.2j + 0.01k
         for path in esms
             file = try
                 ESM.load_path(path)
-            catch
+            catch e
+                corpus_is_resource_error(e) && rethrow()
                 continue
             end
             file.models === nothing && continue

--- a/pkg/EarthSciAST.jl/test/cross_eq_class_emission_test.jl
+++ b/pkg/EarthSciAST.jl/test/cross_eq_class_emission_test.jl
@@ -417,7 +417,8 @@ _xq_kernels(f!) = getfield(getfield(f!, :kernel_section), :kernels)
                 try
                     f!, u0, p, _t, _vm = ESM.build_evaluator(file; model_name=name)
                     return (f=f!, u0=u0, p=p, tally=copy(ESM._CASCADE_TALLY))
-                catch
+                catch e
+                    corpus_is_resource_error(e) && rethrow()
                     return nothing
                 end
             end
@@ -426,7 +427,8 @@ _xq_kernels(f!) = getfield(getfield(f!, :kernel_section), :kernels)
             du = zeros(length(u0))
             try
                 f!(du, u0, p, t)
-            catch
+            catch e
+                corpus_is_resource_error(e) && rethrow()
                 return nothing
             end
             return du
@@ -439,7 +441,8 @@ _xq_kernels(f!) = getfield(getfield(f!, :kernel_section), :kernels)
         for path in esms
             file = try
                 ESM.load_path(path)
-            catch
+            catch e
+                corpus_is_resource_error(e) && rethrow()
                 skipped += 1
                 continue
             end

--- a/pkg/EarthSciAST.jl/test/data_source_url_conformance_test.jl
+++ b/pkg/EarthSciAST.jl/test/data_source_url_conformance_test.jl
@@ -1,6 +1,7 @@
 using Test
 using EarthSciAST
 using JSON3
+include("testutils.jl")   # TESTUTILS_REPO_ROOT
 
 # esm-spec §8.2.1 data-source location resolution, against the SHARED pin.
 #

--- a/pkg/EarthSciAST.jl/test/discrete_materialize_conformance_test.jl
+++ b/pkg/EarthSciAST.jl/test/discrete_materialize_conformance_test.jl
@@ -28,6 +28,7 @@ using DiffEqCallbacks            # loads EarthSciASTDataRefreshExt
 using SciMLBase                  # ext co-trigger (u_modified!)
 import OrdinaryDiffEqTsit5 as ODE  # Tsit5 + ODEProblem + solve (test-only solver dep)
 using JSON3
+include("testutils.jl")   # _require_fixture
 const _ESS_DM = EarthSciAST
 
 # A minimal offline mock Provider returning `src` at each interior anchor from the

--- a/pkg/EarthSciAST.jl/test/oop_scalar_batch_test.jl
+++ b/pkg/EarthSciAST.jl/test/oop_scalar_batch_test.jl
@@ -20,9 +20,9 @@
 #     Dual walk keeps the power rule — groups never blend exponents);
 #   * ForwardDiff through the batched path;
 #   * `ESS_OOP_BATCH=0` restores the pre-feature closure (kill switch).
+using Test
 include("testutils.jl")
 
-using Test
 using ForwardDiff
 using EarthSciAST
 const _OB_ESS = EarthSciAST

--- a/pkg/EarthSciAST.jl/test/reactant_param_vector_test.jl
+++ b/pkg/EarthSciAST.jl/test/reactant_param_vector_test.jl
@@ -26,6 +26,7 @@
 using Test
 using Reactant
 using ComponentArrays
+using ForwardDiff
 
 const _PVR_RX = Reactant
 const _PVR_Enzyme = Reactant.Enzyme

--- a/pkg/EarthSciAST.jl/test/reactant_parameter_gradient_test.jl
+++ b/pkg/EarthSciAST.jl/test/reactant_parameter_gradient_test.jl
@@ -39,6 +39,7 @@
 
 using Test
 using Reactant
+using ForwardDiff
 
 const _PGR_RX = Reactant
 # Enzyme is a dependency OF Reactant, not of the test environment — reaching it

--- a/pkg/EarthSciAST.jl/test/recurrence_validation_test.jl
+++ b/pkg/EarthSciAST.jl/test/recurrence_validation_test.jl
@@ -14,6 +14,7 @@
 
 using Test
 using EarthSciAST
+using JSON3
 using OrderedCollections: OrderedDict
 
 include("testutils.jl")  # TESTUTILS_REPO_ROOT + the _v/_i/_op/_idx AST quartet

--- a/pkg/EarthSciAST.jl/test/runtests.jl
+++ b/pkg/EarthSciAST.jl/test/runtests.jl
@@ -18,6 +18,13 @@ include("testutils.jl")  # shared prelude: repo root, AST builders, _normj, _req
     # `EarthSciASTError` root, or a diagnostic code spelled as an inline literal.
     include("error_hierarchy_test.jl")
 
+    # ---- Test-file prelude hygiene (this directory) ----
+    # The third such invariant, and the one THIS file is complicit in: every
+    # name is already in `Main` by the time a given include runs, so a file that
+    # imports nothing passes here and dies standalone. Early, and reading only
+    # text, so it costs nothing and reports before the run it cannot trust.
+    include("test_file_prelude_test.jl")
+
     # ---- Core types, parse, validate, display (src/types.jl, parse.jl,
     #      validate.jl, display.jl, graph.jl) ----
     include("types_test.jl")

--- a/pkg/EarthSciAST.jl/test/subsystem_loader_conformance_test.jl
+++ b/pkg/EarthSciAST.jl/test/subsystem_loader_conformance_test.jl
@@ -18,6 +18,7 @@ import SciMLBase
 import SciMLBase: solve, remake
 import OrdinaryDiffEqTsit5: Tsit5
 using JSON3
+include("testutils.jl")   # _require_fixture
 const _ESS_SL = EarthSciAST
 
 # Offline CONST stub provider: returns a fixed field array (empty refresh_times ⇒

--- a/pkg/EarthSciAST.jl/test/subsystem_ref_test.jl
+++ b/pkg/EarthSciAST.jl/test/subsystem_ref_test.jl
@@ -1,3 +1,7 @@
+using Test
+using EarthSciAST
+using JSON3
+
 @testset "Subsystem Reference Resolution Tests" begin
 
     @testset "SubsystemRefError construction" begin

--- a/pkg/EarthSciAST.jl/test/test_file_prelude_test.jl
+++ b/pkg/EarthSciAST.jl/test/test_file_prelude_test.jl
@@ -1,0 +1,317 @@
+# Every test file carries the prelude it uses.
+#
+# testutils.jl documents that each file "still runs standalone
+# (`julia --project -e 'using EarthSciAST, Test; include("test/<file>")'`) AND
+# under runtests.jl". Under runtests.jl a file can violate that and pass anyway:
+# `runtests.jl` opens with `using Test` / `using EarthSciAST` / `using JSON3` /
+# `include("testutils.jl")`, and 200 more includes follow, so by the time any
+# given file runs, almost every name it might want is already in `Main`. Borrow
+# one and nothing notices — until someone runs that file on its own (the
+# documented way to verify Julia here, since the full test target hangs on the
+# shared depot lock) and it dies on an `UndefVarError` before the first
+# assertion. Eleven files had drifted that way before this check existed.
+#
+# So: for each file, what does it USE, and does it IMPORT that?
+#
+#   1. a `@test…` / `@inferred` macro          ⇒ `using Test`
+#   2. `include("testutils.jl")`               ⇒ `using Test` ABOVE that line —
+#      the prelude expands a `@test_skip` of its own as it is included, so this
+#      one is an ordering requirement, not just a presence one
+#   3. a name testutils.jl defines             ⇒ `include("testutils.jl")`
+#   4. `SomeModule.something`, where the name
+#      is a package this project declares      ⇒ `using SomeModule`
+#
+# Nothing here is hard-coded. The testutils names in (3) are read out of
+# testutils.jl, the modules the prelude itself imports (and therefore hands to
+# its includer, which is why (4) does not fire on a file that includes it) are
+# read out of testutils.jl too, and the package names in (4) out of
+# Project.toml's `[deps]` / `[weakdeps]` / `[extras]` plus the package's own
+# `name` — so a new helper or a new test dependency is covered the day it lands.
+#
+# SCOPE is every `test/*.jl` except `runtests.jl` itself, which is the driver
+# that establishes the preamble rather than a file that needs one. There is no
+# skip list: an included FRAGMENT (testutils.jl, zero_alloc_harness.jl, the two
+# Reactant files) is held to the same bar as an entry point, because a fragment
+# that imports what it uses costs nothing and a fragment that does not is one
+# `include` away from being the next silent failure.
+#
+# WHAT THIS CANNOT CATCH. It is static: it verifies the prelude is PRESENT, not
+# that the file actually runs in a fresh process. A module reached dynamically
+# (`getfield(Main, :JSON3)`, a name interpolated into `@eval`, a macro that
+# expands to a reference) is invisible to it, and so is a missing import behind
+# any construct the parser does not surface as a qualified reference. It also
+# says nothing about whether the file's ASSERTIONS pass.
+#
+# The evidence for it is agreement, on the case that motivated it, with actually
+# running files in fresh processes: every file it flagged and this environment
+# could run did fail standalone with the named `UndefVarError`, every one passed
+# standalone once the named line was added, and the handful run as controls
+# (files it does NOT flag, including one that reaches `JSON3` only through the
+# prelude it includes) ran clean. That is agreement on ~15 files, not a sweep of
+# all 220 — a measurement, not a guarantee about the next file.
+#
+# If this fails, add the line it names. Do not narrow the docstring.
+
+# `Test` and nothing else: this file reads the tree, it does not build anything.
+# It does not include testutils.jl either — it uses none of those helpers, and an
+# import a file does not need is the other half of the habit this check is about.
+using Test
+
+const _PRELUDE_TEST_DIR = @__DIR__
+const _PRELUDE_PKG_DIR  = normpath(joinpath(_PRELUDE_TEST_DIR, ".."))
+
+# ---------------------------------------------------------------------------
+# AST walk. `Meta.parseall` reads a file without running it, so the scan sees
+# the file as Julia does rather than as a regex does — a `@test` inside a
+# comment or a docstring is simply not in the tree.
+# ---------------------------------------------------------------------------
+
+"""
+    _prelude_facts(path) -> NamedTuple
+
+What one test file imports, uses and defines.
+
+  * `bound`     — module names the file brings into scope (`using M`,
+                  `import M`, `import M as N` ⇒ `N`). A `using M: x` binds `x`
+                  and NOT `M`, and is deliberately not counted: a file that
+                  writes `M.something` after `using M: x` really is missing an
+                  import (checked — Julia leaves `M` undefined there).
+  * `macros`    — every macro the file calls, by name (`Symbol("@testset")`).
+  * `qualified` — every `M` appearing as `M.something`.
+  * `includes`  — every literal `include("…")` target.
+  * `defined`   — every name the file itself binds, so a local helper that
+                  happens to share a testutils name is not counted as borrowing
+                  it, and an alias (`const ESM = EarthSciAST`) is not read as a
+                  missing import.
+  * `symbols`   — every symbol anywhere in the tree, for the testutils check.
+"""
+function _prelude_facts(path::AbstractString)
+    bound     = Set{Symbol}()
+    macros    = Set{Symbol}()
+    qualified = Set{Symbol}()
+    includes  = Set{String}()
+    defined   = Set{Symbol}()
+    symbols   = Set{Symbol}()
+
+    # `Expr(:., :M)` inside a using/import clause; `Expr(:as, clause, :N)`.
+    function modname(e)
+        e isa Expr || return nothing
+        e.head === :. && !isempty(e.args) && e.args[1] isa Symbol && return e.args[1]
+        return nothing
+    end
+    function walk_useclause(e)
+        e isa Expr || return
+        if e.head === :as
+            length(e.args) == 2 && e.args[2] isa Symbol && push!(bound, e.args[2])
+            return                      # `import M as N` binds N, not M
+        elseif e.head === :(:)          # `using M: x` — binds x, not M
+            return
+        end
+        m = modname(e)
+        m === nothing || push!(bound, m)
+    end
+    function def_name(x)
+        x isa Symbol && return x
+        x isa Expr || return nothing
+        x.head === :call && !isempty(x.args) && return def_name(x.args[1])
+        x.head in (:where, :(::)) && !isempty(x.args) && return def_name(x.args[1])
+        return nothing
+    end
+
+    function walk(e)
+        e isa Symbol && (push!(symbols, e); return)
+        e isa Expr || return
+        if e.head in (:using, :import)
+            for a in e.args
+                walk_useclause(a)
+            end
+            return                      # the clause itself is not a reference
+        elseif e.head === :macrocall && !isempty(e.args) && e.args[1] isa Symbol
+            push!(macros, e.args[1])
+        elseif e.head === :. && length(e.args) == 2 &&
+               e.args[1] isa Symbol && e.args[2] isa QuoteNode
+            push!(qualified, e.args[1])
+        elseif e.head === :call && !isempty(e.args) && e.args[1] === :include &&
+               length(e.args) >= 2 && e.args[2] isa AbstractString
+            push!(includes, String(e.args[2]))
+        elseif e.head in (:function, :macro, :(=), :const, :struct, :abstract,
+                          :global, :local)
+            n = def_name(isempty(e.args) ? nothing : e.args[1])
+            n === nothing || push!(defined, n)
+        end
+        for a in e.args
+            walk(a)
+        end
+        return
+    end
+
+    walk(Meta.parseall(read(path, String); filename = path))
+    return (; bound, macros, qualified, includes, defined, symbols)
+end
+
+"""
+    _testutils_exports() -> Set{Symbol}
+
+The names testutils.jl defines, read from testutils.jl — so a helper added there
+is covered without touching this file.
+
+TOP-LEVEL definitions only. testutils.jl wraps its whole body in an
+`if !isdefined(…)` guard, so the walk descends through `block`/`if` and stops at
+the first definition: a local `x` inside `_stencil_model`'s body is not a name
+anyone can borrow, and counting it would flag every file in the tree that
+happens to use an `x`.
+"""
+function _testutils_exports()
+    out = Set{Symbol}()
+    function def_name(x)
+        x isa Symbol && return x
+        x isa Expr || return nothing
+        x.head === :call && !isempty(x.args) && return def_name(x.args[1])
+        x.head in (:where, :(::)) && !isempty(x.args) && return def_name(x.args[1])
+        return nothing
+    end
+    function toplevel(e)
+        e isa Expr || return
+        if e.head in (:toplevel, :block, :if, :module)
+            for a in e.args
+                toplevel(a)
+            end
+        elseif e.head === :const && !isempty(e.args)
+            toplevel(e.args[1])
+        elseif e.head in (:function, :macro, :(=), :struct)
+            n = def_name(e.args[1])
+            n === nothing || push!(out, n)
+        end
+        return
+    end
+    path = joinpath(_PRELUDE_TEST_DIR, "testutils.jl")
+    toplevel(Meta.parseall(read(path, String); filename = path))
+    delete!(out, :ESM_TESTUTILS_LOADED)   # the include guard, not a helper
+    return out
+end
+
+"""
+    _declared_packages() -> Set{Symbol}
+
+Every package name this project declares — `[deps]`, `[weakdeps]` and
+`[extras]` of Project.toml, plus the package's own `name`. A `Mod.` reference to
+anything outside this set is some local alias or a submodule, not an import this
+check has an opinion about.
+"""
+function _declared_packages()
+    out = Set{Symbol}()
+    section = ""
+    for line in eachline(joinpath(_PRELUDE_PKG_DIR, "Project.toml"))
+        s = strip(line)
+        if startswith(s, "[")
+            section = s
+        elseif section in ("[deps]", "[weakdeps]", "[extras]")
+            m = match(r"^([A-Za-z_][A-Za-z0-9_]*)\s*=", s)
+            m === nothing || push!(out, Symbol(m.captures[1]))
+        elseif isempty(section)
+            m = match(r"^name\s*=\s*\"([^\"]+)\"", s)
+            m === nothing || push!(out, Symbol(m.captures[1]))
+        end
+    end
+    return out
+end
+
+"""
+    _testutils_provides() -> Set{Symbol}
+
+The modules `include("testutils.jl")` brings into the INCLUDING module, read
+from testutils.jl's own `using` lines. `include` is textual, so those imports
+land in the includer's scope: a file that includes the prelude and then writes
+`JSON3.read` is not borrowing anything it has no claim to.
+
+`Test` is deliberately NOT in this set even though testutils.jl imports it.
+testutils.jl expands a `@test_skip` of its own, and macro expansion happens when
+the file is INCLUDED — so `Test` has to be in scope BEFORE the include, which
+makes it a precondition of the prelude rather than something the prelude
+supplies. (This is the hazard api_surface_test.jl's header already documents.)
+"""
+function _testutils_provides()
+    f = _prelude_facts(joinpath(_PRELUDE_TEST_DIR, "testutils.jl"))
+    return setdiff(f.bound, Set([:Test]))
+end
+
+_is_test_macro(m::Symbol) =
+    (startswith(String(m), "@test") || String(m) == "@inferred")
+
+# Line of the first `using Test`, and of the `include("testutils.jl")`, or
+# `nothing`. Read from the text rather than the AST because what matters here is
+# ORDER, and a line number is the honest unit for that.
+function _prelude_lines(path::AbstractString)
+    using_test = nothing
+    include_tu = nothing
+    for (i, line) in enumerate(eachline(path))
+        startswith(lstrip(line), "#") && continue
+        using_test === nothing && occursin(r"^\s*using\s+Test\b", line) && (using_test = i)
+        include_tu === nothing && occursin("include(\"testutils.jl\")", line) && (include_tu = i)
+    end
+    return (using_test, include_tu)
+end
+
+"""
+    _missing_prelude(path, tu_names, tu_gives, pkgs) -> Vector{String}
+
+The lines `path` should carry and does not, each spelled as the line to add.
+"""
+function _missing_prelude(path::AbstractString, tu_names::Set{Symbol},
+                          tu_gives::Set{Symbol}, pkgs::Set{Symbol})
+    f = _prelude_facts(path)
+    has_tu = "testutils.jl" in f.includes
+    missing_lines = String[]
+
+    # (1) a Test macro of its own, or (2) the prelude include, which expands one.
+    if :Test ∉ f.bound && (any(_is_test_macro, f.macros) || has_tu)
+        push!(missing_lines, "using Test")
+    elseif has_tu
+        ut, itu = _prelude_lines(path)
+        ut === nothing || itu === nothing || ut < itu ||
+            push!(missing_lines,
+                  "using Test   # MOVE it above the testutils.jl include on " *
+                  "line $(itu); the include expands a `@test_skip`")
+    end
+
+    # (3) a name testutils.jl defines, without the include that defines it.
+    borrowed = sort!(String.(collect(setdiff(intersect(f.symbols, tu_names), f.defined))))
+    isempty(borrowed) || has_tu ||
+        push!(missing_lines,
+              "include(\"testutils.jl\")   # uses " * join(borrowed, ", "))
+
+    # (4) `SomeModule.something` for a package this project declares, unless the
+    #     file imports it or the prelude it includes already did.
+    for m in sort!(collect(intersect(f.qualified, pkgs)))
+        m in f.bound || m in f.defined || (has_tu && m in tu_gives) ||
+            push!(missing_lines, "using $(m)")
+    end
+    return missing_lines
+end
+
+@testset "every test file carries the prelude it uses" begin
+    tu_names = _testutils_exports()
+    tu_gives = _testutils_provides()
+    pkgs     = _declared_packages()
+    @test :TESTUTILS_REPO_ROOT in tu_names && :_require_fixture in tu_names
+    @test :JSON3 in tu_gives && :Test ∉ tu_gives
+    @test :Test in pkgs && :EarthSciAST in pkgs   # Project.toml was really read
+
+    files = sort!(filter(f -> endswith(f, ".jl") && f != "runtests.jl",
+                         readdir(_PRELUDE_TEST_DIR)))
+    @test length(files) > 100                      # the sweep is not vacuous
+
+    offenders = String[]
+    for f in files
+        lines = _missing_prelude(joinpath(_PRELUDE_TEST_DIR, f),
+                                 tu_names, tu_gives, pkgs)
+        isempty(lines) && continue
+        push!(offenders, "  $(f)\n" * join(("      add: " * l for l in lines), "\n"))
+    end
+
+    @test isempty(offenders) || error(
+        "$(length(offenders)) test file(s) use a name they do not import, so " *
+        "they run only under runtests.jl and fail standalone " *
+        "(testutils.jl documents that both must work). Add the line named:\n" *
+        join(offenders, "\n"))
+end

--- a/pkg/EarthSciAST.jl/test/testutils.jl
+++ b/pkg/EarthSciAST.jl/test/testutils.jl
@@ -82,6 +82,19 @@ _normj(x) =
         Any[_normj(v) for v in x] : x
 
 """
+    corpus_is_resource_error(e) -> Bool
+
+Errors a fixture-corpus sweep must never swallow. Those sweeps tolerate a model
+that cannot build standalone by catching everything and skipping it — which
+also catches the process running out of memory or stack. Resource exhaustion
+then reads as an ordinary skip and the run stays green having tested nothing,
+which is exactly how a fixture whose grid exhausted the allocator sat in the
+corpus unnoticed. Rethrow these; skip on the rest.
+"""
+corpus_is_resource_error(e) =
+    e isa OutOfMemoryError || e isa StackOverflowError || e isa InterruptException
+
+"""
     _require_fixture(path) -> Bool
 
 Return `true` when the fixture file (or directory) at `path` exists. When it

--- a/pkg/EarthSciAST.jl/test/testutils.jl
+++ b/pkg/EarthSciAST.jl/test/testutils.jl
@@ -90,6 +90,14 @@ also catches the process running out of memory or stack. Resource exhaustion
 then reads as an ordinary skip and the run stays green having tested nothing,
 which is exactly how a fixture whose grid exhausted the allocator sat in the
 corpus unnoticed. Rethrow these; skip on the rest.
+
+This is a BACKSTOP, not the primary defence. The library is expected to deliver
+these three unwrapped — `EarthSciAST._is_resource_error` marks the same set,
+and every speculative-evaluation `catch` in `src/` that would otherwise decline
+or rebrand consults it first — precisely so a resource error never reaches a
+sweep disguised as a `TreeWalkError`, which this predicate could not recognise.
+Keep the backstop anyway: it costs nothing and it is what catches the next
+`catch` site that forgets.
 """
 corpus_is_resource_error(e) =
     e isa OutOfMemoryError || e isa StackOverflowError || e isa InterruptException

--- a/pkg/EarthSciAST.jl/test/tree_walk_oop_ssa_test.jl
+++ b/pkg/EarthSciAST.jl/test/tree_walk_oop_ssa_test.jl
@@ -25,6 +25,7 @@
 using Test
 using EarthSciAST
 using ForwardDiff
+using JSON3
 
 const ESMs = EarthSciAST
 

--- a/pkg/EarthSciAST.jl/test/version_constants_test.jl
+++ b/pkg/EarthSciAST.jl/test/version_constants_test.jl
@@ -8,6 +8,10 @@
 # as a `parse._CURRENT_VERSION` TUPLE. Every binding now exposes exactly
 # `SCHEMA_VERSION` and `LIBRARY_VERSION`, both strings.
 
+using Test
+using EarthSciAST
+using JSON3
+
 @testset "Version constants" begin
 
     @testset "SCHEMA_VERSION tracks the bundled schema \$id" begin

--- a/scripts/generate-pushdown-goldens.jl
+++ b/scripts/generate-pushdown-goldens.jl
@@ -105,6 +105,32 @@ function canon(io::IO, x, level::Int)
     end
 end
 
+# ---------------------------------------------------------------------------
+# Extent guard for a re-cut input fixture.
+#
+# The committed isrm.esm is the real document at REDUCED extents. Upstream it
+# declares 52,411 x 52,411 source-receptor cells over a 596,444-cell
+# population grid, and the Julia corpus sweeps
+# (pkg/EarthSciAST.jl/test/cross_eq_class_emission_test.jl and
+# cg_foreign_scratch_test.jl) build EVERY fixture in this tree: at production
+# extents that build exhausts the allocator before it reaches any diagnostic,
+# which reads on CI as an ordinary "does not build standalone" skip. Re-cutting
+# the input from a checkout would restore those extents silently, so refuse
+# instead and make the reduction a deliberate step.
+const MAX_FIXTURE_EXTENT = 1024
+
+function check_extents(doc, origin::AbstractString)
+    for (name, set) in get(doc, "index_sets", Dict{String,Any}())
+        n = get(set, "kind", nothing) == "interval" ? get(set, "size", 0) :
+            length(get(set, "members", ()))
+        n isa Integer && n > MAX_FIXTURE_EXTENT && error(
+            "$(origin): index set `$(name)` declares $(n) members, over the " *
+            "$(MAX_FIXTURE_EXTENT) a corpus fixture may carry. Reduce the grid " *
+            "extents before committing (see tests/conformance/pushdown/README.md).")
+    end
+    return doc
+end
+
 function write_canon(path::AbstractString, doc)
     mkpath(dirname(path))
     open(path, "w") do io
@@ -653,6 +679,7 @@ function main()
                         normpath(joinpath(REPO, "..", "isrm.esm", "isrm.esm")))
         isfile(isrm_path) || error("isrm.esm not found at $isrm_path (set ISRM_ESM)")
         ser = EA.serialize_esm_file(EA.load_path(isrm_path))   # metaparameter defaults folded
+        check_extents(ser, isrm_path)
         write_canon(joinpath(OUTDIR, "fixtures", "isrm.esm"), ser)
     end
     ser = EA.serialize_esm_file(EA.load_path(joinpath(OUTDIR, "fixtures", "isrm.esm")))

--- a/scripts/generate-pushdown-goldens.jl
+++ b/scripts/generate-pushdown-goldens.jl
@@ -106,7 +106,7 @@ function canon(io::IO, x, level::Int)
 end
 
 # ---------------------------------------------------------------------------
-# Extent guard for a re-cut input fixture.
+# Extent guard for the isrm input fixture.
 #
 # The committed isrm.esm is the real document at REDUCED extents. Upstream it
 # declares 52,411 x 52,411 source-receptor cells over a 596,444-cell
@@ -114,9 +114,13 @@ end
 # (pkg/EarthSciAST.jl/test/cross_eq_class_emission_test.jl and
 # cg_foreign_scratch_test.jl) build EVERY fixture in this tree: at production
 # extents that build exhausts the allocator before it reaches any diagnostic,
-# which reads on CI as an ordinary "does not build standalone" skip. Re-cutting
-# the input from a checkout would restore those extents silently, so refuse
-# instead and make the reduction a deliberate step.
+# which reads on CI as an ordinary "does not build standalone" skip.
+#
+# Run on BOTH isrm paths. `ISRM_ESM_REFRESH=1` re-cutting the input from a
+# checkout is the obvious way production extents come back, but not the only
+# one: the committed fixture can be hand-edited, or arrive on a branch cut
+# before this guard existed. Refuse either way and make the reduction a
+# deliberate step. `origin` says which path refused.
 const MAX_FIXTURE_EXTENT = 1024
 
 function check_extents(doc, origin::AbstractString)
@@ -674,15 +678,21 @@ function main()
     # upstream isrm.esm keeps evolving, and the frozen fixture — not whatever the
     # sibling checkout currently holds — is the cross-binding contract. Set
     # ISRM_ESM_REFRESH=1 to re-cut the input from a checkout instead.
+    isrm_fixture = joinpath(OUTDIR, "fixtures", "isrm.esm")
     if get(ENV, "ISRM_ESM_REFRESH", "0") == "1"
         isrm_path = get(ENV, "ISRM_ESM",
                         normpath(joinpath(REPO, "..", "isrm.esm", "isrm.esm")))
         isfile(isrm_path) || error("isrm.esm not found at $isrm_path (set ISRM_ESM)")
         ser = EA.serialize_esm_file(EA.load_path(isrm_path))   # metaparameter defaults folded
-        check_extents(ser, isrm_path)
-        write_canon(joinpath(OUTDIR, "fixtures", "isrm.esm"), ser)
+        check_extents(ser, "ISRM_ESM_REFRESH=1 re-cut from $(isrm_path)")
+        write_canon(isrm_fixture, ser)
     end
-    ser = EA.serialize_esm_file(EA.load_path(joinpath(OUTDIR, "fixtures", "isrm.esm")))
+    ser = EA.serialize_esm_file(EA.load_path(isrm_fixture))
+    # Also on the DEFAULT path: the refresh branch is not the only way an
+    # oversized document reaches this tree — the committed fixture can be
+    # hand-edited, or arrive on a branch cut before the guard existed. The
+    # generator is the last thing to read it before the corpus sweeps do.
+    check_extents(ser, "committed fixture $(isrm_fixture)")
     isrm = EA.desugar_pushdown(ser)
     isrm === ser && error("isrm.esm: desugar_pushdown did not fire")
     EA.desugar_pushdown(isrm) === isrm || error("isrm golden re-desugars (idempotency broken)")

--- a/tests/conformance/pushdown/README.md
+++ b/tests/conformance/pushdown/README.md
@@ -84,12 +84,12 @@ is **deep-equal as parsed JSON** to the committed golden.
   the committed input is self-contained (no open metaparameters), at REDUCED
   GRID EXTENTS: `src_cells` and `rcv_cells` carry 64 rather than 52,411, and
   `pop_cells` 96 rather than 596,444, with every other spelling of those
-  extents — the metaparameter defaults, the data-source array shapes and the
-  chunk dimensions that spelled an extent, and the counts named in the
-  descriptions — reduced with them. (The `x_esd` chunk descriptors keep their
-  authored 100-row source chunking, which the reduction leaves larger than the
-  64-cell axis it chunks; a chunk wider than its array is legal zarr and
-  nothing in this repo reads the field.)
+  extents — the metaparameter defaults, the data-source array shapes and
+  chunk sizes, and every count named in a description — reduced with them.
+  No number in the document is left at production scale: the `x_esd` chunking
+  of the source axis came down 100 → 16 so no chunk is wider than the axis it
+  chunks, and the `gated_select._DRAFT` fold size came down 330 GB → 480 KiB
+  (it is quadratic in the extent).
   The rewrite this corpus pins is structural, so the extents were never what
   it tests, and at the real ones the document cannot be carried here at all:
   the Julia corpus sweeps build EVERY fixture in this tree, and the five

--- a/tests/conformance/pushdown/README.md
+++ b/tests/conformance/pushdown/README.md
@@ -84,12 +84,22 @@ is **deep-equal as parsed JSON** to the committed golden.
   the committed input is self-contained (no open metaparameters), at REDUCED
   GRID EXTENTS: `src_cells` and `rcv_cells` carry 64 rather than 52,411, and
   `pop_cells` 96 rather than 596,444, with every other spelling of those
-  extents — the metaparameter defaults, the data-source array shapes and
-  chunk sizes, and the counts named in the descriptions — reduced with them.
+  extents — the metaparameter defaults, the data-source array shapes and the
+  chunk dimensions that spelled an extent, and the counts named in the
+  descriptions — reduced with them. (The `x_esd` chunk descriptors keep their
+  authored 100-row source chunking, which the reduction leaves larger than the
+  64-cell axis it chunks; a chunk wider than its array is legal zarr and
+  nothing in this repo reads the field.)
   The rewrite this corpus pins is structural, so the extents were never what
-  it tests; at the real ones the document is a 2.7e9-pair source-receptor
-  contraction that exhausts the allocator when the Julia corpus sweeps build
-  it, so it cannot be carried at production scale. `generate-pushdown-goldens.jl`
+  it tests, and at the real ones the document cannot be carried here at all:
+  the Julia corpus sweeps build EVERY fixture in this tree, and the five
+  `SR_*` parameters declare `shape: [src_cells, rcv_cells]` with a scalar
+  `default`. esm-spec §6.3 broadcasts such a default over the declared shape
+  before anything classifies the model, so each one is a 52,411 x 52,411
+  `Float64` fill — 2.7e9 cells, 20.5 GiB — five times over, which exhausts
+  the allocator. It is that broadcast and not the source-receptor contraction:
+  the allocation failure is raised from `fill` inside
+  `_register_inline_array_parameters`. `generate-pushdown-goldens.jl`
   refuses to write a re-cut input declaring more than 1024 members.
   FROZEN otherwise: see the re-emission note below.
 - `golden/<id>.rewritten.json` — `desugar_pushdown(input)` from the Julia

--- a/tests/conformance/pushdown/README.md
+++ b/tests/conformance/pushdown/README.md
@@ -81,8 +81,17 @@ is **deep-equal as parsed JSON** to the committed golden.
   `pushdown_diagnostics` list, not a rewritten document.
 - `fixtures/isrm.esm` — the real `isrm.esm` (from the isrm.esm repo), loaded
   with its metaparameter defaults and re-emitted via `serialize_esm_file` so
-  the committed input is self-contained (no open metaparameters). FROZEN: see
-  the re-emission note below.
+  the committed input is self-contained (no open metaparameters), at REDUCED
+  GRID EXTENTS: `src_cells` and `rcv_cells` carry 64 rather than 52,411, and
+  `pop_cells` 96 rather than 596,444, with every other spelling of those
+  extents — the metaparameter defaults, the data-source array shapes and
+  chunk sizes, and the counts named in the descriptions — reduced with them.
+  The rewrite this corpus pins is structural, so the extents were never what
+  it tests; at the real ones the document is a 2.7e9-pair source-receptor
+  contraction that exhausts the allocator when the Julia corpus sweeps build
+  it, so it cannot be carried at production scale. `generate-pushdown-goldens.jl`
+  refuses to write a re-cut input declaring more than 1024 members.
+  FROZEN otherwise: see the re-emission note below.
 - `golden/<id>.rewritten.json` — `desugar_pushdown(input)` from the Julia
   reference implementation.
 

--- a/tests/conformance/pushdown/README.md
+++ b/tests/conformance/pushdown/README.md
@@ -99,8 +99,10 @@ is **deep-equal as parsed JSON** to the committed golden.
   `Float64` fill — 2.7e9 cells, 20.5 GiB — five times over, which exhausts
   the allocator. It is that broadcast and not the source-receptor contraction:
   the allocation failure is raised from `fill` inside
-  `_register_inline_array_parameters`. `generate-pushdown-goldens.jl`
-  refuses to write a re-cut input declaring more than 1024 members.
+  `_register_inline_array_parameters`. `generate-pushdown-goldens.jl` refuses
+  to run at all — on the committed input as well as on an `ISRM_ESM_REFRESH=1`
+  re-cut — once any index set here declares more than 1024 members, so neither
+  a re-cut nor a hand edit puts production extents back silently.
   FROZEN otherwise: see the re-emission note below.
 - `golden/<id>.rewritten.json` — `desugar_pushdown(input)` from the Julia
   reference implementation.

--- a/tests/conformance/pushdown/fixtures/isrm.esm
+++ b/tests/conformance/pushdown/fixtures/isrm.esm
@@ -114,58 +114,58 @@
           "arrays": {
             "E": {
               "chunks": [
-                596444
+                96
               ],
               "dtype": "<f8",
               "shape": [
-                596444
+                96
               ]
             },
             "MortalityRate": {
               "chunks": [
-                596444
+                96
               ],
               "dtype": "<f8",
               "shape": [
-                596444
+                96
               ]
             },
             "N": {
               "chunks": [
-                596444
+                96
               ],
               "dtype": "<f8",
               "shape": [
-                596444
+                96
               ]
             },
             "PrimaryPM25": {
               "chunks": [
                 1,
                 100,
-                52411
+                64
               ],
               "dtype": "<f4",
               "shape": [
                 3,
-                52411,
-                52411
+                64,
+                64
               ]
             },
             "S": {
               "chunks": [
-                596444
+                96
               ],
               "dtype": "<f8",
               "shape": [
-                596444
+                96
               ]
             },
             "SOA": {
               "chunks": [
                 1,
                 100,
-                52411
+                64
               ],
               "compressor": "blosc:lz4:clevel5:shuffle1",
               "dtype": "<f4",
@@ -173,72 +173,72 @@
               "order": "C",
               "shape": [
                 3,
-                52411,
-                52411
+                64,
+                64
               ]
             },
             "TotalPop": {
               "chunks": [
-                596444
+                96
               ],
               "dtype": "<f8",
               "shape": [
-                596444
+                96
               ]
             },
             "W": {
               "chunks": [
-                596444
+                96
               ],
               "dtype": "<f8",
               "shape": [
-                596444
+                96
               ]
             },
             "pNH4": {
               "chunks": [
                 1,
                 100,
-                52411
+                64
               ],
               "dtype": "<f4",
               "shape": [
                 3,
-                52411,
-                52411
+                64,
+                64
               ]
             },
             "pNO3": {
               "chunks": [
                 1,
                 100,
-                52411
+                64
               ],
               "dtype": "<f4",
               "shape": [
                 3,
-                52411,
-                52411
+                64,
+                64
               ]
             },
             "pSO4": {
               "chunks": [
                 1,
                 100,
-                52411
+                64
               ],
               "dtype": "<f4",
               "shape": [
                 3,
-                52411,
-                52411
+                64,
+                64
               ]
             }
           },
           "consolidated": false,
           "format": "zarr",
           "gated_select": {
-            "_DRAFT": "Phase-2-core GATED-PROVIDER field (proposed). Replaces the runner's lazy_select ([0], ppl, :). Per-axis selection over the native SR dims sr_dim_order [emisLayer, source, receptor] = [3, 52411, 52411]; one axis is GATED BY a derived (value-invention) index set. Intended consumption: the engine DEFERS this provider's materialisation until materialize_value_invention has produced the gating set's members+extent, then delivers each `applies_to` array pre-sliced to the compact [emis_src_cells, rcv_cells] slab BEFORE the SR contraction (no 330 GB fold). Per-axis semantics: {\"fixed\":[i]} = take native index i and DROP the axis; {\"gated_by\":\"<derived index set>\"} = take that set's materialised members, in the set's canonical (sorted) member order, as the new axis (here emis_src_cells = the invented ppl); \"all\" = full axis (slice(None)).",
+            "_DRAFT": "Phase-2-core GATED-PROVIDER field (proposed). Replaces the runner's lazy_select ([0], ppl, :). Per-axis selection over the native SR dims sr_dim_order [emisLayer, source, receptor] = [3, 64, 64]; one axis is GATED BY a derived (value-invention) index set. Intended consumption: the engine DEFERS this provider's materialisation until materialize_value_invention has produced the gating set's members+extent, then delivers each `applies_to` array pre-sliced to the compact [emis_src_cells, rcv_cells] slab BEFORE the SR contraction (no 330 GB fold). Per-axis semantics: {\"fixed\":[i]} = take native index i and DROP the axis; {\"gated_by\":\"<derived index set>\"} = take that set's materialised members, in the set's canonical (sorted) member order, as the new axis (here emis_src_cells = the invented ppl); \"all\" = full axis (slice(None)).",
             "applies_to": [
               "SOA",
               "pNO3",
@@ -258,7 +258,7 @@
               "all"
             ]
           },
-          "note": "`format` and the pinned .zarray params are not expressible in the 0.8.0 source schema (G1); the runner sets format at provider creation. PUSHDOWN DRAFT: the SR source-axis slice is no longer the runner-threaded `ppl` lazy_select but the gated_select above, gated by the DERIVED emis_src_cells set the value-invention producer emis_src_cells_faq materialises (G2; Phase-2-core gated-provider deferral). W/S/E/N/TotalPop/MortalityRate are read fully; the first 52411 (the [0:52411] prefix slice) are the SR receptor/source cells. NOTE: for the pushdown, W/S/E/N (full-grid cell rectangles) must also be available to value-invention as build-time const factors (the producer's rectangle filter reads index(W,c)..index(N,c) over the full source grid).",
+          "note": "`format` and the pinned .zarray params are not expressible in the 0.8.0 source schema (G1); the runner sets format at provider creation. PUSHDOWN DRAFT: the SR source-axis slice is no longer the runner-threaded `ppl` lazy_select but the gated_select above, gated by the DERIVED emis_src_cells set the value-invention producer emis_src_cells_faq materialises (G2; Phase-2-core gated-provider deferral). W/S/E/N/TotalPop/MortalityRate are read fully; the first 64 (the [0:64] prefix slice) are the SR receptor/source cells. NOTE: for the pushdown, W/S/E/N (full-grid cell rectangles) must also be available to value-invention as build-time const factors (the producer's rectangle filter reads index(W,c)..index(N,c) over the full source grid).",
           "sr_dim_order": [
             "emisLayer",
             "source",
@@ -298,15 +298,15 @@
     },
     "pop_cells": {
       "kind": "interval",
-      "size": 596444
+      "size": 96
     },
     "rcv_cells": {
       "kind": "interval",
-      "size": 52411
+      "size": 64
     },
     "src_cells": {
       "kind": "interval",
-      "size": 52411
+      "size": 64
     }
   },
   "metadata": {
@@ -352,12 +352,12 @@
       "type": "integer"
     },
     "N_POP": {
-      "default": 596444,
+      "default": 96,
       "description": "Full InMAP grid length of W/S/E/N/TotalPop/MortalityRate.",
       "type": "integer"
     },
     "N_RCV": {
-      "default": 52411,
+      "default": 64,
       "description": "ISRM receptor cells (== the source grid, same ordered cell set).",
       "type": "integer"
     },
@@ -367,8 +367,8 @@
       "type": "integer"
     },
     "N_SRC": {
-      "default": 52411,
-      "description": "ISRM source cells (first-52411 coarse subset of the InMAP grid).",
+      "default": 64,
+      "description": "ISRM source cells (first-64 coarse subset of the InMAP grid).",
       "type": "integer"
     }
   },
@@ -4206,7 +4206,7 @@
         },
         "MortalityRate": {
           "default": 0.0,
-          "description": "Baseline mortality per 100k; from ISRM_SR.MortalityRate (prefix [0:52411]).",
+          "description": "Baseline mortality per 100k; from ISRM_SR.MortalityRate (prefix [0:64]).",
           "shape": [
             "pop_cells"
           ],
@@ -4254,7 +4254,7 @@
         },
         "SR_PrimaryPM25": {
           "default": 0.0,
-          "description": "Source-receptor matrix for the PrimaryPM25 pathway (contracted with PM2_5 emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 52411 receptors (rcv_cells). Wired from ISRM_SR.PrimaryPM25 via param_to_var (G2).",
+          "description": "Source-receptor matrix for the PrimaryPM25 pathway (contracted with PM2_5 emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 64 receptors (rcv_cells). Wired from ISRM_SR.PrimaryPM25 via param_to_var (G2).",
           "shape": [
             "src_cells",
             "rcv_cells"
@@ -4271,7 +4271,7 @@
         },
         "SR_SOA": {
           "default": 0.0,
-          "description": "Source-receptor matrix for the SOA pathway (contracted with VOC emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 52411 receptors (rcv_cells). Wired from ISRM_SR.SOA via param_to_var (G2).",
+          "description": "Source-receptor matrix for the SOA pathway (contracted with VOC emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 64 receptors (rcv_cells). Wired from ISRM_SR.SOA via param_to_var (G2).",
           "shape": [
             "src_cells",
             "rcv_cells"
@@ -4288,7 +4288,7 @@
         },
         "SR_pNH4": {
           "default": 0.0,
-          "description": "Source-receptor matrix for the pNH4 pathway (contracted with NH3 emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 52411 receptors (rcv_cells). Wired from ISRM_SR.pNH4 via param_to_var (G2).",
+          "description": "Source-receptor matrix for the pNH4 pathway (contracted with NH3 emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 64 receptors (rcv_cells). Wired from ISRM_SR.pNH4 via param_to_var (G2).",
           "shape": [
             "src_cells",
             "rcv_cells"
@@ -4305,7 +4305,7 @@
         },
         "SR_pNO3": {
           "default": 0.0,
-          "description": "Source-receptor matrix for the pNO3 pathway (contracted with NOx emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 52411 receptors (rcv_cells). Wired from ISRM_SR.pNO3 via param_to_var (G2).",
+          "description": "Source-receptor matrix for the pNO3 pathway (contracted with NOx emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 64 receptors (rcv_cells). Wired from ISRM_SR.pNO3 via param_to_var (G2).",
           "shape": [
             "src_cells",
             "rcv_cells"
@@ -4322,7 +4322,7 @@
         },
         "SR_pSO4": {
           "default": 0.0,
-          "description": "Source-receptor matrix for the pSO4 pathway (contracted with SOx emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 52411 receptors (rcv_cells). Wired from ISRM_SR.pSO4 via param_to_var (G2).",
+          "description": "Source-receptor matrix for the pSO4 pathway (contracted with SOx emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 64 receptors (rcv_cells). Wired from ISRM_SR.pSO4 via param_to_var (G2).",
           "shape": [
             "src_cells",
             "rcv_cells"
@@ -4347,7 +4347,7 @@
         },
         "TotalPop": {
           "default": 0.0,
-          "description": "Population per cell; from ISRM_SR.TotalPop (read on the rcv range = [0:52411] prefix slice).",
+          "description": "Population per cell; from ISRM_SR.TotalPop (read on the rcv range = [0:64] prefix slice).",
           "shape": [
             "pop_cells"
           ],
@@ -4363,7 +4363,7 @@
         },
         "W": {
           "default": 0.0,
-          "description": "Cell west edge (LCC m); from ISRM_SR.W (full 596444, prefix used).",
+          "description": "Cell west edge (LCC m); from ISRM_SR.W (full 96, prefix used).",
           "shape": [
             "pop_cells"
           ],
@@ -4432,7 +4432,7 @@
           "units": "ug/m^3"
         },
         "deathsK": {
-          "description": "Attributable deaths at each receptor (Krewski RR 1.06): (exp(log(rr)/10*TotalPM25)-1)*TotalPop*pop_scale*MortalityRate/100000*mort_scale. TotalPop/MortalityRate indexed on the rcv range = the [0:52411] prefix slice.",
+          "description": "Attributable deaths at each receptor (Krewski RR 1.06): (exp(log(rr)/10*TotalPM25)-1)*TotalPop*pop_scale*MortalityRate/100000*mort_scale. TotalPop/MortalityRate indexed on the rcv range = the [0:64] prefix slice.",
           "shape": [
             "rcv_cells"
           ],
@@ -4440,7 +4440,7 @@
           "units": "1"
         },
         "deathsL": {
-          "description": "Attributable deaths at each receptor (Lepeule RR 1.14): (exp(log(rr)/10*TotalPM25)-1)*TotalPop*pop_scale*MortalityRate/100000*mort_scale. TotalPop/MortalityRate indexed on the rcv range = the [0:52411] prefix slice.",
+          "description": "Attributable deaths at each receptor (Lepeule RR 1.14): (exp(log(rr)/10*TotalPM25)-1)*TotalPop*pop_scale*MortalityRate/100000*mort_scale. TotalPop/MortalityRate indexed on the rcv range = the [0:64] prefix slice.",
           "shape": [
             "rcv_cells"
           ],

--- a/tests/conformance/pushdown/fixtures/isrm.esm
+++ b/tests/conformance/pushdown/fixtures/isrm.esm
@@ -142,7 +142,7 @@
             "PrimaryPM25": {
               "chunks": [
                 1,
-                100,
+                16,
                 64
               ],
               "dtype": "<f4",
@@ -164,7 +164,7 @@
             "SOA": {
               "chunks": [
                 1,
-                100,
+                16,
                 64
               ],
               "compressor": "blosc:lz4:clevel5:shuffle1",
@@ -198,7 +198,7 @@
             "pNH4": {
               "chunks": [
                 1,
-                100,
+                16,
                 64
               ],
               "dtype": "<f4",
@@ -211,7 +211,7 @@
             "pNO3": {
               "chunks": [
                 1,
-                100,
+                16,
                 64
               ],
               "dtype": "<f4",
@@ -224,7 +224,7 @@
             "pSO4": {
               "chunks": [
                 1,
-                100,
+                16,
                 64
               ],
               "dtype": "<f4",
@@ -238,7 +238,7 @@
           "consolidated": false,
           "format": "zarr",
           "gated_select": {
-            "_DRAFT": "Phase-2-core GATED-PROVIDER field (proposed). Replaces the runner's lazy_select ([0], ppl, :). Per-axis selection over the native SR dims sr_dim_order [emisLayer, source, receptor] = [3, 64, 64]; one axis is GATED BY a derived (value-invention) index set. Intended consumption: the engine DEFERS this provider's materialisation until materialize_value_invention has produced the gating set's members+extent, then delivers each `applies_to` array pre-sliced to the compact [emis_src_cells, rcv_cells] slab BEFORE the SR contraction (no 330 GB fold). Per-axis semantics: {\"fixed\":[i]} = take native index i and DROP the axis; {\"gated_by\":\"<derived index set>\"} = take that set's materialised members, in the set's canonical (sorted) member order, as the new axis (here emis_src_cells = the invented ppl); \"all\" = full axis (slice(None)).",
+            "_DRAFT": "Phase-2-core GATED-PROVIDER field (proposed). Replaces the runner's lazy_select ([0], ppl, :). Per-axis selection over the native SR dims sr_dim_order [emisLayer, source, receptor] = [3, 64, 64]; one axis is GATED BY a derived (value-invention) index set. Intended consumption: the engine DEFERS this provider's materialisation until materialize_value_invention has produced the gating set's members+extent, then delivers each `applies_to` array pre-sliced to the compact [emis_src_cells, rcv_cells] slab BEFORE the SR contraction (no 480 KiB fold). Per-axis semantics: {\"fixed\":[i]} = take native index i and DROP the axis; {\"gated_by\":\"<derived index set>\"} = take that set's materialised members, in the set's canonical (sorted) member order, as the new axis (here emis_src_cells = the invented ppl); \"all\" = full axis (slice(None)).",
             "applies_to": [
               "SOA",
               "pNO3",

--- a/tests/conformance/pushdown/fixtures/isrm.esm
+++ b/tests/conformance/pushdown/fixtures/isrm.esm
@@ -4167,11 +4167,11 @@
           "type": "parameter",
           "units": "m",
           "update": {
-            "kind": "data",
-            "source": "ISRM_SR",
             "from": {
               "file_variable": "E"
-            }
+            },
+            "kind": "data",
+            "source": "ISRM_SR"
           }
         },
         "E_NH3": {
@@ -4213,11 +4213,11 @@
           "type": "parameter",
           "units": "1",
           "update": {
-            "kind": "data",
-            "source": "ISRM_SR",
             "from": {
               "file_variable": "MortalityRate"
-            }
+            },
+            "kind": "data",
+            "source": "ISRM_SR"
           }
         },
         "N": {
@@ -4229,11 +4229,11 @@
           "type": "parameter",
           "units": "m",
           "update": {
-            "kind": "data",
-            "source": "ISRM_SR",
             "from": {
               "file_variable": "N"
-            }
+            },
+            "kind": "data",
+            "source": "ISRM_SR"
           }
         },
         "S": {
@@ -4245,11 +4245,11 @@
           "type": "parameter",
           "units": "m",
           "update": {
-            "kind": "data",
-            "source": "ISRM_SR",
             "from": {
               "file_variable": "S"
-            }
+            },
+            "kind": "data",
+            "source": "ISRM_SR"
           }
         },
         "SR_PrimaryPM25": {
@@ -4262,11 +4262,11 @@
           "type": "parameter",
           "units": "ug/m^3/(kg/yr)",
           "update": {
-            "kind": "data",
-            "source": "ISRM_SR",
             "from": {
               "file_variable": "PrimaryPM25"
-            }
+            },
+            "kind": "data",
+            "source": "ISRM_SR"
           }
         },
         "SR_SOA": {
@@ -4279,11 +4279,11 @@
           "type": "parameter",
           "units": "ug/m^3/(kg/yr)",
           "update": {
-            "kind": "data",
-            "source": "ISRM_SR",
             "from": {
               "file_variable": "SOA"
-            }
+            },
+            "kind": "data",
+            "source": "ISRM_SR"
           }
         },
         "SR_pNH4": {
@@ -4296,11 +4296,11 @@
           "type": "parameter",
           "units": "ug/m^3/(kg/yr)",
           "update": {
-            "kind": "data",
-            "source": "ISRM_SR",
             "from": {
               "file_variable": "pNH4"
-            }
+            },
+            "kind": "data",
+            "source": "ISRM_SR"
           }
         },
         "SR_pNO3": {
@@ -4313,11 +4313,11 @@
           "type": "parameter",
           "units": "ug/m^3/(kg/yr)",
           "update": {
-            "kind": "data",
-            "source": "ISRM_SR",
             "from": {
               "file_variable": "pNO3"
-            }
+            },
+            "kind": "data",
+            "source": "ISRM_SR"
           }
         },
         "SR_pSO4": {
@@ -4330,11 +4330,11 @@
           "type": "parameter",
           "units": "ug/m^3/(kg/yr)",
           "update": {
-            "kind": "data",
-            "source": "ISRM_SR",
             "from": {
               "file_variable": "pSO4"
-            }
+            },
+            "kind": "data",
+            "source": "ISRM_SR"
           }
         },
         "TotalPM25": {
@@ -4354,11 +4354,11 @@
           "type": "parameter",
           "units": "1",
           "update": {
-            "kind": "data",
-            "source": "ISRM_SR",
             "from": {
               "file_variable": "TotalPop"
-            }
+            },
+            "kind": "data",
+            "source": "ISRM_SR"
           }
         },
         "W": {
@@ -4370,11 +4370,11 @@
           "type": "parameter",
           "units": "m",
           "update": {
-            "kind": "data",
-            "source": "ISRM_SR",
             "from": {
               "file_variable": "W"
-            }
+            },
+            "kind": "data",
+            "source": "ISRM_SR"
           }
         },
         "X": {
@@ -4456,11 +4456,11 @@
           "type": "parameter",
           "units": "kg/yr",
           "update": {
-            "kind": "data",
-            "source": "EGU_Emis",
             "from": {
               "file_variable": "ann_value"
-            }
+            },
+            "kind": "data",
+            "source": "EGU_Emis"
           }
         },
         "emis_lat": {
@@ -4472,11 +4472,11 @@
           "type": "parameter",
           "units": "degree",
           "update": {
-            "kind": "data",
-            "source": "EGU_Emis",
             "from": {
               "file_variable": "lat"
-            }
+            },
+            "kind": "data",
+            "source": "EGU_Emis"
           }
         },
         "emis_lon": {
@@ -4488,11 +4488,11 @@
           "type": "parameter",
           "units": "degree",
           "update": {
-            "kind": "data",
-            "source": "EGU_Emis",
             "from": {
               "file_variable": "lon"
-            }
+            },
+            "kind": "data",
+            "source": "EGU_Emis"
           }
         },
         "fact": {
@@ -4560,7 +4560,7 @@
           "units": "degree"
         },
         "lcc_R": {
-          "default": 6370997.0,
+          "default": 6.370997e6,
           "description": "LCC sphere radius (NEI2016). (Named lcc_R, not R, to avoid the reserved physical-constant name R = ideal gas constant.)",
           "type": "parameter",
           "units": "m"
@@ -4636,11 +4636,11 @@
           "type": "parameter",
           "units": "1",
           "update": {
-            "kind": "data",
-            "source": "EGU_Emis",
             "from": {
               "file_variable": "poll"
-            }
+            },
+            "kind": "data",
+            "source": "EGU_Emis"
           }
         },
         "pop_scale": {
@@ -4714,8 +4714,6 @@
           "type": "parameter",
           "units": "m",
           "update": {
-            "kind": "data",
-            "source": "EGU_Emis",
             "from": {
               "file_variable": "stkdiam",
               "unit_conversion": {
@@ -4725,7 +4723,9 @@
                 ],
                 "op": "*"
               }
-            }
+            },
+            "kind": "data",
+            "source": "EGU_Emis"
           }
         },
         "stkhgt": {
@@ -4737,8 +4737,6 @@
           "type": "parameter",
           "units": "m",
           "update": {
-            "kind": "data",
-            "source": "EGU_Emis",
             "from": {
               "file_variable": "stkhgt",
               "unit_conversion": {
@@ -4748,7 +4746,9 @@
                 ],
                 "op": "*"
               }
-            }
+            },
+            "kind": "data",
+            "source": "EGU_Emis"
           }
         },
         "stktemp": {
@@ -4760,8 +4760,6 @@
           "type": "parameter",
           "units": "K",
           "update": {
-            "kind": "data",
-            "source": "EGU_Emis",
             "from": {
               "file_variable": "stktemp",
               "unit_conversion": {
@@ -4783,7 +4781,9 @@
                 ],
                 "op": "+"
               }
-            }
+            },
+            "kind": "data",
+            "source": "EGU_Emis"
           }
         },
         "stkvel": {
@@ -4795,8 +4795,6 @@
           "type": "parameter",
           "units": "m/s",
           "update": {
-            "kind": "data",
-            "source": "EGU_Emis",
             "from": {
               "file_variable": "stkvel",
               "unit_conversion": {
@@ -4806,7 +4804,9 @@
                 ],
                 "op": "*"
               }
-            }
+            },
+            "kind": "data",
+            "source": "EGU_Emis"
           }
         }
       }

--- a/tests/conformance/pushdown/golden/isrm.rewritten.json
+++ b/tests/conformance/pushdown/golden/isrm.rewritten.json
@@ -114,58 +114,58 @@
           "arrays": {
             "E": {
               "chunks": [
-                596444
+                96
               ],
               "dtype": "<f8",
               "shape": [
-                596444
+                96
               ]
             },
             "MortalityRate": {
               "chunks": [
-                596444
+                96
               ],
               "dtype": "<f8",
               "shape": [
-                596444
+                96
               ]
             },
             "N": {
               "chunks": [
-                596444
+                96
               ],
               "dtype": "<f8",
               "shape": [
-                596444
+                96
               ]
             },
             "PrimaryPM25": {
               "chunks": [
                 1,
                 100,
-                52411
+                64
               ],
               "dtype": "<f4",
               "shape": [
                 3,
-                52411,
-                52411
+                64,
+                64
               ]
             },
             "S": {
               "chunks": [
-                596444
+                96
               ],
               "dtype": "<f8",
               "shape": [
-                596444
+                96
               ]
             },
             "SOA": {
               "chunks": [
                 1,
                 100,
-                52411
+                64
               ],
               "compressor": "blosc:lz4:clevel5:shuffle1",
               "dtype": "<f4",
@@ -173,72 +173,72 @@
               "order": "C",
               "shape": [
                 3,
-                52411,
-                52411
+                64,
+                64
               ]
             },
             "TotalPop": {
               "chunks": [
-                596444
+                96
               ],
               "dtype": "<f8",
               "shape": [
-                596444
+                96
               ]
             },
             "W": {
               "chunks": [
-                596444
+                96
               ],
               "dtype": "<f8",
               "shape": [
-                596444
+                96
               ]
             },
             "pNH4": {
               "chunks": [
                 1,
                 100,
-                52411
+                64
               ],
               "dtype": "<f4",
               "shape": [
                 3,
-                52411,
-                52411
+                64,
+                64
               ]
             },
             "pNO3": {
               "chunks": [
                 1,
                 100,
-                52411
+                64
               ],
               "dtype": "<f4",
               "shape": [
                 3,
-                52411,
-                52411
+                64,
+                64
               ]
             },
             "pSO4": {
               "chunks": [
                 1,
                 100,
-                52411
+                64
               ],
               "dtype": "<f4",
               "shape": [
                 3,
-                52411,
-                52411
+                64,
+                64
               ]
             }
           },
           "consolidated": false,
           "format": "zarr",
           "gated_select": {
-            "_DRAFT": "Phase-2-core GATED-PROVIDER field (proposed). Replaces the runner's lazy_select ([0], ppl, :). Per-axis selection over the native SR dims sr_dim_order [emisLayer, source, receptor] = [3, 52411, 52411]; one axis is GATED BY a derived (value-invention) index set. Intended consumption: the engine DEFERS this provider's materialisation until materialize_value_invention has produced the gating set's members+extent, then delivers each `applies_to` array pre-sliced to the compact [emis_src_cells, rcv_cells] slab BEFORE the SR contraction (no 330 GB fold). Per-axis semantics: {\"fixed\":[i]} = take native index i and DROP the axis; {\"gated_by\":\"<derived index set>\"} = take that set's materialised members, in the set's canonical (sorted) member order, as the new axis (here emis_src_cells = the invented ppl); \"all\" = full axis (slice(None)).",
+            "_DRAFT": "Phase-2-core GATED-PROVIDER field (proposed). Replaces the runner's lazy_select ([0], ppl, :). Per-axis selection over the native SR dims sr_dim_order [emisLayer, source, receptor] = [3, 64, 64]; one axis is GATED BY a derived (value-invention) index set. Intended consumption: the engine DEFERS this provider's materialisation until materialize_value_invention has produced the gating set's members+extent, then delivers each `applies_to` array pre-sliced to the compact [emis_src_cells, rcv_cells] slab BEFORE the SR contraction (no 330 GB fold). Per-axis semantics: {\"fixed\":[i]} = take native index i and DROP the axis; {\"gated_by\":\"<derived index set>\"} = take that set's materialised members, in the set's canonical (sorted) member order, as the new axis (here emis_src_cells = the invented ppl); \"all\" = full axis (slice(None)).",
             "applies_to": [
               "SOA",
               "pNO3",
@@ -258,7 +258,7 @@
               "all"
             ]
           },
-          "note": "`format` and the pinned .zarray params are not expressible in the 0.8.0 source schema (G1); the runner sets format at provider creation. PUSHDOWN DRAFT: the SR source-axis slice is no longer the runner-threaded `ppl` lazy_select but the gated_select above, gated by the DERIVED emis_src_cells set the value-invention producer emis_src_cells_faq materialises (G2; Phase-2-core gated-provider deferral). W/S/E/N/TotalPop/MortalityRate are read fully; the first 52411 (the [0:52411] prefix slice) are the SR receptor/source cells. NOTE: for the pushdown, W/S/E/N (full-grid cell rectangles) must also be available to value-invention as build-time const factors (the producer's rectangle filter reads index(W,c)..index(N,c) over the full source grid).",
+          "note": "`format` and the pinned .zarray params are not expressible in the 0.8.0 source schema (G1); the runner sets format at provider creation. PUSHDOWN DRAFT: the SR source-axis slice is no longer the runner-threaded `ppl` lazy_select but the gated_select above, gated by the DERIVED emis_src_cells set the value-invention producer emis_src_cells_faq materialises (G2; Phase-2-core gated-provider deferral). W/S/E/N/TotalPop/MortalityRate are read fully; the first 64 (the [0:64] prefix slice) are the SR receptor/source cells. NOTE: for the pushdown, W/S/E/N (full-grid cell rectangles) must also be available to value-invention as build-time const factors (the producer's rectangle filter reads index(W,c)..index(N,c) over the full source grid).",
           "sr_dim_order": [
             "emisLayer",
             "source",
@@ -303,15 +303,15 @@
     },
     "pop_cells": {
       "kind": "interval",
-      "size": 596444
+      "size": 96
     },
     "rcv_cells": {
       "kind": "interval",
-      "size": 52411
+      "size": 64
     },
     "src_cells": {
       "kind": "interval",
-      "size": 52411
+      "size": 64
     }
   },
   "metadata": {
@@ -376,12 +376,12 @@
       "type": "integer"
     },
     "N_POP": {
-      "default": 596444,
+      "default": 96,
       "description": "Full InMAP grid length of W/S/E/N/TotalPop/MortalityRate.",
       "type": "integer"
     },
     "N_RCV": {
-      "default": 52411,
+      "default": 64,
       "description": "ISRM receptor cells (== the source grid, same ordered cell set).",
       "type": "integer"
     },
@@ -391,8 +391,8 @@
       "type": "integer"
     },
     "N_SRC": {
-      "default": 52411,
-      "description": "ISRM source cells (first-52411 coarse subset of the InMAP grid).",
+      "default": 64,
+      "description": "ISRM source cells (first-64 coarse subset of the InMAP grid).",
       "type": "integer"
     }
   },
@@ -4582,7 +4582,7 @@
         },
         "MortalityRate": {
           "default": 0.0,
-          "description": "Baseline mortality per 100k; from ISRM_SR.MortalityRate (prefix [0:52411]).",
+          "description": "Baseline mortality per 100k; from ISRM_SR.MortalityRate (prefix [0:64]).",
           "shape": [
             "pop_cells"
           ],
@@ -4630,7 +4630,7 @@
         },
         "SR_PrimaryPM25": {
           "default": 0.0,
-          "description": "Source-receptor matrix for the PrimaryPM25 pathway (contracted with PM2_5 emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 52411 receptors (rcv_cells). Wired from ISRM_SR.PrimaryPM25 via param_to_var (G2).",
+          "description": "Source-receptor matrix for the PrimaryPM25 pathway (contracted with PM2_5 emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 64 receptors (rcv_cells). Wired from ISRM_SR.PrimaryPM25 via param_to_var (G2).",
           "shape": [
             "pd_support__src_cells",
             "rcv_cells"
@@ -4647,7 +4647,7 @@
         },
         "SR_SOA": {
           "default": 0.0,
-          "description": "Source-receptor matrix for the SOA pathway (contracted with VOC emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 52411 receptors (rcv_cells). Wired from ISRM_SR.SOA via param_to_var (G2).",
+          "description": "Source-receptor matrix for the SOA pathway (contracted with VOC emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 64 receptors (rcv_cells). Wired from ISRM_SR.SOA via param_to_var (G2).",
           "shape": [
             "pd_support__src_cells",
             "rcv_cells"
@@ -4664,7 +4664,7 @@
         },
         "SR_pNH4": {
           "default": 0.0,
-          "description": "Source-receptor matrix for the pNH4 pathway (contracted with NH3 emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 52411 receptors (rcv_cells). Wired from ISRM_SR.pNH4 via param_to_var (G2).",
+          "description": "Source-receptor matrix for the pNH4 pathway (contracted with NH3 emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 64 receptors (rcv_cells). Wired from ISRM_SR.pNH4 via param_to_var (G2).",
           "shape": [
             "pd_support__src_cells",
             "rcv_cells"
@@ -4681,7 +4681,7 @@
         },
         "SR_pNO3": {
           "default": 0.0,
-          "description": "Source-receptor matrix for the pNO3 pathway (contracted with NOx emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 52411 receptors (rcv_cells). Wired from ISRM_SR.pNO3 via param_to_var (G2).",
+          "description": "Source-receptor matrix for the pNO3 pathway (contracted with NOx emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 64 receptors (rcv_cells). Wired from ISRM_SR.pNO3 via param_to_var (G2).",
           "shape": [
             "pd_support__src_cells",
             "rcv_cells"
@@ -4698,7 +4698,7 @@
         },
         "SR_pSO4": {
           "default": 0.0,
-          "description": "Source-receptor matrix for the pSO4 pathway (contracted with SOx emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 52411 receptors (rcv_cells). Wired from ISRM_SR.pSO4 via param_to_var (G2).",
+          "description": "Source-receptor matrix for the pSO4 pathway (contracted with SOx emissions), already emisLayer-0- and ppl-sliced by the runner's lazy zarr select ([0], ppl, :). Rows are the compact emission-bearing source cells (emis_src_cells), columns the 64 receptors (rcv_cells). Wired from ISRM_SR.pSO4 via param_to_var (G2).",
           "shape": [
             "pd_support__src_cells",
             "rcv_cells"
@@ -4723,7 +4723,7 @@
         },
         "TotalPop": {
           "default": 0.0,
-          "description": "Population per cell; from ISRM_SR.TotalPop (read on the rcv range = [0:52411] prefix slice).",
+          "description": "Population per cell; from ISRM_SR.TotalPop (read on the rcv range = [0:64] prefix slice).",
           "shape": [
             "pop_cells"
           ],
@@ -4739,7 +4739,7 @@
         },
         "W": {
           "default": 0.0,
-          "description": "Cell west edge (LCC m); from ISRM_SR.W (full 596444, prefix used).",
+          "description": "Cell west edge (LCC m); from ISRM_SR.W (full 96, prefix used).",
           "shape": [
             "pop_cells"
           ],
@@ -4808,7 +4808,7 @@
           "units": "ug/m^3"
         },
         "deathsK": {
-          "description": "Attributable deaths at each receptor (Krewski RR 1.06): (exp(log(rr)/10*TotalPM25)-1)*TotalPop*pop_scale*MortalityRate/100000*mort_scale. TotalPop/MortalityRate indexed on the rcv range = the [0:52411] prefix slice.",
+          "description": "Attributable deaths at each receptor (Krewski RR 1.06): (exp(log(rr)/10*TotalPM25)-1)*TotalPop*pop_scale*MortalityRate/100000*mort_scale. TotalPop/MortalityRate indexed on the rcv range = the [0:64] prefix slice.",
           "shape": [
             "rcv_cells"
           ],
@@ -4816,7 +4816,7 @@
           "units": "1"
         },
         "deathsL": {
-          "description": "Attributable deaths at each receptor (Lepeule RR 1.14): (exp(log(rr)/10*TotalPM25)-1)*TotalPop*pop_scale*MortalityRate/100000*mort_scale. TotalPop/MortalityRate indexed on the rcv range = the [0:52411] prefix slice.",
+          "description": "Attributable deaths at each receptor (Lepeule RR 1.14): (exp(log(rr)/10*TotalPM25)-1)*TotalPop*pop_scale*MortalityRate/100000*mort_scale. TotalPop/MortalityRate indexed on the rcv range = the [0:64] prefix slice.",
           "shape": [
             "rcv_cells"
           ],

--- a/tests/conformance/pushdown/golden/isrm.rewritten.json
+++ b/tests/conformance/pushdown/golden/isrm.rewritten.json
@@ -142,7 +142,7 @@
             "PrimaryPM25": {
               "chunks": [
                 1,
-                100,
+                16,
                 64
               ],
               "dtype": "<f4",
@@ -164,7 +164,7 @@
             "SOA": {
               "chunks": [
                 1,
-                100,
+                16,
                 64
               ],
               "compressor": "blosc:lz4:clevel5:shuffle1",
@@ -198,7 +198,7 @@
             "pNH4": {
               "chunks": [
                 1,
-                100,
+                16,
                 64
               ],
               "dtype": "<f4",
@@ -211,7 +211,7 @@
             "pNO3": {
               "chunks": [
                 1,
-                100,
+                16,
                 64
               ],
               "dtype": "<f4",
@@ -224,7 +224,7 @@
             "pSO4": {
               "chunks": [
                 1,
-                100,
+                16,
                 64
               ],
               "dtype": "<f4",
@@ -238,7 +238,7 @@
           "consolidated": false,
           "format": "zarr",
           "gated_select": {
-            "_DRAFT": "Phase-2-core GATED-PROVIDER field (proposed). Replaces the runner's lazy_select ([0], ppl, :). Per-axis selection over the native SR dims sr_dim_order [emisLayer, source, receptor] = [3, 64, 64]; one axis is GATED BY a derived (value-invention) index set. Intended consumption: the engine DEFERS this provider's materialisation until materialize_value_invention has produced the gating set's members+extent, then delivers each `applies_to` array pre-sliced to the compact [emis_src_cells, rcv_cells] slab BEFORE the SR contraction (no 330 GB fold). Per-axis semantics: {\"fixed\":[i]} = take native index i and DROP the axis; {\"gated_by\":\"<derived index set>\"} = take that set's materialised members, in the set's canonical (sorted) member order, as the new axis (here emis_src_cells = the invented ppl); \"all\" = full axis (slice(None)).",
+            "_DRAFT": "Phase-2-core GATED-PROVIDER field (proposed). Replaces the runner's lazy_select ([0], ppl, :). Per-axis selection over the native SR dims sr_dim_order [emisLayer, source, receptor] = [3, 64, 64]; one axis is GATED BY a derived (value-invention) index set. Intended consumption: the engine DEFERS this provider's materialisation until materialize_value_invention has produced the gating set's members+extent, then delivers each `applies_to` array pre-sliced to the compact [emis_src_cells, rcv_cells] slab BEFORE the SR contraction (no 480 KiB fold). Per-axis semantics: {\"fixed\":[i]} = take native index i and DROP the axis; {\"gated_by\":\"<derived index set>\"} = take that set's materialised members, in the set's canonical (sorted) member order, as the new axis (here emis_src_cells = the invented ppl); \"all\" = full axis (slice(None)).",
             "applies_to": [
               "SOA",
               "pNO3",


### PR DESCRIPTION
## The bug

The Julia corpus sweeps in `cross_eq_class_emission_test.jl` and
`cg_foreign_scratch_test.jl` build **every** `.esm` under `tests/valid` +
`tests/conformance` — a feature on, then its kill switch — and compare the two
RHS evaluations. So they also built
`tests/conformance/pushdown/fixtures/isrm.esm`, a frozen snapshot of the real
InMAP source-receptor model committed as a pushdown-**rewrite** golden. At
production extents that build cannot finish: the sweep was SIGKILLed here at
maxRSS **40,199,196 kB**, and `--heap-size-hint=3G` changed nothing.

## Root cause — measured, and not what it looks like

It is **not** the 52,411 × 52,411 source-receptor contraction. Under a memory
limit the build raises `OutOfMemoryError` from exactly one frame:

```
fill(v::Float64, dims::Tuple{Int64, Int64}) at array.jl:542
_register_inline_array_parameters(...) at build.jl:885
```

That is esm-spec §6.3's scalar-`default` broadcast, which materializes a
parameter's declared shape before anything classifies it. Five parameters —
`SR_PrimaryPM25`, `SR_SOA`, `SR_pNH4`, `SR_pNO3`, `SR_pSO4` — each declare
`shape: [src_cells, rcv_cells]` with `default: 0.0`:

| | |
|---|---|
| cells per parameter | 2,746,912,921 |
| `fill(0.0, (52411, 52411))` | **20.5 GiB** each |
| parameters like this | 5 |

Two of them are the 40 GiB. *(An earlier revision of this PR blamed per-cell
scalarization of the contraction. The backtrace says otherwise.)*

## Why CI never went red

The sweeps caught **every** exception and skipped the model, which makes
running out of memory indistinguishable from a document that cannot build
standalone. Measured on the unshrunk fixture under a memory limit:

```
bare catch      -> nothing (SKIPPED, sweep stays green)
narrowed catch  -> rethrew OutOfMemoryError (sweep FAILS)
```

So the Julia job ran the whole suite to completion with this fixture in it: the
allocation failure was caught and counted as a skip. `corpus_is_resource_error`
(testutils.jl) now rethrows `OutOfMemoryError`, `StackOverflowError` and
`InterruptException`; everything else still skips.

## The fix

The extents are reduced **in the fixture**, not worked around in the harness:
`src_cells` and `rcv_cells` carry 64 instead of 52,411, `pop_cells` 96 instead
of 596,444, and every other spelling of those extents goes with them — the
metaparameter defaults, the data-source array shapes and chunk sizes, and the
counts named in the descriptions — so the document stays self-consistent. The
rewrite this corpus pins is structural; the extents were never what it tests.

`golden/isrm.rewritten.json` is regenerated by
`scripts/generate-pushdown-goldens.jl`. Every other fixture and golden in the
category re-emits byte-identically, so the change is isolated to this pair.

The generator now refuses to write a re-cut input declaring more than 1024
members, so `ISRM_ESM_REFRESH=1` cannot silently restore production extents and
with them the OOM.

## Verification

| | result |
|---|---|
| `cross_eq_class_emission_test.jl` | 1741 / 1741 — 4m28s, peak 1072 MiB |
| `cg_foreign_scratch_test.jl` | 1506 / 1506 — 4m09s, peak 1125 MiB |
| `conformance_pushdown_test.jl` (Julia) | 50 / 50 |
| `test_conformance_pushdown.py` (Python) | 8 passed |
| `pushdown_conformance.rs` (Rust) | 2 passed |

The first two could not finish at all here before.

Not run locally: `auto_pushdown_rewrite_test.jl` and `pushdown_edge_test.jl`
need GeometryOps, which this environment's minimal Julia env lacks — CI covers
them. The full `Pkg.test()` target hangs here (see `CONTRIBUTING.md`).

## Not addressed here

The §6.3 broadcast itself, which is the ROOT CAUSE this PR works around rather
than fixes: a scalar default on a data-source-backed array parameter allocates
the full declared shape whether or not anything reads it before the loader
fills it — a library-side question, not a fixture one. Tracked as #309.

Six decline-shaped `catch` sites also remain in `src/`, all OUTSIDE the
tree-walk build path and deliberately left alone: `inline_tests.jl:967` (test
runner), `solver.jl:83` (solver-block parse), `units.jl:757` and `:771`
(Unitful parse declines, where swallowing is the documented behavior), and
`validate.jl:2609` and `:3383` (schema validation). The twelve sites on the
build path — where a swallowed resource error could be recorded as an ordinary
skip or rebranded as a statement about the document — are all fixed here.

https://claude.ai/code/session_01JoQCxbmggBmHkUqABTjtQX

