### PR TITLE
fix(scripts): make the golden generators reproduce the fixtures they emit

### DIFF
--- a/.github/workflows/conformance-testing.yml
+++ b/.github/workflows/conformance-testing.yml
@@ -257,6 +257,20 @@ jobs:
         run: |
           julia --project=. -e 'using Pkg; Pkg.test(coverage=true)'
 
+      # The §9.7 golden generator is the only sanctioned way to produce the
+      # template-import goldens, so a generator that does not reproduce what is
+      # committed hands every fixture author an unrelated diff to notice and
+      # revert by hand (#256: a stale hardcoded `esm` version went unnoticed
+      # precisely because nothing ran the script). Re-run it and require the
+      # tree to be unchanged. One matrix leg is enough — the writer sorts keys,
+      # so the output does not vary by Julia version.
+      - name: Template-import goldens regenerate byte-identically
+        if: matrix.julia-version == '1.12'
+        working-directory: ${{ github.workspace }}
+        run: |
+          julia --project=pkg/EarthSciAST.jl scripts/generate-template-import-goldens.jl
+          git diff --exit-code -- tests/
+
       - name: Process Julia coverage
         uses: julia-actions/julia-processcoverage@v1
         if: matrix.julia-version == '1.12'

--- a/.github/workflows/conformance-testing.yml
+++ b/.github/workflows/conformance-testing.yml
@@ -269,6 +269,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           julia --project=pkg/EarthSciAST.jl scripts/generate-template-import-goldens.jl
+          julia --project=pkg/EarthSciAST.jl scripts/generate-pushdown-goldens.jl
           git diff --exit-code -- tests/
 
       - name: Process Julia coverage

--- a/scripts/generate-pushdown-goldens.jl
+++ b/scripts/generate-pushdown-goldens.jl
@@ -264,8 +264,11 @@ function build_l1_doc()
         _fed!(vn, "MockPts", fv)
     end
 
+    # 1.1.0 is a FLOOR here, not a preference: every one of these documents
+    # carries `faq` nodes (`_agg`), which arrive at esm 1.1.0. It is also what
+    # the committed fixtures declare, so the generator reproduces them.
     doc = Dict{String,Any}(
-        "esm" => "1.0.0",
+        "esm" => "1.1.0",
         "metadata" => Dict{String,Any}("name" => "prepare_pushdown_L1"),
         "index_sets" => Dict{String,Any}(
             "src_cells"    => Dict("kind"=>"interval", "size"=>GRID),
@@ -316,8 +319,9 @@ function build_gated_dense_doc()
         Dict("s"=>Dict("from"=>"src_cells"), "rcv"=>Dict("from"=>"rcv_cells")),
         _op("*", _ix("SR_PM25", "s", "rcv"), _ix("E_PM25", "s"));
         reduce="+", args=["SR_PM25", "E_PM25"]))
+    # `faq` floor, as in `build_l1_doc` above.
     doc = Dict{String,Any}(
-        "esm" => "1.0.0",
+        "esm" => "1.1.0",
         "metadata" => Dict{String,Any}("name" => "pushdown_gated_dense"),
         "index_sets" => Dict{String,Any}(
             "src_cells"    => Dict("kind"=>"interval", "size"=>NC),

--- a/scripts/generate-template-import-goldens.jl
+++ b/scripts/generate-template-import-goldens.jl
@@ -124,8 +124,16 @@ let n = EarthSciAST.MAX_TEMPLATE_EXPANSION_DEPTH + 1
                     "name" => "c_" * lpad(i + 1, 2, '0'),
                     "bindings" => Dict{String,Any}()))
     end
