### PR TITLE
ci(julia): test 1.10/1.12/1.13, drop 1.11

### DIFF
--- a/.github/workflows/conformance-testing.yml
+++ b/.github/workflows/conformance-testing.yml
@@ -228,7 +228,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.10', '1.11', '1.12']
+        julia-version: ['1.10', '1.12', '1.13']
     defaults:
       run:
         working-directory: pkg/EarthSciAST.jl
@@ -545,7 +545,7 @@ jobs:
   # that role (#224). The harness used to re-run all five suites itself before
   # generating any conformance output, which duplicated exactly the work these
   # five jobs had just finished — at ONE pinned version apiece, where the
-  # matrix covers julia 1.10/1.11/1.12, node 20/22, python 3.9-3.12, rust
+  # matrix covers julia 1.10/1.12/1.13, node 20/22, python 3.9-3.12, rust
   # stable/beta/MSRV and go 1.21/1.22/1.23. Less coverage, for the whole cost.
   #
   # That duplication is why this job had NEVER completed: across the last 174

--- a/docs/content/RELEASE_PIPELINE.md
+++ b/docs/content/RELEASE_PIPELINE.md
@@ -116,7 +116,7 @@ All packages maintain synchronized version numbers:
 
 ### Julia (EarthSciAST.jl)
 
-- Tests run on Julia 1.9, 1.10, 1.11, 1.12
+- Tests run on Julia 1.10, 1.12, 1.13
 - Automatic registration with Julia General Registry
 - Coverage reporting via Codecov
 - Package tagged as `EarthSciAST-v{version}`

--- a/scripts/test-conformance.sh
+++ b/scripts/test-conformance.sh
@@ -71,7 +71,7 @@ CORPUS_MANIFEST="$OUTPUT_DIR/corpus_manifest.json"
 # `standard-conformance-testing` job carries
 # `needs: [julia-tests, typescript-tests, python-tests, rust-tests, go-tests]`,
 # so it does not start until all five suites have passed, each across its whole
-# version matrix (julia 1.10/1.11/1.12, node 20/22, python 3.9-3.12, rust
+# version matrix (julia 1.10/1.12/1.13, node 20/22, python 3.9-3.12, rust
 # stable/beta/MSRV, go 1.21/1.22/1.23). Re-running them here repeated that work
 # at ONE pinned version apiece — strictly less coverage, for the entire cost.
 #


### PR DESCRIPTION
## What changed

The Julia CI matrix moves off 1.11 and onto 1.13.

| | matrix |
|---|---|
| before | `julia-version: ['1.10', '1.11', '1.12']` |
| after  | `julia-version: ['1.10', '1.12', '1.13']` |

One line in `.github/workflows/conformance-testing.yml` (the matrix at ~L231); the rest of the diff is three prose references that spelled the old matrix out.

Julia 1.13.0 is released and stable — verified directly against `https://julialang-s3.julialang.org/bin/versions.json`, which is the file `julia-actions/setup-julia` resolves `version: '1.13'` against. (The local `juliaup` channel DB in the dev environment is stale and still maps `1.13` to `rc3`; the authoritative list has `1.13.0` stable.)

`pkg/EarthSciAST.jl/Project.toml` declares `julia = "1.10"`. That floor is unchanged and still tested — 1.10 stays in the matrix.

## Grep sweep over `.github/`

Every Julia version reference in the tree, and the disposition of each:

| Location | Value | Action |
|---|---|---|
| `conformance-testing.yml:231` | matrix `['1.10','1.11','1.12']` | **changed** to `['1.10','1.12','1.13']` |
| `conformance-testing.yml:47` | `env.JULIA_VERSION: '1.10'` | left. Pins the single-version `standard-conformance-testing` job at the declared compat floor, which is still in the matrix. |
| `conformance-testing.yml:262,268` | coverage steps `if: matrix.julia-version == '1.12'` | left — see below |
| `conformance-testing.yml:548` | comment "matrix covers julia 1.10/1.11/1.12" | **updated** — it names the matrix and would otherwise be wrong |
| `security-scan.yml:80` | `setup-julia` `version: '1.12'` | left. Not a matrix leg; 1.12 remains supported and tested, so the pin is not stranded. |
| `docs.yml:40` | `setup-julia` `version: '1.9'` | left, but **flagged**: 1.9 is *below* the declared `julia = "1.10"` floor, and this job only runs `scripts/generate_docs.py` — the Julia setup looks vestigial. Pre-existing and orthogonal to this PR; worth a separate cleanup. |
| `release-publish.yml`, `integrated-release-pipeline.yml`, `binary-release.yml` | JuliaRegistrator / install snippets | no version pins, nothing to do |

Two references outside `.github/` also spelled out the matrix and were **updated**: `scripts/test-conformance.sh:74` and `docs/content/RELEASE_PIPELINE.md:119` (the latter was already stale — it claimed 1.9 was tested).

## Version-gated CI steps

`Process Julia coverage` and `Upload Julia coverage to Codecov` are gated `matrix.julia-version == '1.12'`. **Deliberately left on 1.12.** 1.12 remains in the matrix, so neither step is stranded on a version that no longer exists. Coverage is a single-leg artifact and belongs on the version the package is actually developed and released against, not on the newest leg — whose role here is to surface breakage early, and which is the leg most likely to fail outright and take the coverage upload with it.

This also keeps the diff off the lines #305 touches: that PR adds another `== '1.12'`-gated step to this same file, and this change is confined to the matrix line, so the two should merge cleanly.

## 1.11-specific code: none becomes untested

The package has exactly one version gate:

```julia
_cg_split_supported() = VERSION >= v"1.12"   # src/tree_walk/codegen_kernel.jl:1224
```

This is the previously-diagnosed RGF issue — below 1.12, an inner function inside a `RuntimeGeneratedFunction` body becomes an untyped `Core.OpaqueClosure`, which boxes per cell and segfaults when nested — so the codegen body split is disabled and the oversized-body path declines to the interpreter instead.

**That fallback is not dead code and was not touched.** 1.10 is also `< 1.12` and stays in the matrix, so the `false` branch keeps its coverage, including the tests that pin it (`test/codegen_body_split_test.jl`, `test/codegen_subcall_fn_test.jl`, and the allocation expectations in `test/tree_walk_allocation_test.jl`). 1.11 exercised the identical branch as 1.10; it was the redundant leg. **Nothing in the package becomes untested by this change.**

Note the converse: 1.13 satisfies `>= v"1.12"`, so the newly-added leg runs the split-enabled path.

## 1.13 risk, and what was verified locally

`[compat]` carries no upper bound that can block 1.13 — `julia = "1.10"` means `>=1.10, <2`, and no dependency bound is version-of-Julia-sensitive on its face. The residual risks are in the dependency stack, not the declaration:

- **Reactant (`0.2`)** — the likeliest blocker. It leans on Julia internals and its `Reactant_jll` binary, and historically lags a fresh Julia minor.
- **SymbolicUtils (`4 - 4.45`)** — deliberately held back (see the comment in `Project.toml`), so resolution cannot take a newer release that might carry 1.13 fixes.
- Catalyst 16 / ModelingToolkit 11 / the OrdinaryDiffEq split packages — large, but pure Julia and usually fine.

**Verified locally:** that 1.13.0 is genuinely stable in `versions.json`; the full grep sweep; that the single `VERSION` gate is 1.10-covered.

**Not verified locally:** whether the manifest actually resolves and the suite passes on 1.13. No 1.13 toolchain is installed in the dev environment (`juliaup status` has 1.10, 1.11, 1.12 only) and one was not installed for this. The full Julia test target also hangs in that environment on a Reactant/depot lock. **CI is the real signal here** — see the per-leg result below.

## CI result

_Filled in below once the run completes; the 1.13 leg is the one to watch._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4yB44Nd7y4EtPDGErcLiL