### PR TITLE
test(rust): pin the bare-alias export ordering that #255 fixed (#234)

### DIFF
--- a/pkg/earthsci-ast-rs/tests/alias_observed_export_order.rs
+++ b/pkg/earthsci-ast-rs/tests/alias_observed_export_order.rs
@@ -1,0 +1,156 @@
+//! Issue #234: a bare alias between two unknowns, read by a per-cell rule.
+//!
+//! An observed whose whole body is a bare variable (`Tsfc = Tsfc_raw`) emits
+//! nothing into its home chunk, and the export pass used to append its
+//! `Instr::Export` at the END of the cadence stream — after the
+//! `Instr::Fallback` of the later rule that reads it, which then read the
+//! preallocated `0.0`. PR #255 fixed that by opening the home chunk at the
+//! rule's own place in rule order.
+//!
+//! #255 was written for issue #207, whose fixtures are in
+//! `coupled_const_array_fold.rs`: a const-array gather subscripted by the
+//! ghost zero, which raises `E_TREEWALK_CONSTARRAY_OOB` and is therefore
+//! LOUD. The shape here is the SILENT one — the zero lands in a relaxation
+//! term as a plausible number, so the model integrates on and merely gives
+//! wrong answers. Nothing covered it, which is why #234 was reported
+//! separately, four days later, as a solver failure at 59 levels.
+//!
+//! Four cells is enough: the defect never depended on the grid size, only on
+//! whether the corrupted right-hand side happened to defeat the Newton solve.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use earthsci_ast::load_path;
+use earthsci_ast::simulate_array::{ArrayCompiled, RhsStats};
+
+/// The four cells' initial temperature, and the forcing's mean: at `t = 0` the
+/// column is isothermal at exactly the surface value.
+const T_UNIFORM: f64 = 288.0;
+
+/// `rlx` in the fixtures. The ghost zero made cell 1's tendency
+/// `rlx * (0 - 288) = -0.288 K/s` instead of `0`.
+const RLX: f64 = 1.0e-3;
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/alias_export_order")
+        .join(name)
+}
+
+fn compiled(name: &str) -> ArrayCompiled {
+    let path = fixture(name);
+    let file = load_path(&path).unwrap_or_else(|e| panic!("{name} does not load: {e}"));
+    ArrayCompiled::from_file(&file).unwrap_or_else(|e| panic!("{name} does not compile: {e}"))
+}
+
+/// The production route: a scratch with the compiled tape installed, which is
+/// what the solver's RHS closure carries.
+fn taped_rhs(c: &ArrayCompiled, state: &[f64], t: f64) -> Vec<f64> {
+    let params = c.debug_resolve_params(&HashMap::new());
+    let mut scratch = c.debug_new_scratch_taped();
+    assert!(
+        scratch.has_tape(),
+        "this test is about the TAPED path; without a tape it proves nothing"
+    );
+    let mut dy = vec![0.0f64; c.state_variable_names().len()];
+    let mut stats = RhsStats::default();
+    c.debug_eval_rhs_into(state, t, &params, &mut dy, &mut scratch, &mut stats);
+    assert!(stats.taped_rules > 0, "no rule was taped");
+    dy
+}
+
+/// The per-cell oracle — the legacy interpreter, unchanged by #255.
+fn oracle_rhs(c: &ArrayCompiled, state: &[f64], t: f64) -> Vec<f64> {
+    let (dy, _) = c.debug_eval_rhs(state, t, &HashMap::new(), true);
+    dy
+}
+
+/// States and times that exercise the alias at its mean and away from it.
+fn probe_points() -> Vec<(Vec<f64>, f64)> {
+    vec![
+        (vec![T_UNIFORM; 4], 0.0),
+        (vec![T_UNIFORM; 4], 4000.0),
+        (vec![287.0, 288.5, 289.25, 286.75], 0.0),
+        (vec![287.0, 288.5, 289.25, 286.75], 12_000.0),
+    ]
+}
+
+/// The value test, independent of the oracle: at `t = 0` the column is
+/// isothermal at the surface temperature, so every tendency is exactly zero.
+///
+/// Before #255 this read `-0.288 K/s` in cell 1 — `rlx * (0 - 288)`, the
+/// signature of the alias reaching the consumer as the preallocated zero.
+#[test]
+fn the_alias_value_reaches_a_per_cell_observed() {
+    let dy = taped_rhs(&compiled("bare_alias_observed.esm"), &[T_UNIFORM; 4], 0.0);
+    for (k, v) in dy.iter().enumerate() {
+        assert!(
+            v.abs() < 1e-12,
+            "cell {k} tendency {v:e}, want 0 — a ghost zero for the alias gives {:e} in cell 0",
+            -RLX * T_UNIFORM
+        );
+    }
+}
+
+/// The same alias read straight from the `D(T, t)` rule body, with no
+/// intermediate per-cell observed. Both spellings were corrupted.
+#[test]
+fn the_alias_value_reaches_a_derivative_rule() {
+    let dy = taped_rhs(
+        &compiled("bare_alias_in_derivative.esm"),
+        &[T_UNIFORM; 4],
+        0.0,
+    );
+    for (k, v) in dy.iter().enumerate() {
+        assert!(
+            v.abs() < 1e-12,
+            "cell {k} tendency {v:e}, want 0 — a ghost zero for the alias gives {:e} in cell 0",
+            -RLX * T_UNIFORM
+        );
+    }
+}
+
+/// The structural test: whatever the numbers are, the taped path and the
+/// per-cell oracle must agree bitwise. This is the `ESS_TAPE_CHECK=1`
+/// invariant, pinned for this shape without the environment variable, and it
+/// keeps biting even if someone changes the fixture's arithmetic.
+#[test]
+fn the_taped_path_agrees_with_the_oracle() {
+    for name in ["bare_alias_observed.esm", "bare_alias_in_derivative.esm"] {
+        let c = compiled(name);
+        for (state, t) in probe_points() {
+            let taped = taped_rhs(&c, &state, t);
+            let oracle = oracle_rhs(&c, &state, t);
+            for (k, (a, b)) in taped.iter().zip(oracle.iter()).enumerate() {
+                assert_eq!(
+                    a.to_bits(),
+                    b.to_bits(),
+                    "{name}: dy[{k}] diverged at t={t}: tape {a:e} vs oracle {b:e}"
+                );
+            }
+        }
+    }
+}
+
+/// The alias is semantically inert, so removing it must not change a single
+/// number. A failure here means the fixtures drifted apart, not that the
+/// export ordering regressed.
+#[test]
+fn the_alias_changes_no_number_against_the_inlined_control() {
+    let aliased = compiled("bare_alias_observed.esm");
+    let control = compiled("no_alias_control.esm");
+    for (state, t) in probe_points() {
+        let a = taped_rhs(&aliased, &state, t);
+        let b = taped_rhs(&control, &state, t);
+        for (k, (x, y)) in a.iter().zip(b.iter()).enumerate() {
+            assert_eq!(
+                x.to_bits(),
+                y.to_bits(),
+                "dy[{k}] at t={t}: aliased {x:e} vs inlined {y:e}"
+            );
+        }
+    }
+}