+    # GENERATED FILE: the `esm` version here is the one the fixture is COMMITTED
+    # with, so keep it in step with the rest of tests/invalid/template_imports/
+    # (the 1.0.0 corpus baseline) rather than with the newest spec version. It is
+    # deliberately NOT EarthSciAST.SCHEMA_VERSION: nothing in this document uses a
+    # post-1.0.0 construct, and tracking the library constant would rewrite the
+    # committed fixture -- an unrelated diff for whoever next runs this script --
+    # on every spec bump. The 0.8.0 that used to sit here was the §9.7 version
+    # gate, not the corpus version, and left the generator non-idempotent (#256).
     doc = Dict{String,Any}(
-        "esm" => "0.8.0",
+        "esm" => "1.0.0",
         "metadata" => Dict{String,Any}(
             "name" => "body_chain_too_deep",
             "description" => "GENERATED (scripts/generate-template-import-goldens.jl): a $(n)-template body-reference chain c_01 -> ... -> c_$(lpad(n, 2, '0')); the longest chain exceeds MAX_TEMPLATE_EXPANSION_DEPTH = $(n - 1) templates (template_body_expansion_too_deep, esm-spec 9.7.3)."),


### PR DESCRIPTION
`scripts/generate-template-import-goldens.jl` synthesized
`tests/invalid/template_imports/body_chain_too_deep.esm` with `"esm" => "0.8.0"`
while the committed file declares `1.0.0`, so every run rewrote it and handed
the author a one-line diff unrelated to whatever golden they were regenerating.

## Which side is right, and why

**Chosen: `1.0.0`** — i.e. the committed fixture is correct and the generator
was wrong. It is not a blind bump:

- `0.8.0` was the §9.7 version **gate** (`reject_template_imports_pre_v08`), not
  a corpus version. That is why it read as deliberate — but nothing about this
  fixture wants the oldest version that still parses; it wants the version it is
  committed with.
- The document uses **no post-1.0.0 construct**, and `1.0.0` is what the rest of
  `tests/invalid/template_imports/` declares (18 files). The single file there on
  `1.1.0`, `makearray_region_inverted.esm`, is on it because it carries a `faq`
  node, not because the corpus moved.
- **Deliberately not `EarthSciAST.SCHEMA_VERSION`** (currently `1.1.0`, so
  "newest" and "what the corpus declares" are not the same thing right now). The
  1.x line is additive, so an older minor stays loadable; tracking the library
  constant would rewrite this committed fixture on every spec bump — the same
  unrelated diff the issue is about, just rarer. This is the same reasoning as
  7cc6890ce, which unpinned a golden's version assertion from a literal for the
  mirror-image reason. No new constant was invented; the literal carries a
  comment saying the file is generated and its `esm` version tracks the corpus.

## The sibling defect (second commit, independently droppable)

Checking whether the defect had siblings turned one up in exactly the same
shape: `scripts/generate-pushdown-goldens.jl` builds its two hand-written
documents with `"esm" => "1.0.0"` while all seven committed
`tests/conformance/pushdown/fixtures/*.esm` declare `1.1.0`. Running it rewrites
13 files (7 fixtures + 6 `*.rewritten.json` goldens, which inherit the version
from the document they are the rewrite of) with a one-line version downgrade and
nothing else. Here `1.1.0` is a real floor, not a convention: every one of those
documents carries `faq` nodes, and `faq` arrives at esm 1.1.0 — the fixtures were
correctly bumped by 28f21bd56 (the `aggregate` → `faq` rename) and only the
generator was left behind, so it was emitting a document its own resolver gate
rejects. Kept as a separate commit so it can be dropped if you want this PR
strictly scoped to #256.

Neither commit changes a single committed artifact: both generators now
reproduce every file they emit byte-identically, which is the verification.

## Guard

Nothing ran either script in CI, which is why a stale literal could sit there
unnoticed. Added a step to the `julia-tests` job (1.12 leg only — the writer
sorts keys, so output does not vary by Julia version) that re-runs both
generators and requires `git diff --exit-code -- tests/`. It guards every golden
the scripts emit, not just these three lines.

## Verified

The full Julia test target hangs in this environment (Reactant / shared-depot
lock), so verification used a minimal env dev-linking `EarthSciAST` + `JSON3` +
`Test` and `include`d the specific test file.

- Reproduced first: `julia scripts/generate-template-import-goldens.jl` →
  `git status --short` showed exactly ` M tests/invalid/template_imports/body_chain_too_deep.esm`,
  diff `-  "esm": "1.0.0"` / `+  "esm": "0.8.0"`.
- After the fix, from a clean tree: both generators run →
  `git diff --exit-code -- tests/` exits **0** and `git status --short` is
  **empty**. (The issue's own acceptance criterion.)
- `include("pkg/EarthSciAST.jl/test/template_imports_test.jl")` → **336/336
  pass**. That file's "invalid fixtures: every §9.7 diagnostic code,
  machine-checked" testset `load_path`s this fixture and asserts
  `template_body_expansion_too_deep`, and separately asserts that code is in the
  set of §9.7 codes actually seen — so the fixture still does what it is for.
- `python3 -m pytest pkg/earthsci-ast-py/tests/test_template_imports.py -q` →
  **63 passed** (the invalid corpus is cross-language; the fixture bytes are
  unchanged from `main`, so no binding sees a different document).

## Mutation test

Restored `"esm" => "0.8.0"` in the template-import generator, re-ran it, and ran
the new guard's assertion: `git diff --exit-code -- tests/` exited **1**, naming
exactly `tests/invalid/template_imports/body_chain_too_deep.esm`. Before this PR
nothing went red on that mutation — no test or CI job ran either generator.

Fixes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4yB44Nd7y4EtPDGErcLiL