--- a/pkg/earthsci-ast-rs/tests/fixtures/alias_export_order/bare_alias_in_derivative.esm
+++ b/pkg/earthsci-ast-rs/tests/fixtures/alias_export_order/bare_alias_in_derivative.esm
@@ -1,0 +1,226 @@
+{
+ "esm": "1.1.0",
+ "metadata": {
+  "name": "alias_export_order_derivative",
+  "description": "As bare_alias_observed.esm, but the alias is read straight from the D(T, t) rule body rather than through an intermediate per-cell observed. Both spellings diverged before PR #255.",
+  "license": "MIT"
+ },
+ "index_sets": {
+  "lev": {
+   "kind": "interval",
+   "size": 4
+  }
+ },
+ "models": {
+  "Column": {
+   "variables": {
+    "kappa": {
+     "type": "parameter",
+     "units": "1/s",
+     "default": 0.002,
+     "description": "diffusion rate per cell"
+    },
+    "omega": {
+     "type": "parameter",
+     "units": "1/s",
+     "default": 7.27220521664304e-05,
+     "description": "diurnal frequency"
+    },
+    "amp": {
+     "type": "parameter",
+     "units": "K",
+     "default": 10.0,
+     "description": "surface forcing amplitude"
+    },
+    "Tsfc0": {
+     "type": "parameter",
+     "units": "K",
+     "default": 288.0,
+     "description": "surface mean temperature"
+    },
+    "rlx": {
+     "type": "parameter",
+     "units": "1/s",
+     "default": 0.001,
+     "description": "surface relaxation rate"
+    },
+    "T": {
+     "type": "unknown",
+     "units": "K",
+     "shape": [
+      "lev"
+     ],
+     "description": "cell temperature"
+    },
+    "Tsfc_raw": {
+     "type": "unknown",
+     "units": "K",
+     "description": "the prescribed surface temperature, before the alias"
+    },
+    "Tsfc": {
+     "type": "unknown",
+     "units": "K",
+     "description": "a BARE alias of Tsfc_raw, read directly by the derivative rule"
+    }
+   },
+   "equations": [
+    {
+     "lhs": "Tsfc_raw",
+     "rhs": {
+      "op": "+",
+      "args": [
+       "Tsfc0",
+       {
+        "op": "*",
+        "args": [
+         "amp",
+         {
+          "op": "sin",
+          "args": [
+           {
+            "op": "*",
+            "args": [
+             "omega",
+             "t"
+            ]
+           }
+          ]
+         }
+        ]
+       }
+      ]
+     }
+    },
+    {
+     "lhs": "Tsfc",
+     "rhs": "Tsfc_raw"
+    },
+    {
+     "lhs": {
+      "op": "D",
+      "args": [
+       "T"
+      ],
+      "wrt": "t"
+     },
+     "rhs": {
+      "op": "faq",
+      "output_idx": [
+       "k"
+      ],
+      "args": [],
+      "ranges": {
+       "k": {
+        "from": "lev"
+       }
+      },
+      "expr": {
+       "op": "+",
+       "args": [
+        {
+         "op": "*",
+         "args": [
+          "kappa",
+          {
+           "op": "-",
+           "args": [
+            {
+             "op": "+",
+             "args": [
+              {
+               "op": "index",
+               "args": [
+                "T",
+                {
+                 "op": "max",
+                 "args": [
+                  1,
+                  {
+                   "op": "-",
+                   "args": [
+                    "k",
+                    1
+                   ]
+                  }
+                 ]
+                }
+               ]
+              },
+              {
+               "op": "index",
+               "args": [
+                "T",
+                {
+                 "op": "min",
+                 "args": [
+                  4,
+                  {
+                   "op": "+",
+                   "args": [
+                    "k",
+                    1
+                   ]
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            },
+            {
+             "op": "*",
+             "args": [
+              2.0,
+              {
+               "op": "index",
+               "args": [
+                "T",
+                "k"
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        },
+        {
+         "op": "*",
+         "args": [
+          "rlx",
+          {
+           "op": "ifelse",
+           "args": [
+            {
+             "op": "==",
+             "args": [
+              "k",
+              1
+             ]
+            },
+            {
+             "op": "-",
+             "args": [
+              "Tsfc",
+              {
+               "op": "index",
+               "args": [
+                "T",
+                "k"
+               ]
+              }
+             ]
+            },
+            0.0
+           ]
+          }
+         ]
+        }
+       ]
+      }
+     }
+    }
+   ]
+  }
+ }
+}

--- a/pkg/earthsci-ast-rs/tests/fixtures/alias_export_order/bare_alias_observed.esm
+++ b/pkg/earthsci-ast-rs/tests/fixtures/alias_export_order/bare_alias_observed.esm
@@ -1,0 +1,238 @@
+{
+ "esm": "1.1.0",
+ "metadata": {
+  "name": "alias_export_order_observed",
+  "description": "Four-cell column whose per-cell tendency reads a BARE alias between two unknowns (Tsfc = Tsfc_raw). Regression fixture for EarthSciAST issue #234, fixed by PR #255: an observed whose body is a bare variable emits nothing into its home chunk, and its Export used to be appended at the END of the cadence stream \u2014 after the Fallback of the later rule that reads it, which then read the preallocated 0.0.",
+  "license": "MIT"
+ },
+ "index_sets": {
+  "lev": {
+   "kind": "interval",
+   "size": 4
+  }
+ },
+ "models": {
+  "Column": {
+   "variables": {
+    "kappa": {
+     "type": "parameter",
+     "units": "1/s",
+     "default": 0.002,
+     "description": "diffusion rate per cell"
+    },
+    "omega": {
+     "type": "parameter",
+     "units": "1/s",
+     "default": 7.27220521664304e-05,
+     "description": "diurnal frequency"
+    },
+    "amp": {
+     "type": "parameter",
+     "units": "K",
+     "default": 10.0,
+     "description": "surface forcing amplitude"
+    },
+    "Tsfc0": {
+     "type": "parameter",
+     "units": "K",
+     "default": 288.0,
+     "description": "surface mean temperature"
+    },
+    "rlx": {
+     "type": "parameter",
+     "units": "1/s",
+     "default": 0.001,
+     "description": "surface relaxation rate"
+    },
+    "T": {
+     "type": "unknown",
+     "units": "K",
+     "shape": [
+      "lev"
+     ],
+     "description": "cell temperature"
+    },
+    "Tsfc_raw": {
+     "type": "unknown",
+     "units": "K",
+     "description": "the prescribed surface temperature, before the alias"
+    },
+    "Tsfc": {
+     "type": "unknown",
+     "units": "K",
+     "description": "a BARE alias of Tsfc_raw \u2014 the shape this fixture exists to pin"
+    },
+    "dTdt": {
+     "type": "unknown",
+     "units": "K/s",
+     "shape": [
+      "lev"
+     ],
+     "description": "per-cell tendency, reading the alias in cell 1"
+    }
+   },
+   "equations": [
+    {
+     "lhs": "Tsfc_raw",
+     "rhs": {
+      "op": "+",
+      "args": [
+       "Tsfc0",
+       {
+        "op": "*",
+        "args": [
+         "amp",
+         {
+          "op": "sin",
+          "args": [
+           {
+            "op": "*",
+            "args": [
+             "omega",
+             "t"
+            ]
+           }
+          ]
+         }
+        ]
+       }
+      ]
+     }
+    },
+    {
+     "lhs": "Tsfc",
+     "rhs": "Tsfc_raw"
+    },
+    {
+     "lhs": "dTdt",
+     "rhs": {
+      "op": "faq",
+      "output_idx": [
+       "k"
+      ],
+      "args": [],
+      "ranges": {
+       "k": {
+        "from": "lev"
+       }
+      },
+      "expr": {
+       "op": "+",
+       "args": [
+        {
+         "op": "*",
+         "args": [
+          "kappa",
+          {
+           "op": "-",
+           "args": [
+            {
+             "op": "+",
+             "args": [
+              {
+               "op": "index",
+               "args": [
+                "T",
+                {
+                 "op": "max",
+                 "args": [
+                  1,
+                  {
+                   "op": "-",
+                   "args": [
+                    "k",
+                    1
+                   ]
+                  }
+                 ]
+                }
+               ]
+              },
+              {
+               "op": "index",
+               "args": [
+                "T",
+                {
+                 "op": "min",
+                 "args": [
+                  4,
+                  {
+                   "op": "+",
+                   "args": [
+                    "k",
+                    1
+                   ]
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            },
+            {
+             "op": "*",
+             "args": [
+              2.0,
+              {
+               "op": "index",
+               "args": [
+                "T",
+                "k"
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        },
+        {
+         "op": "*",
+         "args": [
+          "rlx",
+          {
+           "op": "ifelse",
+           "args": [
+            {
+             "op": "==",
+             "args": [
+              "k",
+              1
+             ]
+            },
+            {
+             "op": "-",
+             "args": [
+              "Tsfc",
+              {
+               "op": "index",
+               "args": [
+                "T",
+                "k"
+               ]
+              }
+             ]
+            },
+            0.0
+           ]
+          }
+         ]
+        }
+       ]
+      }
+     }
+    },
+    {
+     "lhs": {
+      "op": "D",
+      "args": [
+       "T"
+      ],
+      "wrt": "t"
+     },
+     "rhs": "dTdt"
+    }
+   ]
+  }
+ }
+}

--- a/pkg/earthsci-ast-rs/tests/fixtures/alias_export_order/no_alias_control.esm
+++ b/pkg/earthsci-ast-rs/tests/fixtures/alias_export_order/no_alias_control.esm
@@ -1,0 +1,229 @@
+{
+ "esm": "1.1.0",
+ "metadata": {
+  "name": "alias_export_order_control",
+  "description": "The control for bare_alias_observed.esm: mathematically identical, with the alias removed. It was green throughout, so a failure here indicts the fixtures rather than the export ordering.",
+  "license": "MIT"
+ },
+ "index_sets": {
+  "lev": {
+   "kind": "interval",
+   "size": 4
+  }
+ },
+ "models": {
+  "Column": {
+   "variables": {
+    "kappa": {
+     "type": "parameter",
+     "units": "1/s",
+     "default": 0.002,
+     "description": "diffusion rate per cell"
+    },
+    "omega": {
+     "type": "parameter",
+     "units": "1/s",
+     "default": 7.27220521664304e-05,
+     "description": "diurnal frequency"
+    },
+    "amp": {
+     "type": "parameter",
+     "units": "K",
+     "default": 10.0,
+     "description": "surface forcing amplitude"
+    },
+    "Tsfc0": {
+     "type": "parameter",
+     "units": "K",
+     "default": 288.0,
+     "description": "surface mean temperature"
+    },
+    "rlx": {
+     "type": "parameter",
+     "units": "1/s",
+     "default": 0.001,
+     "description": "surface relaxation rate"
+    },
+    "T": {
+     "type": "unknown",
+     "units": "K",
+     "shape": [
+      "lev"
+     ],
+     "description": "cell temperature"
+    },
+    "Tsfc": {
+     "type": "unknown",
+     "units": "K",
+     "description": "the prescribed surface temperature, defined directly"
+    },
+    "dTdt": {
+     "type": "unknown",
+     "units": "K/s",
+     "shape": [
+      "lev"
+     ],
+     "description": "per-cell tendency"
+    }
+   },
+   "equations": [
+    {
+     "lhs": "Tsfc",
+     "rhs": {
+      "op": "+",
+      "args": [
+       "Tsfc0",
+       {
+        "op": "*",
+        "args": [
+         "amp",
+         {
+          "op": "sin",
+          "args": [
+           {
+            "op": "*",
+            "args": [
+             "omega",
+             "t"
+            ]
+           }
+          ]
+         }
+        ]
+       }
+      ]
+     }
+    },
+    {
+     "lhs": "dTdt",
+     "rhs": {
+      "op": "faq",
+      "output_idx": [
+       "k"
+      ],
+      "args": [],
+      "ranges": {
+       "k": {
+        "from": "lev"
+       }
+      },
+      "expr": {
+       "op": "+",
+       "args": [
+        {
+         "op": "*",
+         "args": [
+          "kappa",
+          {
+           "op": "-",
+           "args": [
+            {
+             "op": "+",
+             "args": [
+              {
+               "op": "index",
+               "args": [
+                "T",
+                {
+                 "op": "max",
+                 "args": [
+                  1,
+                  {
+                   "op": "-",
+                   "args": [
+                    "k",
+                    1
+                   ]
+                  }
+                 ]
+                }
+               ]
+              },
+              {
+               "op": "index",
+               "args": [
+                "T",
+                {
+                 "op": "min",
+                 "args": [
+                  4,
+                  {
+                   "op": "+",
+                   "args": [
+                    "k",
+                    1
+                   ]
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            },
+            {
+             "op": "*",
+             "args": [
+              2.0,
+              {
+               "op": "index",
+               "args": [
+                "T",
+                "k"
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        },
+        {
+         "op": "*",
+         "args": [
+          "rlx",
+          {
+           "op": "ifelse",
+           "args": [
+            {
+             "op": "==",
+             "args": [
+              "k",
+              1
+             ]
+            },
+            {
+             "op": "-",
+             "args": [
+              "Tsfc",
+              {
+               "op": "index",
+               "args": [
+                "T",
+                "k"
+               ]
+              }
+             ]
+            },
+            0.0
+           ]
+          }
+         ]
+        }
+       ]
+      }
+     }
+    },
+    {
+     "lhs": {
+      "op": "D",
+      "args": [
+       "T"
+      ],
+      "wrt": "t"
+     },
+     "rhs": "dTdt"
+    }
+   ]
+  }
+ }
+}


### PR DESCRIPTION
Test-only. Closes the coverage gap behind #234, which #255 fixed without either side knowing about the other.

## What was uncovered

#255 stopped the export pass appending a taped observed's `Instr::Export` at the END of its cadence stream, where it ran after the `Instr::Fallback` of the later rule that reads it — which then read the preallocated `0.0`. The tests it brought (`coupled_const_array_fold.rs`, `scalar_param_array_default.rs`) are the **loud** form of that defect, #207: a const-array gather subscripted by the ghost zero, raising `E_TREEWALK_CONSTARRAY_OOB`.

The **silent** form had nothing. An observed whose whole body is a bare variable — `Tsfc = Tsfc_raw`, an alias between two unknowns — emits nothing into its home chunk and takes exactly that path. When a per-cell rule reads it as a relaxation target, the ghost zero is a *plausible* number: nothing raises, the model integrates, the answers are just wrong. That is #234, filed separately four days later as a solver failure over a 59-level column (`Exceeded maximum number of nonlinear solver failures (51) at time = 39.76304343430315`).

It is worth covering because the shape is not exotic here — components factored and imported by reference, coupled through additive `<x>_in` parameters and `variable_map`, are chains of pass-throughs by construction.

## What this adds

`tests/alias_observed_export_order.rs`, plus three fixtures under `tests/fixtures/alias_export_order/`. Four cells, no integration, 0.03 s:

| fixture | shape |
|---|---|
| `bare_alias_observed.esm` | the alias read by a separate per-cell observed |
| `bare_alias_in_derivative.esm` | the alias read straight from the `D(T, t)` rule body |
| `no_alias_control.esm` | the alias inlined away — mathematically identical |

and four tests:

- **two value tests** — an isothermal column at `t = 0` sits at the surface temperature, so every tendency is exactly zero. The ghost zero gives `rlx * (0 - 288) = -0.288 K/s` in cell 1. Independent of the oracle, so they keep biting even if both paths regress together.
- **`the_taped_path_agrees_with_the_oracle`** — the taped `dy` against the per-cell oracle, bitwise, at four (state, t) points. This is the `ESS_TAPE_CHECK=1` invariant pinned for this shape without the environment variable, and it is the stronger guard: it catches any divergence, not just the one whose arithmetic I happened to predict.
- **`the_alias_changes_no_number_against_the_inlined_control`** — a semantically inert alias must not move a single bit. A failure here indicts the fixtures rather than the runtime.

## Confirmed to fail pre-fix

Not merely green today. Against `ebc432873` — the commit immediately before #255 — all four fail:

```
the_alias_value_reaches_a_per_cell_observed:
  cell 0 tendency -2.8800000000000003e-1, want 0
the_taped_path_agrees_with_the_oracle:
  bare_alias_observed.esm: dy[0] diverged at t=0: tape -2.8800000000000003e-1 vs oracle 0e0
the_alias_changes_no_number_against_the_inlined_control:
  dy[0] at t=0: aliased -2.8800000000000003e-1 vs inlined 0e0
```

`test result: FAILED. 0 passed; 4 failed`, against `ok. 4 passed` on `main`. That run respelled the fixtures `faq` → `aggregate` and esm 1.1.0 → 1.0.0, which is all `ebc432873` can load; nothing else changed.

## Sizing, and why four cells

The report reads as a threshold at 59 levels, but that is the symptom, not the defect. `ESS_TAPE_CHECK=1` on the reporter's probes shows `dy[0]` diverging at **N = 4** — `lev = 58` was equally corrupted and merely survived the Newton solve. So the cheapest fixture that bites is a four-cell one, and a 59-level fixture would buy nothing but runtime.

## Scope

Rust-only by construction: the defect is in the array runtime's tape lowering, which no other binding has, so there is no cross-language fixture to add. `cargo test` is green on the branch; `cargo fmt --check` clean.

Refs #234, #255, #207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
